### PR TITLE
Collapse the answer-store class and teach the grid about "-"

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -222,6 +222,10 @@ state model are in `DESIGN.md`.
   back onto the matching system/part cell; lyric-panel scroll is preserved across
   the refresh. Blank cells are omitted, so this editor expresses a lyric line
   starting in a system, not an instruction to clear one isolated cell.
+- The clean panel's per-system grid mirrors the backend's answer rules: a blank cell
+  inherits the staff's previous answer (shown as a faint placeholder) and `-` marks the
+  staff silent from there on, clearing the carry — both cleared and never-named slots are
+  flagged `unset` and listed in the "will be DROPPED" confirm before cleaning.
 - **Hazards guarded:** re-cleaning warns it discards manual edits (the Clean
   button label changes once a cleaned file exists); lyric import uses `--replace`.
   No automatic LLM (users have no API key) — the lyrics stage supports either a
@@ -308,8 +312,8 @@ A staff left blank in a system inherits its previous system's answer (`-` =
 `per_system.CLEARED` declares nothing and stops that inheritance); the
 prompt offers the recorded answer as a `[default]` (Enter reuses it). Answers are
 recorded per input file (basename, no extension) in `.persystem_cache.json` at the repo
-root (gitignored) via `save_answers`/`saved_answers`/`has_answers`; the store itself is
-internal (`JsonAnswerStore`, swappable in tests through `use_answer_store`). A complete
+root (gitignored) via `save_answers`/`saved_answers`/`has_answers`; the file itself is
+internal (swap it in tests with `use_answer_file(path)`). A complete
 answer set lets per-system mode run **non-interactively** (no TTY) — that is how the web
 app cleans headless after the grid is submitted, and how the tests drive it. `main()`
 handles per-system mode in an early branch: it calls `clean_per_system` (handing it the

--- a/src/clean_score/tests/test_per_system.py
+++ b/src/clean_score/tests/test_per_system.py
@@ -13,7 +13,6 @@ import pytest
 from lxml import etree
 
 from src.clean_score.utils.per_system import (
-    JsonAnswerStore,
     clean_per_system,
     layout_for_file,
     save_answers,
@@ -21,7 +20,7 @@ from src.clean_score.utils.per_system import (
     has_answers,
     system_layout,
     system_ranges,
-    use_answer_store,
+    use_answer_file,
 )
 from src.clean_score.utils.per_system_prompt import prompt_for_answers
 
@@ -47,8 +46,8 @@ ANSWERS = {
 
 @pytest.fixture(autouse=True)
 def isolated_store(tmp_path):
-    """Never touch the repo's real answer store from a test."""
-    with use_answer_store(JsonAnswerStore(str(tmp_path / "answers.json"))):
+    """Never touch the repo's real answer file from a test."""
+    with use_answer_file(str(tmp_path / "answers.json")):
         yield
 
 

--- a/src/clean_score/utils/per_system.py
+++ b/src/clean_score/utils/per_system.py
@@ -141,64 +141,37 @@ AnswerSource = Callable[[List[SystemLayout]], Answers]
 
 
 # --------------------------------------------------------------------------- #
-# Answer persistence (internal, substitutable for tests)
+# Answer persistence (internal; the file is swappable for tests)
 # --------------------------------------------------------------------------- #
 
-class JsonAnswerStore:
-    """Answers for many scores in one JSON file, keyed by input file name."""
-
-    def __init__(self, path: str):
-        self.path = path
-
-    def load(self, key: str) -> Optional[Answers]:
-        if not key or not os.path.exists(self.path):
-            return None
-        try:
-            with open(self.path, "r", encoding="utf-8") as f:
-                raw = json.load(f)
-        except (OSError, ValueError):
-            return None
-        entry = raw.get(key)
-        if not entry:
-            return None
-        return {int(sidx): {int(sid): ans for sid, ans in staves.items()}
-                for sidx, staves in entry.items()}
-
-    def save(self, key: str, answers: Answers) -> None:
-        if not key:
-            return
-        raw: Dict[str, Dict[str, Dict[str, str]]] = {}
-        if os.path.exists(self.path):
-            try:
-                with open(self.path, "r", encoding="utf-8") as f:
-                    raw = json.load(f)
-            except (OSError, ValueError):
-                raw = {}
-        raw[key] = {str(sidx): {str(sid): ans for sid, ans in staves.items()}
-                    for sidx, staves in answers.items()}
-        try:
-            with open(self.path, "w", encoding="utf-8") as f:
-                json.dump(raw, f, indent=2, ensure_ascii=False)
-        except OSError as exc:
-            logger.warning("Could not write per-system answers: %s", exc)
-
-
-# Repo-root store; lets you re-run the same score without retyping (and lets the
-# song app clean headless after its grid is submitted).
-_STORE: JsonAnswerStore = JsonAnswerStore(os.path.normpath(
+# Answers for every score live in one JSON file at the repo root, keyed by the input
+# score's file name. That is what lets you re-run a score without retyping, and lets
+# the song app clean headless after its grid is submitted.
+_ANSWER_FILE = os.path.normpath(
     os.path.join(os.path.dirname(__file__), "..", "..", "..", ".persystem_cache.json")
-))
+)
 
 
 @contextlib.contextmanager
-def use_answer_store(store) -> Iterator[None]:
-    """Swap the answer store for the duration of the block (tests, alternate hosts)."""
-    global _STORE
-    previous, _STORE = _STORE, store
+def use_answer_file(path: str) -> Iterator[None]:
+    """Record answers in `path` for the duration of the block (tests, alternate hosts)."""
+    global _ANSWER_FILE
+    previous, _ANSWER_FILE = _ANSWER_FILE, path
     try:
         yield
     finally:
-        _STORE = previous
+        _ANSWER_FILE = previous
+
+
+def _read_answer_file() -> Dict[str, Dict[str, Dict[str, str]]]:
+    """The whole answer file, or an empty mapping if it is missing or unreadable."""
+    if not os.path.exists(_ANSWER_FILE):
+        return {}
+    try:
+        with open(_ANSWER_FILE, "r", encoding="utf-8") as f:
+            return json.load(f)
+    except (OSError, ValueError):
+        return {}
 
 
 def _key_for(input_path: Optional[str]) -> str:
@@ -210,7 +183,12 @@ def _key_for(input_path: Optional[str]) -> str:
 
 def saved_answers(input_path: Optional[str]) -> Optional[Answers]:
     """Return the answers previously recorded for this input score, or None."""
-    return _STORE.load(_key_for(input_path))
+    key = _key_for(input_path)
+    entry = _read_answer_file().get(key) if key else None
+    if not entry:
+        return None
+    return {int(sidx): {int(sid): ans for sid, ans in staves.items()}
+            for sidx, staves in entry.items()}
 
 
 def has_answers(input_path: Optional[str]) -> bool:
@@ -220,7 +198,17 @@ def has_answers(input_path: Optional[str]) -> bool:
 
 def save_answers(input_path: Optional[str], answers: Answers) -> None:
     """Record answers for this input score so a later rebuild needs no prompting."""
-    _STORE.save(_key_for(input_path), answers)
+    key = _key_for(input_path)
+    if not key:
+        return
+    raw = _read_answer_file()
+    raw[key] = {str(sidx): {str(sid): ans for sid, ans in staves.items()}
+                for sidx, staves in answers.items()}
+    try:
+        with open(_ANSWER_FILE, "w", encoding="utf-8") as f:
+            json.dump(raw, f, indent=2, ensure_ascii=False)
+    except OSError as exc:
+        logger.warning("Could not write per-system answers: %s", exc)
 
 
 # --------------------------------------------------------------------------- #

--- a/src/song_app/static/app.js
+++ b/src/song_app/static/app.js
@@ -415,6 +415,9 @@ async function panelClean(panel, song, slug, P, refresh) {
 
       // Roll a staff's answer forward: an empty field shows the previous system's
       // answer for the same staff as a faint placeholder (and inherits it at clean).
+      // A cell holding "-" says the staff is silent from there on, so it clears the
+      // carry instead of setting it — same rule the backend applies (per_system.CLEARED).
+      const CLEARED = "-";
       const inputs = [...holder.querySelectorAll("input[data-sys]")];
       const byStaff = () => {
         const m = {};
@@ -427,10 +430,11 @@ async function panelClean(panel, song, slug, P, refresh) {
           let carry = "";
           for (const inp of list) {
             const v = inp.value.trim();
-            if (v) carry = v;
+            if (v === CLEARED) carry = "";
+            else if (v) carry = v;
             else inp.placeholder = carry || inp.dataset.hint;
-            // flag staves that will be dropped (no value and nothing to inherit)
-            inp.classList.toggle("unset", !v && !carry);
+            // flag staves that will be dropped (cleared, or no value and nothing to inherit)
+            inp.classList.toggle("unset", (!v || v === CLEARED) && !carry);
           }
         }
       };
@@ -441,8 +445,10 @@ async function panelClean(panel, song, slug, P, refresh) {
           let carry = "";
           for (const inp of list) {
             const v = inp.value.trim();
-            if (v) carry = v;
-            else if (!carry) out.push(`staff ${inp.dataset.staff} · system ${+inp.dataset.sys + 1}`);
+            if (v === CLEARED) carry = "";
+            else if (v) carry = v;
+            if ((!v || v === CLEARED) && !carry)
+              out.push(`staff ${inp.dataset.staff} · system ${+inp.dataset.sys + 1}`);
           }
         }
         return out;
@@ -502,9 +508,9 @@ function sysBlock(sys) {
       el("td", {}, String(st.voices)),
       el("td", { className: "stsum" }, st.summary),
       el("td", {}, el("input", {
-        value: st.answer || "", placeholder: st.voices > 1 ? "e.g. T1, T2 (type to set)" : "e.g. T1 (type to set)",
+        value: st.answer || "", placeholder: st.voices > 1 ? "e.g. T1, T2 (- = silent)" : "e.g. T1 (- = silent)",
         "data-sys": sys.system, "data-staff": st.staff_id,
-        "data-hint": st.voices > 1 ? "e.g. T1, T2 (type to set)" : "e.g. T1 (type to set)",
+        "data-hint": st.voices > 1 ? "e.g. T1, T2 (- = silent)" : "e.g. T1 (- = silent)",
       }))));
   return el("div", { className: "sysblock" },
     el("h4", {}, `System ${sys.system + 1} — measures ${sys.measure_start}–${sys.measure_end}`),

--- a/src/song_app/tests/test_clean_flow.py
+++ b/src/song_app/tests/test_clean_flow.py
@@ -14,7 +14,7 @@ import pytest
 from lxml import etree
 
 from src.clean_score.tests.test_per_system import ANSWERS  # the fixture's reading
-from src.clean_score.utils.per_system import JsonAnswerStore, use_answer_store
+from src.clean_score.utils.per_system import use_answer_file
 from src.song_app import pipeline
 
 FIXTURE = os.path.join(
@@ -25,11 +25,11 @@ FIXTURE = os.path.join(
 
 @pytest.fixture
 def song_dir(tmp_path):
-    """A song folder holding the fixture, with an answer store of its own."""
+    """A song folder holding the fixture, with an answer file of its own."""
     d = tmp_path / "song"
     d.mkdir()
     shutil.copy2(FIXTURE, d / "laulun_aika.mscx")
-    with use_answer_store(JsonAnswerStore(str(tmp_path / "answers.json"))):
+    with use_answer_file(str(tmp_path / "answers.json")):
         yield str(d)
 
 


### PR DESCRIPTION
The two follow-ups recorded in #3's Review note.

## Answer store → answer file

`JsonAnswerStore` + the `_STORE` global + `use_answer_store(store)` existed to point one JSON file somewhere else in tests; there is one instance in production. The seam stays (tests should not patch a private constant — that is what the original issue asked to stop), the class goes: `_ANSWER_FILE` holds the path, `use_answer_file(path)` swaps it, and `saved_answers`/`save_answers` read and write it directly. Net −26 lines, no behaviour change.

## The grid now applies the backend's `-` rule

`cascade()` and `unnamed()` in `static/app.js` treated any non-empty cell as a part name, so a `-` typed into a cell cascaded forward as an inherited answer and was excluded from the "will be DROPPED" confirm — while the backend cleared that staff and stopped inheritance. Both sides now follow the same rule, and the placeholder says `- = silent`.

Checked the two implementations against each other on the four sequences that matter, for one staff across three systems (the list is the systems where the staff ends up dropped):

| cells | grid | backend |
|---|---|---|
| `T1`, blank, blank | none | none |
| `T1`, `-`, blank | 2nd, 3rd | 2nd, 3rd |
| `-`, blank, `T2` | 1st, 2nd | 1st, 2nd |
| blank, blank, blank | all | all |

**Fast check:** `.venv/bin/python -m pytest src/clean_score/tests/ src/song_app/tests/ -q` → 73 passed; `node --check src/song_app/static/app.js` clean. No review lanes were run on this one — it is the follow-up work #3's review already named.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H5kKorL2a8NxRGzKjtkPjS
