### PR TITLE
Deepen per-system score assignment behind one interface

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -99,7 +99,7 @@ python rename_parts.py score.mscx SSAA -o score_renamed.mscx
 ### Tests
 
 ```bash
-.venv/bin/python -m pytest src/clean_score/tests/ -q     # 60 tests, all passing
+.venv/bin/python -m pytest src/clean_score/tests/ src/song_app/tests/ -q   # 73 tests, all passing
 ```
 
 `pyproject.toml` only sets `log_cli_level=DEBUG`. Key test modules:
@@ -112,9 +112,13 @@ python rename_parts.py score.mscx SSAA -o score_renamed.mscx
   output, regenerate the goldens by copying the freshly produced
   `<name>_test_output.mscx` over `<name>_output.mscx`. The comparison is
   shallow (tags only, not text/attributes).
-- `test_per_system.py` — drives the `--per-system` rebuild against the real
-  `laulun_aika.mscx` fixture (systems, part order, per-system pull, tuplet survival,
-  line breaks, prompt reuse, and the answer cache).
+- `test_per_system.py` — drives the per-system module's own interface against the
+  real `laulun_aika.mscx` fixture (systems, layout, part order, per-system pull,
+  tuplet survival, line breaks, lyric map/metaTags, carried-forward answers, answer
+  persistence) and pins both assignment adapters — the CLI prompt and grid answers —
+  to the same rebuild.
+- `src/song_app/tests/test_clean_flow.py` — the song-app path: grid answers →
+  `save_system_answers` → headless `run_clean` → rebuilt parts + lyric routing.
 - `test_missing_tuplets.py` — the dropped-tuplet cross-voice auto-fix (mirror
   within/across staves; well-formed and donor-less voices left untouched).
 - `test_revoice.py` / `test_interactive.py` / `test_json_staff_mapping.py` — the
@@ -136,11 +140,13 @@ state model are in `DESIGN.md`.
   separate stage, so a song can be "recorded but not yet uploaded". The folder is
   a slug; the display name lives in the JSON.
 - `pipeline.py` is the glue: `convert_to_mscx` (mscx as-is / mscz unzip / xml via
-  MuseScore CLI), `run_clean` (calls `main(..., interactive=False)`; per-system
-  reads `.persystem_cache.json`, which the **grid form** populates via
-  `save_system_answers`), and `run_lyric_import` (calls `import_file`, capturing
-  the stderr `Warning:` lines as the syllable-mismatch list). `system_grid` builds
-  the per-system grid from `per_system.find_systems` + the staff voice summaries.
+  MuseScore CLI), `run_clean` (calls `main(..., interactive=False)`; per-system runs off
+  the answers the **grid form** recorded via `save_system_answers`), and
+  `run_lyric_import` (calls `import_file`, capturing the stderr `Warning:` lines
+  as the syllable-mismatch list). `system_grid` / `save_system_answers` /
+  `has_system_answers` / `system_ranges` are one-liners over the per-system module's
+  interface (`layout_for_file`, `save_answers`, `has_answers`, `system_ranges`) —
+  the grid is an adapter, not a second implementation.
   `render_score_pdf` exports a `.mscx` to PDF via the MuseScore CLI (cached by
   mtime) so scores can be shown in-browser next to the original PDF — it renders
   from a temp copy with the staff size (`<Spatium>`) shrunk by `SPATIUM_SCALE`
@@ -209,7 +215,7 @@ state model are in `DESIGN.md`.
   **Paste from AI** keeps the prompt/JSON round-trip, while **Type by system**
   fetches `/lyric-grid` and renders a textarea for every `(printed system, output
   part)`. The backend derives part names from `Part/trackName`, skips click/rest
-  parts, gets system ranges from `per_system.find_systems`, and prefills cells by
+  parts, gets system ranges via `pipeline.system_ranges`, and prefills cells by
   exporting the score's current lyrics. The browser turns non-empty cells into
   name-addressed JSON blocks (`parts: [part name]`, `measure_start: system start`)
   and submits them through the same `/lyrics` importer. Import warnings are parsed
@@ -282,24 +288,39 @@ stem/pitch logic, not strictly by the typed order. `≤2`-voice divisi is left a
 
 `--per-system` (`utils/per_system.py`) is a separate opt-in mode for scores where the
 physical staves change role per printed system (the Laulun aika fixture). It bypasses
-the normal split entirely: `find_systems` cuts at line breaks, `prompt_system_decls`
-asks the user to name each staff's voices per system, and `build_parts` rebuilds the
-score as one staff per named part (sorted S<A<T<B, then by number), pulling each
-part's notes from the declared `(staff, voice)` per system and filling measure-rests
-where absent. Old Parts/Staves are removed (that's how part deletion happens). Same
-name on two staves in a system → first wins; blank → skip. Each staff prompt offers
-the previous system's answer as a `[default]` (Enter reuses, `-` clears), and the
-original line breaks are re-added on the top staff so the system layout survives.
-Answers are cached per input file (basename, no extension) in `.persystem_cache.json`
-at the repo root (gitignored): each interactive run loads the prior answers as the
-`[default]` per staff and saves the chosen answers back, so re-running needs almost no
-typing — and a complete cache lets `--per-system` run **non-interactively** (no TTY),
-which is how tests drive it (`revoice_by_system(..., can_prompt=False)`).
-main() handles this in an early branch. Because the PDF's printed staff numbering
+the normal split entirely, and the module owns the whole assignment-to-score behavior
+behind one entry point, `clean_per_system(root, input_path=..., answers_from=...)`:
+it cuts systems at line breaks, describes each system's note-bearing staves
+(`system_layout` / `layout_for_file` → `SystemLayout`/`StaffRow`), resolves the
+answers, rebuilds the score as one staff per named part (sorted S<A<T<B, then by
+number) pulling each part's notes from the declared `(staff, voice)` per system and
+filling measure-rests where absent, re-adds the original line breaks on the top staff,
+runs the post-rebuild cleanup (`add_missing_ties` + the same decoration strip the split
+does), and writes the lyric-routing metaTags. Old Parts/Staves are removed (that's how
+part deletion happens). Same name on two staves in a system → first wins.
+
+Assignments are an `Answers` mapping (`{system_index: {staff_id: "T1,T2"}}`) produced
+by either of two **adapters at the same seam**: the terminal prompt
+(`utils/per_system_prompt.prompt_for_answers`, passed to `clean_per_system` as
+`answers_from`) and the web grid (`song_app.pipeline.system_grid` →
+`save_system_answers`, after which the rebuild reads them back from the store).
+A staff left blank in a system inherits its previous system's answer (`-` =
+`per_system.CLEARED` declares nothing and stops that inheritance); the
+prompt offers the recorded answer as a `[default]` (Enter reuses it). Answers are
+recorded per input file (basename, no extension) in `.persystem_cache.json` at the repo
+root (gitignored) via `save_answers`/`saved_answers`/`has_answers`; the store itself is
+internal (`JsonAnswerStore`, swappable in tests through `use_answer_store`). A complete
+answer set lets per-system mode run **non-interactively** (no TTY) — that is how the web
+app cleans headless after the grid is submitted, and how the tests drive it. `main()`
+handles per-system mode in an early branch: it calls `clean_per_system` (handing it the
+prompt adapter only when there is a TTY) and writes the file — the rebuild details and
+the metadata are the module's.
+
+Because the PDF's printed staff numbering
 **shifts per system** as parts are omitted (e.g. with T3 absent, the bass becomes
 printed staff 3), it writes a per-system `lyricsSystemMap` metaTag (JSON: per
 measure-range, `printed_no -> [output staff ids]`) in addition to an identity
-`lyricsStaffMap` fallback. `build_system_lyric_map` builds it by grouping parts that
+`lyricsStaffMap` fallback. The module builds it by grouping parts that
 share a source staff into one printed staff (divisi: voice 0 → 'above', voice 1 →
 'below') and ordering printed staves by **musical rank** (S<A<T<B, then number) — not
 by the OCR's source-staff order, which can be shuffled. `lyric_txt.py` import reads it
@@ -367,7 +388,7 @@ prompt files `lyric_json_prompt.txt` / `lyrics_txt_prompt.txt` drive that.
   A null `measure_start` (the LLM emits null when no measure number is printed at the
   start of a line) is auto-filled by `_fill_missing_measure_starts`: blocks are one
   per printed system in order, so each null block takes the start measure of the
-  system at its position (`find_systems`); explicit values are left alone, and a
+  system at its position (`per_system.system_ranges`); explicit values are left alone, and a
   block-count vs system-count mismatch is warned (so the user verifies alignment).
 - Import is in-place on the tree, removes verse 2+, and clears lyrics from
   ineligible (spanner-continuation) chords. `--replace` / `clear_existing=True`

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -194,7 +194,7 @@ measure→coordinate map.** It's the original engraving; the OCR'd XML doesn't
 reliably retain printed layout. Pixel-accurate jumping would need PDF layout
 analysis (OCR bounding boxes) we don't currently produce.
 
-What we *do* know: in per-system mode, `find_systems` gives **system →
+What we *do* know: in per-system mode, `per_system.system_ranges` gives **system →
 measure-range**, so we can locate a measure to its *system*, not a pixel.
 
 - **v1 (recommended):** side-by-side PDF with **page/system-level** navigation.

--- a/src/clean_score/lyric_txt.py
+++ b/src/clean_score/lyric_txt.py
@@ -1074,8 +1074,8 @@ def _fill_missing_measure_starts(json_str: str, score_root: etree._Element) -> s
     if not any(b.get("measure_start") is None for b in blocks):
         return json_str  # nothing to infer
 
-    from .utils.per_system import find_systems
-    starts = [a + 1 for (a, _b) in find_systems(score_root)]
+    from .utils.per_system import system_ranges
+    starts = [r.start for r in system_ranges(score_root)]
     if not starts:
         print("Warning: lyric lines have null measure_start but the score has no "
               "system breaks to infer from; those lines were skipped.", file=sys.stderr)

--- a/src/clean_score/main.py
+++ b/src/clean_score/main.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 
 from copy import deepcopy
-import json
 import os
 import sys
 from lxml import etree
@@ -28,7 +27,8 @@ from .utils.revoice import (
     capture_revoice_plan,
     establish_baseline,
 )
-from .utils.per_system import revoice_by_system
+from .utils.per_system import clean_per_system
+from .utils.per_system_prompt import prompt_for_answers
 
 from .utils.utils import (
     delete_all_elements_by_selector,
@@ -221,41 +221,21 @@ def main(
     # Per-system mode: rebuild the score from per-system part declarations instead of
     # the normal split. For badly-parsed scores where staves change role per system.
     if per_system:
-        input_key = os.path.splitext(os.path.basename(input_path))[0]
         can_prompt = interactive and sys.stdin.isatty()
-        parts, system_map = revoice_by_system(
-            root, input_key=input_key, can_prompt=can_prompt
+        result = clean_per_system(
+            root,
+            input_path=input_path,
+            answers_from=prompt_for_answers if can_prompt else None,
         )
-        if not parts:
+        if not result:
             logger.warning("Per-system re-voicing produced no parts; nothing written.")
             return
-        add_missing_ties(root)
-        # Note: LayoutBreaks are intentionally kept (per_system re-adds system breaks).
-        for sel in (
-            ".//Lyrics", ".//offset", ".//Dynamic",
-            ".//Spanner[@type='HairPin']", ".//Articulation", ".//Tempo",
-            ".//Harmony", ".//bracket", ".//barLineSpan",
-        ):
-            delete_all_elements_by_selector(root, sel)
-        score_element = root.find(".//Score")
-        existing_meta = score_element.findall("metaTag")
-        insert_at = (
-            score_element.index(existing_meta[-1]) + 1 if existing_meta else len(score_element)
-        )
-        # Per-system printed-staff -> output-staff map (the printed numbering shifts
-        # per system as parts are omitted), plus an identity lyricsStaffMap fallback.
-        sys_meta = etree.Element("metaTag", name="lyricsSystemMap")
-        sys_meta.text = json.dumps(system_map, separators=(",", ":"))
-        score_element.insert(insert_at, sys_meta)
-        meta = etree.Element("metaTag", name="lyricsStaffMap")
-        meta.text = ";".join(f"{i}:{i}" for i in range(1, len(parts) + 1))
-        score_element.insert(insert_at, meta)
         output_content = etree.tostring(
             root, pretty_print=True, encoding="UTF-8"
         ).decode("UTF-8")
         with open(output_path, "w", encoding="utf-8") as f:
             f.write(output_content)
-        logger.info("Per-system re-voicing complete. Parts: %s", parts)
+        logger.info("Per-system re-voicing complete. Parts: %s", result.parts)
         return
 
     # Resolve OCR voice-count anomalies (measures with >2 voices) before splitting.

--- a/src/clean_score/tests/test_per_system.py
+++ b/src/clean_score/tests/test_per_system.py
@@ -1,24 +1,29 @@
 """
-Per-system re-voicing tests, driven by the real (badly-parsed) Laulun aika score.
+Per-system assignment tests, driven by the real (badly-parsed) Laulun aika score.
 
-The physical staves change role per system; these tests pin the rebuild that turns
-that into one clean staff per part (T1, T2, T3, B).
+The physical staves change role per system; these tests pin the behavior that turns
+that into one clean staff per part (T1, T2, T3, B), driving the module the way its
+two adapters do: with an `Answers` mapping ({system: {staff_id: "T1,T2"}}).
 """
 
+import json
 import os
 
+import pytest
 from lxml import etree
 
-from src.clean_score.utils import per_system
 from src.clean_score.utils.per_system import (
-    build_parts,
-    build_system_lyric_map,
-    decls_from_answers,
-    find_systems,
-    load_answer_cache,
-    prompt_system_decls,
-    save_answer_cache,
+    JsonAnswerStore,
+    clean_per_system,
+    layout_for_file,
+    save_answers,
+    saved_answers,
+    has_answers,
+    system_layout,
+    system_ranges,
+    use_answer_store,
 )
+from src.clean_score.utils.per_system_prompt import prompt_for_answers
 
 FIXTURE = os.path.join(os.path.dirname(__file__), "test_files", "laulun_aika.mscx")
 
@@ -27,17 +32,33 @@ def _load():
     return etree.parse(FIXTURE).getroot()
 
 
-# The user's reading of the score, per system (staff_id, voice_index) -> part.
+# The user's reading of the score, per system: staff_id -> its voices, top to bottom.
 # Systems: 0=m1-6, 1=m7-11, 2=m12-15, 3=m16-19, 4=m20-25, 5=m26-29, 6=m30-35.
-DECLS = {
-    0: {(1, 0): "T1", (1, 1): "T2", (2, 0): "B"},
-    1: {(1, 0): "T1", (1, 1): "T2", (2, 0): "B"},
-    2: {(1, 0): "T1", (1, 1): "T2", (2, 0): "B"},
-    3: {(1, 0): "T1", (1, 1): "T2", (2, 0): "B"},
-    4: {(1, 0): "T3", (2, 0): "B", (3, 0): "T1", (3, 1): "T2"},
-    5: {(1, 0): "T1", (2, 0): "B", (3, 0): "T2"},
-    6: {(1, 0): "T3", (2, 0): "T1", (3, 0): "T2", (4, 0): "B"},
+ANSWERS = {
+    0: {1: "T1,T2", 2: "B"},
+    1: {1: "T1,T2", 2: "B"},
+    2: {1: "T1,T2", 2: "B"},
+    3: {1: "T1,T2", 2: "B"},
+    4: {1: "T3", 2: "B", 3: "T1,T2"},
+    5: {1: "T1", 2: "B", 3: "T2"},
+    6: {1: "T3", 2: "T1", 3: "T2", 4: "B"},
 }
+
+
+@pytest.fixture(autouse=True)
+def isolated_store(tmp_path):
+    """Never touch the repo's real answer store from a test."""
+    with use_answer_store(JsonAnswerStore(str(tmp_path / "answers.json"))):
+        yield
+
+
+def _rebuilt(answers=None):
+    """Rebuild the fixture from answers; returns (result, root, staves-by-part)."""
+    root = _load()
+    result = clean_per_system(root, answers_from=lambda _layouts: answers or ANSWERS)
+    staves = {p.find("trackName").text: s
+              for p, s in zip(root.findall(".//Part"), root.findall(".//Score/Staff"))}
+    return result, root, staves
 
 
 def _pitches(staff, measure_index):
@@ -50,33 +71,57 @@ def _pitches(staff, measure_index):
     ]
 
 
-def test_find_systems():
-    root = _load()
-    systems = find_systems(root)
-    assert systems == [(0, 5), (6, 10), (11, 14), (15, 18), (19, 24), (25, 28), (29, 34)]
+# --------------------------------------------------------------------------- #
+# System discovery + layout
+# --------------------------------------------------------------------------- #
+
+def test_system_ranges_are_1_based_measure_spans():
+    ranges = [(r.start, r.end) for r in system_ranges(_load())]
+    assert ranges == [(1, 6), (7, 11), (12, 15), (16, 19), (20, 25), (26, 29), (30, 35)]
 
 
-def test_build_parts_order_and_count():
-    root = _load()
-    systems = find_systems(root)
-    parts = build_parts(root, systems, DECLS)
-    assert parts == ["T1", "T2", "T3", "B"]
-    staves = root.findall(".//Score/Staff")
-    assert len(staves) == 4
-    # Track names reflect the parts.
-    assert [p.find("trackName").text for p in root.findall(".//Part")] == ["T1", "T2", "T3", "B"]
+def test_layout_reports_the_staves_to_name_per_system():
+    layouts = system_layout(_load())
+    assert [l.index for l in layouts] == list(range(7))
+    first = layouts[0]
+    assert (first.start, first.end) == (1, 6)
+    # System 1: staff 1 carries two voices (T1+T2 divisi), staff 2 one.
+    assert [(r.staff_id, r.voices) for r in first.staves] == [(1, 2), (2, 1)]
+    assert first.staves[0].summary != "(empty)"
+    assert first.staves[0].answer == ""  # nothing recorded yet
+    # System 7: all four staves sound.
+    assert [r.staff_id for r in layouts[6].staves] == [1, 2, 3, 4]
 
 
-def test_t3_staff_silent_until_it_enters():
-    root = _load()
+def test_layout_prefills_recorded_answers():
+    save_answers(FIXTURE, ANSWERS)
+    layouts = layout_for_file(FIXTURE)
+    assert layouts[4].staves[0].answer == "T3"
+    assert layouts[4].staves[2].answer == "T1,T2"
+    # to_dict is the shape the web grid consumes.
+    d = layouts[0].to_dict()
+    assert d["system"] == 0 and d["measure_start"] == 1 and d["measure_end"] == 6
+    assert d["staves"][0]["staff_id"] == 1 and d["staves"][0]["voices"] == 2
+
+
+# --------------------------------------------------------------------------- #
+# Reconstruction
+# --------------------------------------------------------------------------- #
+
+def test_parts_order_and_count():
+    result, root, _ = _rebuilt()
+    assert result.parts == ["T1", "T2", "T3", "B"]
+    assert len(root.findall(".//Score/Staff")) == 4
+    assert [p.find("trackName").text for p in root.findall(".//Part")] == result.parts
+
+
+def test_absent_part_gets_measure_rests_until_it_enters():
     src = _load()  # untouched copy for source-content comparison
-    systems = find_systems(root)
-    build_parts(root, systems, DECLS)
-    staves = {p.find("trackName").text: s
-              for p, s in zip(root.findall(".//Part"), root.findall(".//Score/Staff"))}
+    _, _, staves = _rebuilt()
     t3 = staves["T3"]
     # System 0 (m1) has no T3 -> measure rest, no notes.
     assert _pitches(t3, 0) == []
+    assert t3.findall("Measure")[0].find("voice/Rest/durationType").text == "measure"
     # System 4 (m20) declares T3 = source staff 1 voice 0; content must match the source.
     src_staff1 = src.findall(".//Score/Staff")[0]
     assert _pitches(t3, 19) == _pitches(src_staff1, 19)
@@ -84,12 +129,8 @@ def test_t3_staff_silent_until_it_enters():
 
 
 def test_parts_pull_from_the_right_staff_per_system():
-    root = _load()
     src = _load()
-    systems = find_systems(root)
-    build_parts(root, systems, DECLS)
-    staves = {p.find("trackName").text: s
-              for p, s in zip(root.findall(".//Part"), root.findall(".//Score/Staff"))}
+    _, _, staves = _rebuilt()
     src_s = src.findall(".//Score/Staff")
     # m26 (system 5): T2 comes from source staff 3 voice 0.
     assert _pitches(staves["T2"], 25) == _pitches(src_s[2], 25)
@@ -101,14 +142,9 @@ def test_parts_pull_from_the_right_staff_per_system():
 
 def test_tuplet_survives_rebuild():
     """Measure 14 has a triplet (Tuplet/endTuplet) — it must survive into the rebuilt part."""
-    root = _load()
-    systems = find_systems(root)
-    build_parts(root, systems, DECLS)
-    staves = {p.find("trackName").text: s
-              for p, s in zip(root.findall(".//Part"), root.findall(".//Score/Staff"))}
+    _, _, staves = _rebuilt()
     # m14 (index 13) T1 comes from source staff 1 voice 0, which has the triplet.
-    m14 = staves["T1"].findall("Measure")[13]
-    voice = m14.find("voice")
+    voice = staves["T1"].findall("Measure")[13].find("voice")
     assert voice.find("Tuplet") is not None, "Tuplet start lost in rebuild"
     assert voice.find("endTuplet") is not None, "endTuplet lost in rebuild"
     # The three triplet chords sit between Tuplet and endTuplet.
@@ -126,9 +162,7 @@ def _line_break_measures(staff):
 
 
 def test_line_breaks_re_added_on_top_staff():
-    root = _load()
-    systems = find_systems(root)
-    build_parts(root, systems, DECLS)
+    _, root, _ = _rebuilt()
     staves = root.findall(".//Score/Staff")
     # Top staff carries the system breaks (end of each system except the last).
     assert _line_break_measures(staves[0]) == [5, 10, 14, 18, 24, 28]
@@ -136,79 +170,55 @@ def test_line_breaks_re_added_on_top_staff():
     assert _line_break_measures(staves[1]) == []
 
 
-def _two_system_score():
-    """One staff, two measures, a line break after measure 1 -> two systems."""
-    root = etree.Element("museScore")
-    score = etree.SubElement(root, "Score")
-    part = etree.SubElement(score, "Part")
-    etree.SubElement(part, "trackName").text = "Track 1"
-    etree.SubElement(part, "Staff", id="1")
-    instr = etree.SubElement(part, "Instrument")
-    for tag in ("longName", "shortName", "trackName"):
-        etree.SubElement(instr, tag).text = "Track 1"
-    staff = etree.SubElement(score, "Staff", id="1")
-    for pitch, brk in ((60, True), (62, False)):
-        m = etree.SubElement(staff, "Measure")
-        v = etree.SubElement(m, "voice")
-        ch = etree.SubElement(v, "Chord")
-        etree.SubElement(ch, "durationType").text = "whole"
-        etree.SubElement(etree.SubElement(ch, "Note"), "pitch").text = str(pitch)
-        if brk:
-            lb = etree.SubElement(m, "LayoutBreak")
-            etree.SubElement(lb, "subtype").text = "line"
-    return root
+def test_rebuild_strips_decorations_the_split_also_removes():
+    _, root, _ = _rebuilt()
+    for selector in (".//Lyrics", ".//Dynamic", ".//Harmony", ".//bracket"):
+        assert root.findall(selector) == []
 
 
-def test_prompt_reuses_last_input(monkeypatch):
-    root = _two_system_score()
-    systems = find_systems(root)
-    assert systems == [(0, 0), (1, 1)]
-    # System 1: type "T1"; System 2: press Enter to reuse.
-    answers = iter(["T1", ""])
-    monkeypatch.setattr(per_system, "input", lambda *a: next(answers), raising=False)
-    decls, raw = prompt_system_decls(root, systems)
-    assert decls[0] == {(1, 0): "T1"}
-    assert decls[1] == {(1, 0): "T1"}  # reused
-    assert raw == {0: {1: "T1"}, 1: {1: "T1"}}  # saved answers (Enter resolved to "T1")
+def test_duplicate_name_in_one_system_is_first_wins():
+    """Two staves claiming the same part in one system: the first declaration wins."""
+    answers = {i: dict(a) for i, a in ANSWERS.items()}
+    answers[6] = {1: "T3", 2: "T1", 3: "T1", 4: "B"}  # staff 3 also claims T1
+    src = _load()
+    result, _, staves = _rebuilt(answers)
+    assert result.parts == ["T1", "T2", "T3", "B"]
+    src_s = src.findall(".//Score/Staff")
+    # T1 in m30 comes from staff 2 (the first claim), not staff 3.
+    assert _pitches(staves["T1"], 29) == _pitches(src_s[1], 29)
+    # Nobody is named T2 there, so T2 rests through the last system.
+    assert _pitches(staves["T2"], 29) == []
 
 
-def test_prompt_dash_clears(monkeypatch):
-    root = _two_system_score()
-    systems = find_systems(root)
-    answers = iter(["T1", "-"])  # second system explicitly skipped
-    monkeypatch.setattr(per_system, "input", lambda *a: next(answers), raising=False)
-    decls, raw = prompt_system_decls(root, systems)
-    assert decls.get(0) == {(1, 0): "T1"}
-    assert 1 not in decls  # nothing declared for system 2
-    assert raw == {0: {1: "T1"}, 1: {1: ""}}  # dash recorded as empty
+def test_blank_answer_carries_the_previous_system_forward():
+    """Only the systems where the layout changes need an answer."""
+    sparse = {0: ANSWERS[0], 4: ANSWERS[4], 5: ANSWERS[5], 6: ANSWERS[6]}
+    full, _, _ = _rebuilt()
+    lean, _, _ = _rebuilt(sparse)
+    assert lean.parts == full.parts
+    assert lean.lyric_map == full.lyric_map
 
 
-def test_decls_from_answers_matches_full_decls():
-    """Cached answers should rebuild exactly the same decls the prompt produced."""
+def test_no_answers_leaves_the_score_untouched():
     root = _load()
-    systems = find_systems(root)
-    answers = {
-        0: {1: "T1,T2", 2: "B"},
-        1: {1: "T1,T2", 2: "B"},
-        2: {1: "T1,T2", 2: "B"},
-        3: {1: "T1,T2", 2: "B"},
-        4: {1: "T3", 2: "B", 3: "T1,T2"},
-        5: {1: "T1", 2: "B", 3: "T2"},
-        6: {1: "T3", 2: "T1", 3: "T2", 4: "B"},
-    }
-    assert decls_from_answers(root, systems, answers) == DECLS
+    before = etree.tostring(root)
+    result = clean_per_system(root, input_path=FIXTURE)  # nothing recorded
+    assert not result
+    assert result.parts == []
+    assert etree.tostring(root) == before
 
 
-def test_system_lyric_map_handles_omitted_and_reordered_staves():
+# --------------------------------------------------------------------------- #
+# Lyric routing metadata
+# --------------------------------------------------------------------------- #
+
+def test_lyric_map_handles_omitted_and_reordered_staves():
     """
     Printed staff numbering shifts per system as parts are omitted; the map must order
     by musical rank (not OCR source order) and merge divisi onto one printed staff.
     """
-    root = _load()
-    systems = find_systems(root)
-    parts = build_parts(root, systems, DECLS)  # ["T1","T2","T3","B"] -> ids 1,2,3,4
-    smap = build_system_lyric_map(systems, DECLS, parts)
-    by_range = {(e["start"], e["end"]): e["map"] for e in smap}
+    result, _, _ = _rebuilt()  # parts ["T1","T2","T3","B"] -> ids 1,2,3,4
+    by_range = {(e["start"], e["end"]): e["map"] for e in result.lyric_map}
     # System 1 (m1-6): T1+T2 share source staff 1 (divisi) -> one printed staff; B -> staff 2.
     assert by_range[(1, 6)] == {1: [1, 2], 2: [4]}
     # System 5 (m20-25): T1,T2 divisi printed first, then T3, then B (rank order, not source order).
@@ -219,11 +229,101 @@ def test_system_lyric_map_handles_omitted_and_reordered_staves():
     assert by_range[(30, 35)] == {1: [1], 2: [2], 3: [3], 4: [4]}
 
 
-def test_cache_save_and_load_roundtrip(tmp_path, monkeypatch):
-    monkeypatch.setattr(per_system, "_CACHE_PATH", str(tmp_path / "cache.json"))
-    answers = {0: {1: "T1,T2", 2: "B"}, 1: {1: "T3"}}
-    save_answer_cache("song-x", answers)
-    save_answer_cache("song-y", {0: {1: "S"}})  # second key coexists
-    assert load_answer_cache("song-x") == answers
-    assert load_answer_cache("song-y") == {0: {1: "S"}}
-    assert load_answer_cache("missing") is None
+def test_lyric_maps_are_written_into_the_score():
+    """Lyric import reads the routing back out of the score's metaTags."""
+    result, root, _ = _rebuilt()
+    meta = {m.get("name"): m.text for m in root.findall(".//Score/metaTag")}
+    assert json.loads(meta["lyricsSystemMap"]) == json.loads(json.dumps(result.lyric_map))
+    # Identity fallback, one entry per output staff.
+    assert meta["lyricsStaffMap"] == "1:1;2:2;3:3;4:4"
+
+
+# --------------------------------------------------------------------------- #
+# The two assignment adapters
+# --------------------------------------------------------------------------- #
+
+def _scripted_prompt(replies):
+    """A prompt adapter whose typing is `replies` (in the order it is asked)."""
+    it = iter(replies)
+
+    def source(layouts):
+        with open(os.devnull, "w") as devnull:
+            return prompt_for_answers(layouts, ask=lambda _p: next(it), out=devnull)
+
+    return source
+
+
+def _typed_like(answers, layouts):
+    """What a user would type at the prompt to produce `answers`, in prompt order."""
+    return [answers.get(l.index, {}).get(r.staff_id, "-") for l in layouts for r in l.staves]
+
+
+def test_prompt_adapter_and_grid_answers_rebuild_the_same_score():
+    """The CLI prompt and the web grid are two ways into the same behavior."""
+    from_grid, _, _ = _rebuilt(ANSWERS)
+
+    root = _load()
+    typed = _typed_like(ANSWERS, system_layout(root))
+    from_prompt = clean_per_system(root, answers_from=_scripted_prompt(typed))
+
+    assert from_prompt.parts == from_grid.parts
+    assert from_prompt.lyric_map == from_grid.lyric_map
+
+
+def test_prompt_enter_reuses_the_previous_answer(capsys):
+    layouts = system_layout(_load())
+    # System 1: type the answers; every later system: press Enter to reuse.
+    typed = ["T1,T2", "B"] + [""] * (sum(len(l.staves) for l in layouts) - 2)
+    replies = iter(typed)
+    answers = prompt_for_answers(layouts, ask=lambda _p: next(replies))
+    assert answers[0] == {1: "T1,T2", 2: "B"}
+    assert answers[1] == {1: "T1,T2", 2: "B"}          # reused
+    assert answers[6][3] == ""  # staff 3 first appears in system 5 -> nothing to reuse
+
+
+def test_prompt_dash_clears_a_staff():
+    layouts = system_layout(_load())[:2]
+    replies = iter(["T1,T2", "B", "-", ""])
+    answers = prompt_for_answers(layouts, ask=lambda _p: next(replies))
+    assert answers == {0: {1: "T1,T2", 2: "B"}, 1: {1: "-", 2: "B"}}
+    # A cleared staff declares nothing, and stays cleared for the later systems too
+    # (staff 1 sounds again from system 5 on, but nothing is named there).
+    result, _, staves = _rebuilt(answers)
+    assert result.parts == ["T1", "T2", "B"]
+    assert _pitches(staves["T1"], 29) == []
+
+
+def test_prompt_offers_the_recorded_answer_as_the_default():
+    save_answers(FIXTURE, ANSWERS)
+    layouts = layout_for_file(FIXTURE)
+    prompts = []
+
+    def ask(prompt):
+        prompts.append(prompt)
+        return ""  # accept every default
+
+    assert prompt_for_answers(layouts, ask=ask) == ANSWERS
+    assert "[T1,T2]" in prompts[0]
+
+
+# --------------------------------------------------------------------------- #
+# Answer persistence
+# --------------------------------------------------------------------------- #
+
+def test_answers_are_recorded_per_input_score():
+    save_answers("/somewhere/song-x.mscx", {0: {1: "T1,T2", 2: "B"}, 1: {1: "T3"}})
+    save_answers("/elsewhere/song-y.mscz", {0: {1: "S"}})  # a second score coexists
+    assert saved_answers("songs/song-x.mscx") == {0: {1: "T1,T2", 2: "B"}, 1: {1: "T3"}}
+    assert saved_answers("song-y.mscx") == {0: {1: "S"}}
+    assert saved_answers("missing.mscx") is None
+    assert has_answers("song-y.mscx") and not has_answers("missing.mscx")
+
+
+def test_prompted_answers_are_recorded_for_the_next_run():
+    root = _load()
+    typed = _typed_like(ANSWERS, system_layout(root))
+    clean_per_system(root, input_path=FIXTURE, answers_from=_scripted_prompt(typed))
+    assert saved_answers(FIXTURE) == ANSWERS
+    # A later run needs no prompting at all.
+    again = clean_per_system(_load(), input_path=FIXTURE)
+    assert again.parts == ["T1", "T2", "T3", "B"]

--- a/src/clean_score/utils/per_system.py
+++ b/src/clean_score/utils/per_system.py
@@ -1,91 +1,239 @@
 #!/usr/bin/env python3
 """
-Per-system re-voicing (opt-in) for badly-parsed scores.
+Per-system score assignment (opt-in) for badly-parsed scores.
 
 Some OCR'd scores assign parts to physical staves inconsistently: the same staff
 carries different parts in different systems (e.g. staff 1 is T1+T2 at the start,
 T3 at measure 20, T1 at measure 26). The only reliable cut is the printed system,
 i.e. each line break.
 
-This mode walks the score system by system (between line breaks) and asks the user
-to name each staff's voices for that system. It then rebuilds the score as one clean
-staff per named part, pulling each part's notes from whichever (staff, voice) was
-declared in each system and filling rests where the part is absent. Undeclared /
-empty staves simply disappear (this is also how part deletion happens here).
+This module owns the whole assignment-to-score behavior: it discovers the printed
+systems, describes each system's staves so a caller can ask a human what they hold,
+carries answers forward between systems, rebuilds the score as one clean staff per
+named part (pulling notes from whichever (staff, voice) was declared per system,
+measure-rests where the part is absent), restores the printed line breaks, and
+writes the lyric-routing metadata the lyric importer reads back.
 
-Only used when explicitly enabled (clean_score --per-system) and stdin is a TTY.
+Two adapters sit at the seam and both go through the same interface:
+
+  * the CLI prompt (`per_system_prompt.prompt_for_answers`), used by clean_score;
+  * the web assignment grid (`song_app.pipeline.system_grid` /
+    `save_system_answers`), used by the song app.
+
+Both produce the same `Answers` mapping ({system_index: {staff_id: "T1,T2"}}),
+which is all this module needs to rebuild a score:
+
+    result = clean_per_system(root, input_path="laulun_aika.mscx")   # recorded answers
+    result = clean_per_system(root, input_path=p, answers_from=prompt_for_answers)
+
+Answers are remembered per input file, so re-running a score needs no retyping and
+the song app can clean headless after the grid is submitted.
 """
 
+from __future__ import annotations
+
+import contextlib
 import json
+import logging
 import os
-import sys
 from copy import deepcopy
-from typing import Dict, List, Optional, Tuple
+from dataclasses import dataclass, field
+from typing import Callable, Dict, Iterator, List, Optional, Tuple
 
 from lxml import etree
 
-import logging
-
-from .revoice import _midi_name, _staff_label, _voice_summary
+from .missing_ties import add_missing_ties
+from .revoice import _voice_summary
+from .utils import delete_all_elements_by_selector
 
 logger = logging.getLogger(__name__)
 
-# Repo-root cache of per-system answers, keyed by input file name (no extension).
-# Lets you re-run the same score without retyping (and run non-interactively in tests).
-_CACHE_PATH = os.path.normpath(
-    os.path.join(os.path.dirname(__file__), "..", "..", "..", ".persystem_cache.json")
-)
+# {system_index: {staff_id: "T1,T2"}} — one answer string per staff per system.
+# An empty answer means "unanswered": the staff keeps whatever it was named in the
+# previous system (layouts usually change at only a few systems). To say a staff holds
+# nothing from here on, answer CLEARED.
+Answers = Dict[int, Dict[int, str]]
 
+CLEARED = "-"
 
-def load_answer_cache(input_key: str) -> Optional[Dict[int, Dict[int, str]]]:
-    """Return cached answers {system_index: {staff_id: answer}} for input_key, or None."""
-    if not input_key or not os.path.exists(_CACHE_PATH):
-        return None
-    try:
-        with open(_CACHE_PATH, "r", encoding="utf-8") as f:
-            raw = json.load(f)
-    except (OSError, ValueError):
-        return None
-    entry = raw.get(input_key)
-    if not entry:
-        return None
-    return {int(sidx): {int(sid): ans for sid, ans in staves.items()}
-            for sidx, staves in entry.items()}
+# {system_index: {(staff_id, voice_index): part_name}} — internal, resolved form.
+_Decls = Dict[int, Dict[Tuple[int, int], str]]
 
+# Part letter -> sort rank / clef. Unknown letters sort last.
+_PART_ORDER = {"S": 0, "A": 1, "T": 2, "B": 3, "M": 4, "W": 5}
+_PART_CLEF = {"S": "G", "A": "G", "T": "G8vb", "B": "F", "M": "G8vb", "W": "G"}
 
-def save_answer_cache(input_key: str, answers: Dict[int, Dict[int, str]]) -> None:
-    """Persist answers {system_index: {staff_id: answer}} for input_key."""
-    if not input_key:
-        return
-    raw: Dict[str, Dict[str, Dict[str, str]]] = {}
-    if os.path.exists(_CACHE_PATH):
-        try:
-            with open(_CACHE_PATH, "r", encoding="utf-8") as f:
-                raw = json.load(f)
-        except (OSError, ValueError):
-            raw = {}
-    raw[input_key] = {str(sidx): {str(sid): ans for sid, ans in staves.items()}
-                      for sidx, staves in answers.items()}
-    try:
-        with open(_CACHE_PATH, "w", encoding="utf-8") as f:
-            json.dump(raw, f, indent=2, ensure_ascii=False)
-    except OSError as exc:
-        logger.warning("Could not write per-system cache: %s", exc)
-
-# Part letter -> (sort rank, full name, clef). Unknown letters sort last.
 # Voice elements provided by the staff skeleton (not copied from the source voice).
 # Everything else (Chord, Rest, location, Tuplet, endTuplet, Beam, Spanner, ...) is
 # note content and IS copied, so tuplets/beams/ties survive the rebuild.
 _SKELETON_KEEP = {"TimeSig", "KeySig", "Clef"}
 
-_PART_ORDER = {"S": 0, "A": 1, "T": 2, "B": 3, "M": 4, "W": 5}
-_PART_FULL = {"S": "Soprano", "A": "Alto", "T": "Tenor", "B": "Bass", "M": "Men", "W": "Women"}
-_PART_CLEF = {"S": "G", "A": "G", "T": "G8vb", "B": "F", "M": "G8vb", "W": "G"}
+# Decorations dropped from the rebuilt score (same set the normal split removes).
+_STRIP_SELECTORS = (
+    ".//Lyrics", ".//offset", ".//Dynamic",
+    ".//Spanner[@type='HairPin']", ".//Articulation", ".//Tempo",
+    ".//Harmony", ".//bracket", ".//barLineSpan",
+)
 
 
-def find_systems(root: etree._Element) -> List[Tuple[int, int]]:
-    """Return (start, end) 0-based inclusive measure ranges, split at line breaks."""
-    score = root if root.tag == "Score" else root.find(".//Score")
+# --------------------------------------------------------------------------- #
+# What a caller sees: the systems, and what each system's staves hold.
+# --------------------------------------------------------------------------- #
+
+@dataclass(frozen=True)
+class SystemRange:
+    """A printed system, as 1-based inclusive measure numbers."""
+
+    index: int
+    start: int
+    end: int
+
+
+@dataclass(frozen=True)
+class StaffRow:
+    """One note-bearing staff within one system, as an adapter should show it."""
+
+    staff_id: int
+    voices: int
+    summary: str
+    answer: str = ""  # the saved answer for this cell ("" = never answered)
+
+    def to_dict(self) -> Dict:
+        return {
+            "staff_id": self.staff_id,
+            "voices": self.voices,
+            "summary": self.summary,
+            "answer": self.answer,
+        }
+
+
+@dataclass(frozen=True)
+class SystemLayout:
+    """One printed system plus the staves a caller must name for it."""
+
+    index: int
+    start: int
+    end: int
+    staves: List[StaffRow] = field(default_factory=list)
+
+    def to_dict(self) -> Dict:
+        return {
+            "system": self.index,
+            "measure_start": self.start,
+            "measure_end": self.end,
+            "staves": [s.to_dict() for s in self.staves],
+        }
+
+
+@dataclass(frozen=True)
+class PerSystemResult:
+    """What a rebuild produced: the ordered output parts and the lyric routing map."""
+
+    parts: List[str] = field(default_factory=list)
+    lyric_map: List[Dict] = field(default_factory=list)
+
+    def __bool__(self) -> bool:
+        return bool(self.parts)
+
+
+# An adapter that turns the layout into answers (the CLI prompt, or a test double).
+AnswerSource = Callable[[List[SystemLayout]], Answers]
+
+
+# --------------------------------------------------------------------------- #
+# Answer persistence (internal, substitutable for tests)
+# --------------------------------------------------------------------------- #
+
+class JsonAnswerStore:
+    """Answers for many scores in one JSON file, keyed by input file name."""
+
+    def __init__(self, path: str):
+        self.path = path
+
+    def load(self, key: str) -> Optional[Answers]:
+        if not key or not os.path.exists(self.path):
+            return None
+        try:
+            with open(self.path, "r", encoding="utf-8") as f:
+                raw = json.load(f)
+        except (OSError, ValueError):
+            return None
+        entry = raw.get(key)
+        if not entry:
+            return None
+        return {int(sidx): {int(sid): ans for sid, ans in staves.items()}
+                for sidx, staves in entry.items()}
+
+    def save(self, key: str, answers: Answers) -> None:
+        if not key:
+            return
+        raw: Dict[str, Dict[str, Dict[str, str]]] = {}
+        if os.path.exists(self.path):
+            try:
+                with open(self.path, "r", encoding="utf-8") as f:
+                    raw = json.load(f)
+            except (OSError, ValueError):
+                raw = {}
+        raw[key] = {str(sidx): {str(sid): ans for sid, ans in staves.items()}
+                    for sidx, staves in answers.items()}
+        try:
+            with open(self.path, "w", encoding="utf-8") as f:
+                json.dump(raw, f, indent=2, ensure_ascii=False)
+        except OSError as exc:
+            logger.warning("Could not write per-system answers: %s", exc)
+
+
+# Repo-root store; lets you re-run the same score without retyping (and lets the
+# song app clean headless after its grid is submitted).
+_STORE: JsonAnswerStore = JsonAnswerStore(os.path.normpath(
+    os.path.join(os.path.dirname(__file__), "..", "..", "..", ".persystem_cache.json")
+))
+
+
+@contextlib.contextmanager
+def use_answer_store(store) -> Iterator[None]:
+    """Swap the answer store for the duration of the block (tests, alternate hosts)."""
+    global _STORE
+    previous, _STORE = _STORE, store
+    try:
+        yield
+    finally:
+        _STORE = previous
+
+
+def _key_for(input_path: Optional[str]) -> str:
+    """Answers are keyed by the input score's file name, without extension."""
+    if not input_path:
+        return ""
+    return os.path.splitext(os.path.basename(input_path))[0]
+
+
+def saved_answers(input_path: Optional[str]) -> Optional[Answers]:
+    """Return the answers previously recorded for this input score, or None."""
+    return _STORE.load(_key_for(input_path))
+
+
+def has_answers(input_path: Optional[str]) -> bool:
+    """True if this input score has a recorded answer set (i.e. it is a per-system score)."""
+    return bool(saved_answers(input_path))
+
+
+def save_answers(input_path: Optional[str], answers: Answers) -> None:
+    """Record answers for this input score so a later rebuild needs no prompting."""
+    _STORE.save(_key_for(input_path), answers)
+
+
+# --------------------------------------------------------------------------- #
+# System discovery + layout
+# --------------------------------------------------------------------------- #
+
+def _score_of(root: etree._Element) -> etree._Element:
+    return root if root.tag == "Score" else root.find(".//Score")
+
+
+def _system_bounds(root: etree._Element) -> List[Tuple[int, int]]:
+    """(start, end) 0-based inclusive measure ranges, split at line breaks."""
+    score = _score_of(root)
     staff = score.find("Staff")
     measures = staff.findall("Measure")
     breaks = set()
@@ -104,11 +252,13 @@ def find_systems(root: etree._Element) -> List[Tuple[int, int]]:
     return systems
 
 
-def _part_sort_key(name: str) -> Tuple[int, int, str]:
-    letter = name[0].upper() if name else "Z"
-    rank = _PART_ORDER.get(letter, 99)
-    digits = "".join(c for c in name if c.isdigit())
-    return (rank, int(digits) if digits else 0, name)
+def system_ranges(root: etree._Element) -> List[SystemRange]:
+    """The score's printed systems as 1-based inclusive measure ranges.
+
+    The printed system is the unit the lyric JSON is written in (one block per
+    line), so lyric handling shares this discovery rather than repeating it.
+    """
+    return [SystemRange(i, a + 1, b + 1) for i, (a, b) in enumerate(_system_bounds(root))]
 
 
 def _max_voices_in_range(staff: etree._Element, a: int, b: int) -> int:
@@ -131,107 +281,90 @@ def _first_nonempty_summary(staff: etree._Element, a: int, b: int) -> str:
     return "(empty)"
 
 
-def _apply_answer(
-    decls: Dict[int, Dict[Tuple[int, int], str]],
-    sidx: int,
-    sid: int,
-    nv: int,
-    chosen: str,
-) -> None:
-    """Turn one staff's answer string ("T1,T2") into decl entries for that system."""
-    labels = [n.strip() for n in chosen.split(",")] if chosen else []
-    for vidx, name in enumerate(labels):
-        if vidx < nv and name:
-            decls.setdefault(sidx, {})[(sid, vidx)] = name
+def system_layout(
+    root: etree._Element, input_path: Optional[str] = None
+) -> List[SystemLayout]:
+    """Describe every printed system: its measures and its note-bearing staves.
 
-
-def decls_from_answers(
-    root: etree._Element,
-    systems: List[Tuple[int, int]],
-    answers: Dict[int, Dict[int, str]],
-) -> Dict[int, Dict[Tuple[int, int], str]]:
-    """Build decls from cached/saved answers without prompting."""
-    score = root if root.tag == "Score" else root.find(".//Score")
+    This is what both assignment adapters render — the CLI prompt and the web grid.
+    Each staff row carries the answer recorded for that exact cell (empty when never
+    answered); carrying an answer forward to later systems is the rebuild's job, not
+    the adapter's.
+    """
+    score = _score_of(root)
     staves = score.findall("Staff")
-    decls: Dict[int, Dict[Tuple[int, int], str]] = {}
-    last_answer: Dict[int, str] = {}  # carry a staff's answer into later systems
-    for sidx, (a, b) in enumerate(systems):
-        sys_ans = answers.get(sidx, {})
+    recorded = saved_answers(input_path) or {}
+    layouts: List[SystemLayout] = []
+    for sidx, (a, b) in enumerate(_system_bounds(root)):
+        rows = []
         for staff in staves:
             sid = int(staff.get("id", "0"))
             nv = _max_voices_in_range(staff, a, b)
             if nv == 0:
                 continue
-            raw = sys_ans.get(sid, "")
+            rows.append(StaffRow(
+                staff_id=sid,
+                voices=nv,
+                summary=_first_nonempty_summary(staff, a, b),
+                answer=recorded.get(sidx, {}).get(sid, ""),
+            ))
+        layouts.append(SystemLayout(index=sidx, start=a + 1, end=b + 1, staves=rows))
+    return layouts
+
+
+def layout_for_file(mscx_path: str) -> List[SystemLayout]:
+    """`system_layout` for a score on disk, prefilled with its recorded answers."""
+    with open(mscx_path, "r", encoding="utf-8") as f:
+        root = etree.fromstring(f.read().encode("utf-8"))
+    return system_layout(root, input_path=mscx_path)
+
+
+# --------------------------------------------------------------------------- #
+# Answers -> declarations
+# --------------------------------------------------------------------------- #
+
+def _part_sort_key(name: str) -> Tuple[int, int, str]:
+    letter = name[0].upper() if name else "Z"
+    rank = _PART_ORDER.get(letter, 99)
+    digits = "".join(c for c in name if c.isdigit())
+    return (rank, int(digits) if digits else 0, name)
+
+
+def _decls_from_answers(layouts: List[SystemLayout], answers: Answers) -> _Decls:
+    """Resolve answer strings ("T1,T2") into {(staff_id, voice_index): part} per system.
+
+    A staff left unanswered in a system inherits its answer from the previous system;
+    CLEARED declares nothing and stops that inheritance (the staff stays unnamed until
+    it is answered again). Names beyond the staff's voice count are ignored.
+    """
+    decls: _Decls = {}
+    last_answer: Dict[int, str] = {}
+    for layout in layouts:
+        sys_ans = answers.get(layout.index, {})
+        for row in layout.staves:
+            raw = sys_ans.get(row.staff_id, "")
             if raw == "":
-                raw = last_answer.get(sid, "")  # inherit previous system's answer
+                raw = last_answer.get(row.staff_id, "")  # inherit previous system
             else:
-                last_answer[sid] = raw
-            _apply_answer(decls, sidx, sid, nv, raw)
+                last_answer[row.staff_id] = raw
+            if raw == CLEARED:
+                continue
+            labels = [n.strip() for n in raw.split(",")] if raw else []
+            for vidx, name in enumerate(labels):
+                if vidx < row.voices and name and name != CLEARED:
+                    decls.setdefault(layout.index, {})[(row.staff_id, vidx)] = name
     return decls
 
 
-def prompt_system_decls(
-    root: etree._Element,
-    systems: List[Tuple[int, int]],
-    cache: Optional[Dict[int, Dict[int, str]]] = None,
-) -> Tuple[Dict[int, Dict[Tuple[int, int], str]], Dict[int, Dict[int, str]]]:
-    """
-    For each system, ask the user to name each staff's voices.
+# --------------------------------------------------------------------------- #
+# Score reconstruction
+# --------------------------------------------------------------------------- #
 
-    Returns (decls, answers) where decls[system_index][(staff_id, voice_index)] = part_name
-    and answers[system_index][staff_id] = the chosen answer string (for caching).
-
-    If `cache` is given, its per-staff answer is offered as the default for that system
-    (Enter reuses it), so re-running a previously-answered score needs almost no typing.
-    """
-    score = root if root.tag == "Score" else root.find(".//Score")
-    staves = score.findall("Staff")
-    decls: Dict[int, Dict[Tuple[int, int], str]] = {}
-    answers: Dict[int, Dict[int, str]] = {}
-    last_answer: Dict[int, str] = {}  # per staff id; Enter reuses it
-    cache = cache or {}
-    print(
-        "\nPer-system re-voicing: for each system, name each staff's voices "
-        "(comma per voice).\n"
-        "   Enter reuses the previous answer (shown in [brackets]); "
-        "'-' clears/skips a staff.",
-        file=sys.stderr,
-    )
-    for sidx, (a, b) in enumerate(systems):
-        print(f"\n— System {sidx + 1}: measures {a + 1}-{b + 1} —", file=sys.stderr)
-        for staff in staves:
-            sid = int(staff.get("id", "0"))
-            nv = _max_voices_in_range(staff, a, b)
-            summary = _first_nonempty_summary(staff, a, b)
-            print(f"   staff {sid}: {nv} voice(s) — {summary}", file=sys.stderr)
-        for staff in staves:
-            sid = int(staff.get("id", "0"))
-            nv = _max_voices_in_range(staff, a, b)
-            if nv == 0:
-                continue
-            # Prefer this system's cached answer as the default; fall back to the
-            # previous system's answer for the same staff.
-            default = cache.get(sidx, {}).get(sid, last_answer.get(sid, ""))
-            hint = f" [{default}]" if default else ""
-            raw = input(f"   staff {sid} ({nv} voice(s)){hint} > ").strip()
-            if raw == "":
-                chosen = default          # reuse default for this staff
-            elif raw == "-":
-                chosen = ""               # explicit skip / clear
-            else:
-                chosen = raw
-            last_answer[sid] = chosen
-            answers.setdefault(sidx, {})[sid] = chosen
-            _apply_answer(decls, sidx, sid, nv, chosen)
-    return decls, answers
-
-
-def _system_of(measure_index: int, systems: List[Tuple[int, int]]) -> int:
-    for sidx, (a, b) in enumerate(systems):
+def _system_of(measure_index: int, bounds: List[Tuple[int, int]]) -> int:
+    for sidx, (a, b) in enumerate(bounds):
         if a <= measure_index <= b:
             return sidx
-    return len(systems) - 1
+    return len(bounds) - 1
 
 
 def _measure_rest(sig_n: int, sig_d: int) -> etree._Element:
@@ -251,16 +384,14 @@ def _set_clef(staff: etree._Element, letter: str) -> None:
                 child.text = clef_type
 
 
-def build_parts(
-    root: etree._Element,
-    systems: List[Tuple[int, int]],
-    decls: Dict[int, Dict[Tuple[int, int], str]],
+def _build_parts(
+    root: etree._Element, bounds: List[Tuple[int, int]], decls: _Decls
 ) -> List[str]:
     """
     Rebuild the score as one staff per declared part. Returns the ordered part names.
     Old Parts/Staves are removed (so empty/undeclared staves are deleted).
     """
-    score = root if root.tag == "Score" else root.find(".//Score")
+    score = _score_of(root)
     source_staves = {int(s.get("id", "0")): s for s in score.findall("Staff")}
     template_part = score.find("Part")
     ref_staff = score.find("Staff")
@@ -301,7 +432,7 @@ def build_parts(
                 if el.tag not in _SKELETON_KEEP:
                     voice.remove(el)
             # Find the source (staff, voice) declared as this part in this system.
-            system = _system_of(mi, systems)
+            system = _system_of(mi, bounds)
             src: Optional[Tuple[int, int]] = None
             for (sid, vidx), name in decls.get(system, {}).items():
                 if name == part:
@@ -324,13 +455,12 @@ def build_parts(
         new_staves.append(staff)
 
         new_part = deepcopy(template_part)
-        ps = new_part.find(".//Staff")
-        if ps is not None:
-            ps.set("id", str(out_idx))
+        pstaff = new_part.find(".//Staff")
+        if pstaff is not None:
+            pstaff.set("id", str(out_idx))
         tn = new_part.find("trackName")
         if tn is not None:
             tn.text = part
-        full = _PART_FULL.get(part[0].upper(), part) if part else part
         for tag, val in (("longName", part), ("shortName", part), ("trackName", part)):
             el = new_part.find(f".//Instrument/{tag}")
             if el is not None:
@@ -341,7 +471,7 @@ def build_parts(
     # so the rebuilt score keeps the original system layout.
     if new_staves:
         top_measures = new_staves[0].findall("Measure")
-        for (a, b) in systems[:-1]:
+        for (a, b) in bounds[:-1]:
             if b < len(top_measures):
                 lb = etree.SubElement(top_measures[b], "LayoutBreak")
                 etree.SubElement(lb, "subtype").text = "line"
@@ -358,10 +488,12 @@ def build_parts(
     return parts
 
 
-def build_system_lyric_map(
-    systems: List[Tuple[int, int]],
-    decls: Dict[int, Dict[Tuple[int, int], str]],
-    parts: List[str],
+# --------------------------------------------------------------------------- #
+# Lyric routing metadata
+# --------------------------------------------------------------------------- #
+
+def _build_lyric_map(
+    bounds: List[Tuple[int, int]], decls: _Decls, parts: List[str]
 ) -> List[Dict]:
     """
     Per-system printed-staff -> output-staff(s) map for lyric placement.
@@ -380,7 +512,7 @@ def build_system_lyric_map(
     """
     part_id = {name: i + 1 for i, name in enumerate(parts)}
     out: List[Dict] = []
-    for sidx, (a, b) in enumerate(systems):
+    for sidx, (a, b) in enumerate(bounds):
         groups: Dict[int, List[Tuple[int, str]]] = {}
         for (sid, vidx), name in decls.get(sidx, {}).items():
             groups.setdefault(sid, []).append((vidx, name))
@@ -397,37 +529,79 @@ def build_system_lyric_map(
     return out
 
 
-def revoice_by_system(
-    root: etree._Element,
-    input_key: Optional[str] = None,
-    can_prompt: bool = True,
-) -> Tuple[List[str], List[Dict]]:
-    """
-    Run the full per-system flow (prompt + rebuild). Returns (ordered part names,
-    per-system lyric staff map).
+def _write_lyric_metadata(
+    root: etree._Element, parts: List[str], lyric_map: List[Dict]
+) -> None:
+    """Store the lyric routing maps in the score, where lyric import reads them back.
 
-    If `input_key` is given, cached answers for that input are loaded as prompt
-    defaults and the chosen answers are saved back. When `can_prompt` is False
-    (non-TTY / non-interactive), a complete cache is required and used directly;
-    without one, nothing is rebuilt.
+    `lyricsSystemMap` is the real one (the printed numbering shifts per system as
+    parts are omitted); `lyricsStaffMap` is the identity fallback for readers that
+    only know the single-map form.
     """
-    systems = find_systems(root)
-    if not systems:
-        return [], []
-    cache = load_answer_cache(input_key) if input_key else None
-    if can_prompt:
-        decls, answers = prompt_system_decls(root, systems, cache=cache)
-        if input_key:
-            save_answer_cache(input_key, answers)
-    elif cache:
-        logger.info("Per-system: using cached answers for %s", input_key)
-        decls = decls_from_answers(root, systems, cache)
+    score = root.find(".//Score") if root.tag != "Score" else root
+    existing_meta = score.findall("metaTag")
+    insert_at = (
+        score.index(existing_meta[-1]) + 1 if existing_meta else len(score)
+    )
+    sys_meta = etree.Element("metaTag", name="lyricsSystemMap")
+    sys_meta.text = json.dumps(lyric_map, separators=(",", ":"))
+    score.insert(insert_at, sys_meta)
+    meta = etree.Element("metaTag", name="lyricsStaffMap")
+    meta.text = ";".join(f"{i}:{i}" for i in range(1, len(parts) + 1))
+    score.insert(insert_at, meta)
+
+
+# --------------------------------------------------------------------------- #
+# The one entry point
+# --------------------------------------------------------------------------- #
+
+def clean_per_system(
+    root: etree._Element,
+    input_path: Optional[str] = None,
+    answers_from: Optional[AnswerSource] = None,
+) -> PerSystemResult:
+    """Rebuild `root` in place as one staff per part, from per-system assignments.
+
+    The assignments come from `answers_from` — an adapter that is handed the layout
+    and returns answers, i.e. the CLI prompt; its answers are recorded for next
+    time — or, with no adapter, from the answers already recorded for `input_path`
+    by an earlier run or by the web grid.
+
+    Returns the ordered part names and the per-system lyric map (also written into
+    the score). An empty result means nothing was rebuilt and the score is untouched:
+    no systems, no answers to work from, or no part named in any answer.
+    """
+    layouts = system_layout(root, input_path=input_path)
+    if not layouts:
+        return PerSystemResult()
+
+    if answers_from is not None:
+        answers = answers_from(layouts)
+        save_answers(input_path, answers)
     else:
-        logger.warning(
-            "Per-system needs a terminal to prompt, or a cached answer set for '%s'.",
-            input_key,
-        )
-        return [], []
-    parts = build_parts(root, systems, decls)
-    system_map = build_system_lyric_map(systems, decls, parts)
-    return parts, system_map
+        answers = saved_answers(input_path)
+        if answers:
+            logger.info("Per-system: using recorded answers for %s", _key_for(input_path))
+        else:
+            logger.warning(
+                "Per-system needs a terminal to prompt, or a recorded answer set for '%s'.",
+                _key_for(input_path),
+            )
+            return PerSystemResult()
+
+    bounds = [(l.start - 1, l.end - 1) for l in layouts]
+    decls = _decls_from_answers(layouts, answers)
+    parts = _build_parts(root, bounds, decls)
+    if not parts:
+        return PerSystemResult()
+
+    # Post-rebuild cleanup: recover ties the OCR dropped, then strip the decorations
+    # the normal split also removes. LayoutBreaks are kept — the rebuild re-adds the
+    # system breaks and they carry the printed layout.
+    add_missing_ties(root)
+    for selector in _STRIP_SELECTORS:
+        delete_all_elements_by_selector(root, selector)
+
+    lyric_map = _build_lyric_map(bounds, decls, parts)
+    _write_lyric_metadata(root, parts, lyric_map)
+    return PerSystemResult(parts=parts, lyric_map=lyric_map)

--- a/src/clean_score/utils/per_system_prompt.py
+++ b/src/clean_score/utils/per_system_prompt.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+"""
+Terminal adapter for per-system assignment.
+
+One of the two ways a human names each staff's voices per printed system (the other
+is the song app's assignment grid). It only renders the layout `per_system` hands it
+and returns the answers `per_system` rebuilds from — it knows nothing about systems,
+declarations, or the score itself.
+"""
+
+from __future__ import annotations
+
+import sys
+from typing import Callable, Dict, List, Optional
+
+from .per_system import CLEARED, Answers, SystemLayout
+
+
+def prompt_for_answers(
+    layouts: List[SystemLayout],
+    ask: Optional[Callable[[str], str]] = None,
+    out=None,
+) -> Answers:
+    """Ask, system by system, what each staff holds. Returns the answers.
+
+    Each staff's default (shown in [brackets], reused by pressing Enter) is the answer
+    recorded for that cell, or failing that the answer just given for the same staff in
+    an earlier system — layouts usually change at only a few systems. '-' says the staff
+    holds nothing from here on.
+    """
+    ask = ask or input
+    out = out or sys.stderr
+    answers: Answers = {}
+    last_answer: Dict[int, str] = {}  # per staff id; Enter reuses it
+    print(
+        "\nPer-system re-voicing: for each system, name each staff's voices "
+        "(comma per voice).\n"
+        "   Enter reuses the previous answer (shown in [brackets]); "
+        "'-' clears/skips a staff.",
+        file=out,
+    )
+    for layout in layouts:
+        print(f"\n— System {layout.index + 1}: measures {layout.start}-{layout.end} —", file=out)
+        for row in layout.staves:
+            print(f"   staff {row.staff_id}: {row.voices} voice(s) — {row.summary}", file=out)
+        for row in layout.staves:
+            default = row.answer or last_answer.get(row.staff_id, "")
+            hint = f" [{default}]" if default else ""
+            raw = ask(f"   staff {row.staff_id} ({row.voices} voice(s)){hint} > ").strip()
+            if raw == "":
+                chosen = default          # reuse default for this staff
+            elif raw == CLEARED:
+                chosen = CLEARED          # explicit skip / clear
+            else:
+                chosen = raw
+            last_answer[row.staff_id] = chosen
+            answers.setdefault(layout.index, {})[row.staff_id] = chosen
+    return answers

--- a/src/song_app/pipeline.py
+++ b/src/song_app/pipeline.py
@@ -20,7 +20,7 @@ from lxml import etree
 
 from src.clean_score.main import main as clean_main
 from src.clean_score.lyric_txt import import_file
-from src.clean_score.utils import per_system as ps
+from src.clean_score.utils import per_system
 
 MUSESCORE_EXTS = (".mscz", ".mscx", ".musicxml", ".xml")
 Logger = Callable[[str], None]
@@ -76,50 +76,28 @@ def convert_to_mscx(input_path: str, out_dir: str, log: Logger = _noop) -> str:
     return target
 
 
-def cache_key(mscx_path: str) -> str:
-    """The .persystem_cache.json key clean_score uses (input basename, no ext)."""
-    return os.path.splitext(os.path.basename(mscx_path))[0]
-
-
 def system_grid(mscx_path: str) -> List[Dict]:
     """Per-system staff layout for the clean-stage grid form.
 
     Returns one entry per printed system: measure range + each note-bearing staff's
-    id, voice count and a short content summary. Pre-fills answers from the cache.
+    id, voice count and a short content summary, prefilled with any saved answer.
     """
-    with open(mscx_path, "r", encoding="utf-8") as f:
-        root = etree.fromstring(f.read().encode("utf-8"))
-    score = root if root.tag == "Score" else root.find(".//Score")
-    staves = score.findall("Staff")
-    systems = ps.find_systems(root)
-    cache = ps.load_answer_cache(cache_key(mscx_path)) or {}
-
-    grid: List[Dict] = []
-    for sidx, (a, b) in enumerate(systems):
-        rows = []
-        for staff in staves:
-            sid = int(staff.get("id", "0"))
-            nv = ps._max_voices_in_range(staff, a, b)
-            if nv == 0:
-                continue
-            rows.append({
-                "staff_id": sid,
-                "voices": nv,
-                "summary": ps._first_nonempty_summary(staff, a, b),
-                "answer": cache.get(sidx, {}).get(sid, ""),
-            })
-        grid.append({
-            "system": sidx,
-            "measure_start": a + 1,
-            "measure_end": b + 1,
-            "staves": rows,
-        })
-    return grid
+    return [layout.to_dict() for layout in per_system.layout_for_file(mscx_path)]
 
 
 def save_system_answers(mscx_path: str, answers: Dict[int, Dict[int, str]]) -> None:
-    """Persist the grid answers to .persystem_cache.json so clean can run headless."""
-    ps.save_answer_cache(cache_key(mscx_path), answers)
+    """Record the grid answers for this score so cleaning can run headless."""
+    per_system.save_answers(mscx_path, answers)
+
+
+def has_system_answers(input_path: str) -> bool:
+    """True if this score has a recorded per-system answer set (so it is per-system)."""
+    return per_system.has_answers(input_path)
+
+
+def system_ranges(root: etree._Element) -> List[per_system.SystemRange]:
+    """The score's printed systems as 1-based measure spans (for the lyric grid)."""
+    return per_system.system_ranges(root)
 
 
 def run_clean(

--- a/src/song_app/server.py
+++ b/src/song_app/server.py
@@ -160,9 +160,9 @@ def _import_one(name: str) -> bool:
     if not (inp or cleaned or outputs):
         return False  # not a recognisable song folder
 
-    # per-system if a cached answer set exists for this input basename
-    key = os.path.splitext(inp)[0] if inp else (cleaned[: -len("_cleaned.mscx")] if cleaned else "")
-    mode = "per-system" if pipeline.ps.load_answer_cache(key) else "normal"
+    # per-system if an answer set was recorded for this input score
+    src_name = inp or (cleaned[: -len("_cleaned.mscx")] + ".mscx" if cleaned else "")
+    mode = "per-system" if pipeline.has_system_answers(src_name) else "normal"
 
     try:
         created = os.path.getmtime(d)
@@ -438,21 +438,21 @@ def api_lyric_grid(slug: str) -> Dict:
             continue
         parts.append({"name": name or f"staff {sid}", "id": sid})
     parts.sort(key=lambda x: x["id"])
-    sys_ranges = pipeline.ps.find_systems(root)
-    systems = [{"index": i, "start": a + 1, "end": b + 1} for i, (a, b) in enumerate(sys_ranges)]
+    sys_ranges = pipeline.system_ranges(root)
+    systems = [{"index": r.index, "start": r.start, "end": r.end} for r in sys_ranges]
 
     # Prefill: the lyrics already in the score, as hyphenated text per (system, part).
     from src.clean_score.lyric_txt import lyrics_by_measure_staff, _merge_tokens
     bms = lyrics_by_measure_staff(root)
     prefill: Dict[str, Dict[str, str]] = {}
-    for i, (a, b) in enumerate(sys_ranges):
+    for r in sys_ranges:
         for part in parts:
             toks = []
-            for mi in range(a, b + 1):
+            for mi in range(r.start - 1, r.end):
                 toks += [t for t in bms.get(mi, {}).get(part["id"], []) if t != "_"]
             text = _merge_tokens(toks).strip()
             if text:
-                prefill.setdefault(str(i), {})[part["name"]] = text
+                prefill.setdefault(str(r.index), {})[part["name"]] = text
     return {"parts": parts, "systems": systems, "prefill": prefill}
 
 

--- a/src/song_app/tests/test_clean_flow.py
+++ b/src/song_app/tests/test_clean_flow.py
@@ -1,0 +1,80 @@
+"""
+The song app's clean path: grid answers in, rebuilt score and lyric routing out.
+
+This drives the web adapter (pipeline.system_grid / save_system_answers / run_clean)
+over the same per-system module the CLI prompt uses, so the two adapters stay pinned
+to one behavior.
+"""
+
+import json
+import os
+import shutil
+
+import pytest
+from lxml import etree
+
+from src.clean_score.tests.test_per_system import ANSWERS  # the fixture's reading
+from src.clean_score.utils.per_system import JsonAnswerStore, use_answer_store
+from src.song_app import pipeline
+
+FIXTURE = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.dirname(__file__))),
+    "clean_score", "tests", "test_files", "laulun_aika.mscx",
+)
+
+
+@pytest.fixture
+def song_dir(tmp_path):
+    """A song folder holding the fixture, with an answer store of its own."""
+    d = tmp_path / "song"
+    d.mkdir()
+    shutil.copy2(FIXTURE, d / "laulun_aika.mscx")
+    with use_answer_store(JsonAnswerStore(str(tmp_path / "answers.json"))):
+        yield str(d)
+
+
+def _source(song_dir):
+    return os.path.join(song_dir, "laulun_aika.mscx")
+
+
+def test_grid_describes_every_system(song_dir):
+    grid = pipeline.system_grid(_source(song_dir))
+    assert len(grid) == 7
+    assert grid[0]["measure_start"] == 1 and grid[0]["measure_end"] == 6
+    assert [s["staff_id"] for s in grid[0]["staves"]] == [1, 2]
+    assert grid[0]["staves"][0]["voices"] == 2
+    assert all(s["answer"] == "" for sys in grid for s in sys["staves"])
+
+
+def test_grid_answers_survive_a_reload(song_dir):
+    src = _source(song_dir)
+    assert not pipeline.has_system_answers(src)
+    pipeline.save_system_answers(src, ANSWERS)
+    assert pipeline.has_system_answers(src)
+    grid = pipeline.system_grid(src)
+    assert grid[4]["staves"][0]["answer"] == "T3"
+
+
+def test_grid_answers_clean_headless_into_parts_and_lyric_routing(song_dir):
+    src = _source(song_dir)
+    pipeline.save_system_answers(src, ANSWERS)
+
+    cleaned, mscx = pipeline.run_clean(src, song_dir, per_system=True)
+    assert mscx == src  # a .mscx source needs no conversion
+    assert os.path.exists(cleaned)
+
+    root = etree.parse(cleaned).getroot()
+    assert [p.findtext("trackName") for p in root.findall(".//Part")] == ["T1", "T2", "T3", "B"]
+    assert len(root.findall(".//Score/Staff")) == 4
+
+    # The lyric importer routes by these; printed numbering shifts per system.
+    meta = {m.get("name"): m.text for m in root.findall(".//Score/metaTag")}
+    smap = {(e["start"], e["end"]): e["map"] for e in json.loads(meta["lyricsSystemMap"])}
+    assert smap[(1, 6)] == {"1": [1, 2], "2": [4]}      # T1+T2 divisi, then B
+    assert smap[(26, 29)] == {"1": [1], "2": [2], "3": [4]}  # T3 absent -> printed 3 is B
+    assert meta["lyricsStaffMap"] == "1:1;2:2;3:3;4:4"
+
+
+def test_clean_without_answers_reports_no_output(song_dir):
+    with pytest.raises(RuntimeError, match="no parts declared"):
+        pipeline.run_clean(_source(song_dir), song_dir, per_system=True)


### PR DESCRIPTION
Closes #1.

## Summary

`per_system.py` becomes a deep module owning the whole assignment-to-score behavior behind one entry point, `clean_per_system(root, input_path=, answers_from=)`: system discovery, answer inheritance, score reconstruction, part ordering, line-break restoration, post-rebuild cleanup (`add_missing_ties` + the decoration strip) and the `lyricsSystemMap`/`lyricsStaffMap` metaTags.

The CLI prompt moves to `per_system_prompt.py`, so it and the web grid are two adapters at the same seam, both producing the same `Answers` mapping (`{system_index: {staff_id: "T1,T2"}}`). Callers no longer reach past the interface: `main.py` is call + write + log, `pipeline`'s helpers are one-liners over `layout_for_file` / `save_answers` / `has_answers` / `system_ranges`, `server.py` no longer goes through `pipeline.ps`, and `lyric_txt` asks for `system_ranges`. Answer persistence is internal (`JsonAnswerStore` behind `use_answer_store`), so tests no longer patch a private cache path.

Tests are rewritten against the interface (73 pass), including one that drives both adapters to the same rebuild and a new song-app path test (grid answers → headless clean → parts + lyric routing). Cleaning the `laulun_aika` fixture through the CLI produces byte-identical output to the pre-refactor code.

## Review

Reviewed at working tree over `c6b5504`, effort `high`: 3 correctness lanes + 6 architecture lanes, then 1 lane re-checking the fixes. First pass on this branch — no prior review record.

**Correctness: 0 findings** across all three lanes.

**Architecture verdict: Reconsider** — 4 dimensions `sound` (Right problem 82, Right approach 72, Right place 78, Use cases/UX 72), 2 `questionable` (Scope & blast radius 72, Over-engineering 70). Two gated flags is a `Reconsider` under the procedure's rule; both are shape opinions, not defects, and neither lane disputed the consolidation itself.

Fixed:
- Dropped the `answers=` parameter from `clean_per_system` — it had no production caller, so the entry point had three ways in where two are used (Over-engineering finding 2). Tests pass `answers_from=lambda _layouts: ...`.
- Routed the lyric grid's system ranges through the glue layer (new `pipeline.system_ranges`) instead of `server.py` importing from `clean_score` directly — the Right-place and Over-engineering lanes both flagged that half of the web layer went through `pipeline` and half did not (Right place, Over-engineering finding 3).
- Derived `bounds` from the already-computed layouts instead of re-walking the tree with a second `_system_bounds(root)` call (Right approach, non-blocking observation).

Deliberately skipped:
- **Collapsing `JsonAnswerStore` + `_STORE` + `use_answer_store` into a module path constant** (Over-engineering finding 1, conf 70). The card explicitly permits persistence "behind a justified local-substitutable seam", the Right-approach lane rated the same code `sound` on the same evidence, and collapsing it would put tests back to `monkeypatch.setattr(per_system, "_CACHE_PATH", ...)` — reaching past the interface, which is what the card's test direction asks to stop. Revisit only if a second store never materialises and the seam stays test-only.
- **Teaching the web grid about `-`** (Use cases/UX note, conf 72). `static/app.js` cascades any non-empty cell forward as an inherited answer and excludes it from the "will be DROPPED" warning, so a `-` typed into a cell now clears server-side without the UI previewing it. Skipped because the card puts grid redesign out of scope and the current behaviour is still strictly better than before (a `-` used to produce a part literally named `-`). The fix is ~2 lines in `cascade()`/`unnamed()`: treat `"-"` as clearing the carry rather than setting it.
- **Splitting the `CLEARED` semantics into its own commit** (Scope lane's proposed alternative). Unwinding beyond-the-card work mid-review is a bigger unreviewed change than leaving it; it is disclosed below instead.
- **Moving the shared `ANSWERS` fixture into a conftest** (Right place, minor). `src/song_app/tests/test_clean_flow.py` imports it from `src/clean_score/tests/test_per_system.py`; a cross-package conftest would have to live at the repo root, which is more structure than one constant warrants.

**Beyond the card:**
- `-` (`per_system.CLEARED`) is now recorded literally and stops answer inheritance, where the CLI previously recorded `""` and a cached `""` meant "inherit" (`src/clean_score/utils/per_system.py`, `per_system_prompt.py`). One owner needed one rule, but this is a behaviour change the card did not ask for; it could have shipped separately. Existing `.persystem_cache.json` entries hold `""` only, so they replay exactly as before — verified against the repo's real cache file.
- `find_systems` (0-based tuples) became `system_ranges` (1-based `SystemRange`), rippling into `lyric_txt.py` and the `api_lyric_grid` prefill loop in `server.py`. Only the import location was in scope; the index-base change rode along. Separable.
- Dead code removed: the unused `_PART_FULL` constant and two unused imports in `per_system.py`. Separable.
- Documentation rewritten in `CLAUDE.md` (per-system section, pipeline bullet, test command) and one line in `DESIGN.md`. Rename-tracking on the governing docs.

**Fast check:** `.venv/bin/python -m pytest src/clean_score/tests/ src/song_app/tests/ -q` → 73 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H5kKorL2a8NxRGzKjtkPjS
