### PR TITLE
Deepen lyric placement and return structured diagnostics

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -99,13 +99,21 @@ python rename_parts.py score.mscx SSAA -o score_renamed.mscx
 ### Tests
 
 ```bash
-.venv/bin/python -m pytest src/clean_score/tests/ src/song_app/tests/ -q   # 73 tests, all passing
+.venv/bin/python -m pytest src/clean_score/tests/ src/song_app/tests/ -q   # 82 tests, all passing
 ```
 
 `pyproject.toml` only sets `log_cli_level=DEBUG`. Key test modules:
 
 - `test_lyric_txt_spanner.py` — asserts lyric export→import round-trips back to
-  the original XML (the real behavioral coverage).
+  the original XML (the real behavioral coverage), driven through `export_lyrics` /
+  `place_lyrics`.
+- `test_json_staff_mapping.py` — lyric **routing**: builds a synthetic score, places
+  a PDF-derived line, and reads back which output staff got the words (printed
+  staff+position, per-system map, part names, explicit `parts` override).
+- `test_lyric_diagnostics.py` — the structured `Mismatch` fields, measure_start
+  inference, and the editor-grid → cells → blocks → import → editor-grid round trip.
+- `src/clean_score/tests/scorebuilder.py` — the shared synthetic-score helper those
+  two use (not a test module).
 - `test_simple1_split.py` — a **golden-file snapshot** test: it runs the split
   pipeline on `test_files/<name>_input.mscx` and compares the element-tag
   sequence against `<name>_output.mscx`. If you intentionally change pipeline
@@ -121,8 +129,8 @@ python rename_parts.py score.mscx SSAA -o score_renamed.mscx
   `save_system_answers` → headless `run_clean` → rebuilt parts + lyric routing.
 - `test_missing_tuplets.py` — the dropped-tuplet cross-voice auto-fix (mirror
   within/across staves; well-formed and donor-less voices left untouched).
-- `test_revoice.py` / `test_interactive.py` / `test_json_staff_mapping.py` — the
-  re-voicing plan, non-interactive anomaly reduction, and JSON lyric staff mapping.
+- `test_revoice.py` / `test_interactive.py` — the re-voicing plan and the
+  non-interactive anomaly reduction.
 
 ## The song web app (`src/song_app/`)
 
@@ -142,8 +150,8 @@ state model are in `DESIGN.md`.
 - `pipeline.py` is the glue: `convert_to_mscx` (mscx as-is / mscz unzip / xml via
   MuseScore CLI), `run_clean` (calls `main(..., interactive=False)`; per-system runs off
   the answers the **grid form** recorded via `save_system_answers`), and
-  `run_lyric_import` (calls `import_file`, capturing the stderr `Warning:` lines
-  as the syllable-mismatch list). `system_grid` / `save_system_answers` /
+  `run_lyric_import` (calls `import_file` and returns its `LyricImport` — the
+  mismatches come back as records, nothing is scraped from stderr). `system_grid` / `save_system_answers` /
   `has_system_answers` / `system_ranges` are one-liners over the per-system module's
   interface (`layout_for_file`, `save_answers`, `has_answers`, `system_ranges`) —
   the grid is an adapter, not a second implementation.
@@ -213,15 +221,18 @@ state model are in `DESIGN.md`.
   is page-level only** (no bounding boxes) — see DESIGN.md.
 - The Lyrics panel has two client-side modes (remembered in `localStorage`):
   **Paste from AI** keeps the prompt/JSON round-trip, while **Type by system**
-  fetches `/lyric-grid` and renders a textarea for every `(printed system, output
-  part)`. The backend derives part names from `Part/trackName`, skips click/rest
-  parts, gets system ranges via `pipeline.system_ranges`, and prefills cells by
-  exporting the score's current lyrics. The browser turns non-empty cells into
-  name-addressed JSON blocks (`parts: [part name]`, `measure_start: system start`)
-  and submits them through the same `/lyrics` importer. Import warnings are parsed
-  back onto the matching system/part cell; lyric-panel scroll is preserved across
-  the refresh. Blank cells are omitted, so this editor expresses a lyric line
-  starting in a system, not an instruction to clear one isolated cell.
+  fetches `/lyric-grid` (`lyric_txt.editor_grid(...).to_dict()`) and renders a
+  textarea for every `(printed system, output part)` — parts, systems and the
+  prefilled text all come from the lyric module, not from `server.py`. The browser
+  POSTs the raw cells (`{"cells": {system: {part: text}}}`); the server turns them
+  into name-addressed JSON blocks with `blocks_from_cells` (`parts: [part name]`,
+  `measure_start: system start`), writes them to `lyrics.json`, and runs the same
+  importer as the paste mode. Mismatches come back as **fields** (`kind`,
+  `measure_start`, `measure_end`, `staff_ids`, `syllables`, `slots`, `message`) and
+  are attached to the matching system/part cell by comparing those fields — the
+  browser no longer parses warning prose. Lyric-panel scroll is preserved across the
+  refresh. Blank cells are omitted, so this editor expresses a lyric line starting in
+  a system, not an instruction to clear one isolated cell.
 - The clean panel's per-system grid mirrors the backend's answer rules: a blank cell
   inherits the staff's previous answer (shown as a faint placeholder) and `-` marks the
   staff silent from there on, clearing the carry — both cleared and never-named slots are
@@ -349,12 +360,34 @@ lyric-fixing flow (and its `pdf_path` plumbing, `utils/gemini_api.py`,
 it deletes any `Lyrics` elements on the staves it splits but does not author or
 fix lyric text.
 
-## Lyric txt/json format (`src/clean_score/lyric_txt.py`)
+## Lyric placement (`src/clean_score/lyric_txt.py`)
 
-The most intricate module. Round-trips lyrics between `.mscx` and a plain text
-or JSON format, designed so an LLM can fix lyrics against the original score
-(e.g. a PDF pasted into the chat) without breaking syllable alignment. The
-prompt files `lyric_json_prompt.txt` / `lyrics_txt_prompt.txt` drive that.
+The most intricate module, and the single owner of lyric placement: format
+normalization, target routing, chord eligibility, syllable distribution, XML
+placement and the diagnostics that fall out of it. It round-trips lyrics between
+`.mscx` and a plain text or JSON format, designed so an LLM can fix lyrics against
+the original score (e.g. a PDF pasted into the chat) without breaking syllable
+alignment. The prompt files `lyric_json_prompt.txt` / `lyrics_txt_prompt.txt` drive
+that.
+
+Its interface — all three callers (the CLI file adapters, the AI-JSON paste, the
+song app's manual editor) go through these, and nothing else is public:
+
+```python
+export_lyrics(root) -> str                      # the TXT projection of the score
+place_lyrics(root, source, fmt=, replace=, split=) -> LyricImport
+editor_grid(root) -> EditorGrid                 # parts x printed systems, prefilled
+blocks_from_cells(grid, cells) -> [block]       # those cells as lyric JSON
+export_file(...) / import_file(...) -> LyricImport      # the .txt/.json adapters
+```
+
+`source` is TXT, JSON text, or already-parsed JSON blocks (`fmt` overrides the
+sniff). **Diagnostics are returned, never printed**: `LyricImport.mismatches` is a
+list of `Mismatch(kind, message, measure_start, measure_end, staff_ids, syllables,
+slots)` — kinds `too_many` / `too_few` / `no_systems` / `no_system_for_line` /
+`block_count` — plus `filled_measure_starts` for nulls inferred from the printed
+systems. `to_dict()` puts them on the wire for the browser; the CLI wrapper prints
+`Warning: <message>` itself, so terminal output is unchanged.
 
 - **Eligibility**: only voice 0, verse 1. A note gets a syllable token unless it
   is a slur/tie *continuation* (not the first note of the slur/tie) — those get

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -230,7 +230,9 @@ state model are in `DESIGN.md`.
   importer as the paste mode. Mismatches come back as **fields** (`kind`,
   `measure_start`, `measure_end`, `staff_ids`, `syllables`, `slots`, `message`) and
   are attached to the matching system/part cell by comparing those fields — the
-  browser no longer parses warning prose. Lyric-panel scroll is preserved across the
+  browser no longer parses warning prose (a song whose `.song.json` predates this holds
+  the sentence as a string; the panel reads the fields back out of it). Lyric-panel
+  scroll is preserved across the
   refresh. Blank cells are omitted, so this editor expresses a lyric line starting in
   a system, not an instruction to clear one isolated cell.
 - The clean panel's per-system grid mirrors the backend's answer rules: a blank cell
@@ -339,7 +341,7 @@ measure-range, `printed_no -> [output staff ids]`) in addition to an identity
 share a source staff into one printed staff (divisi: voice 0 → 'above', voice 1 →
 'below') and ordering printed staves by **musical rank** (S<A<T<B, then number) — not
 by the OCR's source-staff order, which can be shuffled. `lyric_txt.py` import reads it
-(`read_lyrics_system_map`) and resolves each JSON block via the map for the system
+(`_read_lyrics_system_map`) and resolves each JSON block via the map for the system
 covering its `measure_start`. Tested against `tests/test_files/laulun_aika.mscx` (a
 real converted score kept as a fixture).
 Caveat: the musical-rank ordering is wrong when an ossia/extra voice is *printed on top*
@@ -404,26 +406,26 @@ systems. `to_dict()` puts them on the wire for the browser; the CLI wrapper prin
   PDF-derived format has a `lyrics` array of `{text, staff_number, position,
   verse, parts}`. `staff_number` is the printed staff (top=1); `position` is
   `above`/`below`. These are mapped to **output staff ids** via the
-  `lyricsStaffMap` metaTag that `clean_score` writes (`read_lyrics_staff_map`):
+  `lyricsStaffMap` metaTag that `clean_score` writes (`_read_lyrics_staff_map`):
   a printed staff that split into two voices gets the line on both voices when
   only one position appears *in that block* (unison), or split upper/lower when
   both positions appear (divisi is decided **per block**, not globally). An
   explicit `parts` on a lyric overrides the staff_number/position mapping (manual fix
   for the ~inevitable LLM errors). `parts` accepts output staff **ids** *and/or part
   **names*** (`["T1","T2"]`, also a scalar `part`); names resolve via the score's
-  trackNames (`read_part_name_map`). Names are the robust override — immune to
+  trackNames (`_read_part_name_map`). Names are the robust override — immune to
   printed-staff order (e.g. an ossia T3 printed on top), which staff_number cannot
   handle. The current `lyric_json_prompt.txt` has the LLM emit `"parts": []` (empty)
   in **every** lyric so manual overriding is just dropping ids/names into the existing
   array; empty → auto-map by staff_number/position. (An empty list is falsy, so the
-  `if parts:` check falls through to the staff_number path — same as omitting it.) Legacy numeric/`DEFAULT_PART_TO_STAFF` part keys still work. `--split`
+  `if parts:` check falls through to the staff_number path — same as omitting it.) Legacy numeric/`_DEFAULT_PART_TO_STAFF` part keys still work. `--split`
   duplicates a part into two staves. When a lyric has no `parts`, import falls back to
   staff_number/position: for `--per-system` scores the printed numbering shifts per
-  system, so it uses the per-system `lyricsSystemMap` (`read_lyrics_system_map`) for the
+  system, so it uses the per-system `lyricsSystemMap` (`_read_lyrics_system_map`) for the
   block's `measure_start`, else the single `lyricsStaffMap`. Resolution priority per
   lyric: explicit `parts` (ids/names) → staff_number+position via system/staff map.
   A null `measure_start` (the LLM emits null when no measure number is printed at the
-  start of a line) is auto-filled by `_fill_missing_measure_starts`: blocks are one
+  start of a line) is auto-filled by `_fill_missing_measure_starts` (reported as `filled_measure_starts`): blocks are one
   per printed system in order, so each null block takes the start measure of the
   system at its position (`per_system.system_ranges`); explicit values are left alone, and a
   block-count vs system-count mismatch is warned (so the user verifies alignment).

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -72,7 +72,11 @@ state file *is* the UX; the user never tracks any of this in their head.
     ]
   },
   "lyrics": { "json": "laulun_aika.json", "imported_against": "sha1:…",
-              "warnings": ["m16-19: 11 syllables / 9 slots"] },
+              // one record per mismatch, as fields (older songs hold the sentence
+              // as a plain string; the UI reads the fields back out of it)
+              "warnings": [{ "kind": "too_many", "measure_start": 16, "measure_end": 19,
+                             "staff_ids": [1, 2], "syllables": 11, "slots": 9,
+                             "message": "Measures 16-19 (staffs 1, 2): too many …" }] },
   "record": { "exported": false, "youtube_id": null }
 }
 ```

--- a/lyric_txt.py
+++ b/lyric_txt.py
@@ -92,7 +92,12 @@ def main() -> None:
                 split = [int(x.strip()) for x in args.split.split(",") if x.strip()]
             except ValueError:
                 sys.exit("--split must be comma-separated part numbers (e.g. 3,4)")
-        import_file(txt_path, mscx_in, out, split=split, replace=args.replace)
+        result = import_file(txt_path, mscx_in, out, split=split, replace=args.replace)
+        for mismatch in result.mismatches:
+            print(f"Warning: {mismatch.message}", file=sys.stderr)
+        if result.filled_measure_starts:
+            print(f"Note: auto-filled {len(result.filled_measure_starts)} null measure_start "
+                  f"value(s) from the score's systems.", file=sys.stderr)
         print(f"Imported to {out}")
 
 

--- a/lyric_txt.py
+++ b/lyric_txt.py
@@ -93,9 +93,12 @@ def main() -> None:
             except ValueError:
                 sys.exit("--split must be comma-separated part numbers (e.g. 3,4)")
         result = import_file(txt_path, mscx_in, out, split=split, replace=args.replace)
+        kinds = set()
         for mismatch in result.mismatches:
             print(f"Warning: {mismatch.message}", file=sys.stderr)
-        if result.filled_measure_starts:
+            kinds.add(mismatch.kind)
+        # The block-count warning already says how many were filled; don't say it twice.
+        if result.filled_measure_starts and "block_count" not in kinds:
             print(f"Note: auto-filled {len(result.filled_measure_starts)} null measure_start "
                   f"value(s) from the score's systems.", file=sys.stderr)
         print(f"Imported to {out}")

--- a/src/clean_score/lyric_txt.py
+++ b/src/clean_score/lyric_txt.py
@@ -40,6 +40,8 @@ from typing import Any, Dict, List, Optional, Tuple
 
 from lxml import etree
 
+from .utils.per_system import system_ranges
+
 # --------------------------------------------------------------------------- #
 # What a caller gets back
 # --------------------------------------------------------------------------- #
@@ -86,12 +88,6 @@ class LyricImport:
     def ok(self) -> bool:
         return not self.mismatches
 
-    def to_dict(self) -> Dict[str, Any]:
-        return {
-            "mismatches": [m.to_dict() for m in self.mismatches],
-            "filled_measure_starts": list(self.filled_measure_starts),
-        }
-
 
 @dataclass(frozen=True)
 class EditorPart:
@@ -126,7 +122,7 @@ class EditorGrid:
             "parts": [{"name": p.name, "id": p.id} for p in self.parts],
             "systems": [{"index": s.index, "start": s.start, "end": s.end}
                         for s in self.systems],
-            "prefill": {str(si): dict(cells) for si, cells in self.cells.items()},
+            "cells": {str(si): dict(cells) for si, cells in self.cells.items()},
         }
 
 # Default mapping from JSON part keys (e.g. S1, A2) to staff id. Overridable.
@@ -1189,7 +1185,6 @@ def _fill_missing_measure_starts(
     if not any(b.get("measure_start") is None for b in blocks):
         return json_str, [], []  # nothing to infer
 
-    from .utils.per_system import system_ranges
     starts = [r.start for r in system_ranges(score_root)]
     if not starts:
         return json_str, [Mismatch(
@@ -1329,6 +1324,9 @@ def place_lyrics(
     verse-1 lyric first (a full replace); without it, measures and staves the source
     does not name keep what they have. `split` duplicates a part onto two staves
     (JSON only). Returns the mismatches — nothing is written to stdout or stderr.
+
+    Only the JSON path measures syllables against chords, so a TXT import always
+    reports an empty result (TXT is written per measure, so it cannot drift).
     """
     if fmt is None:
         fmt = "txt" if isinstance(source, str) and not source.lstrip().startswith("[") else "json"
@@ -1352,8 +1350,6 @@ def editor_grid(score_root: etree._Element) -> EditorGrid:
     the score for that part over that system's measures — the same syllable rules the
     TXT export uses, so what the editor shows round-trips back through `place_lyrics`.
     """
-    from .utils.per_system import system_ranges
-
     score = score_root.find(".//Score") if score_root.tag != "Score" else score_root
     parts: List[EditorPart] = []
     for p in score.findall("Part"):

--- a/src/clean_score/lyric_txt.py
+++ b/src/clean_score/lyric_txt.py
@@ -13,19 +13,124 @@ those positions get no token on export and verse 1 lyrics are cleared from them 
 Verse 1 only, voice 0. Rests get no token.
 
 JSON format (line-by-line): array of objects with "measure_start" (int) and part keys (e.g. S1, S2, A1, A2) whose values are lyric lines. Tokens are distributed across measures using the score. Use a .json path with import_file to import this format.
+
+This module owns lyric placement end to end — format normalization, target routing,
+chord eligibility, syllable distribution, XML placement and the diagnostics that come
+out of it — for all three callers: the CLI file adapters, the AI-JSON paste, and the
+song app's manual editor. Its interface:
+
+    export_lyrics(root) -> str                     the TXT projection of the score
+    place_lyrics(root, source, replace=, split=)   put lyrics in; returns LyricImport
+    editor_grid(root) -> EditorGrid                what the manual editor renders
+    blocks_from_cells(grid, cells) -> [block]      that editor's cells as lyric JSON
+    export_file(...) / import_file(...)            the .txt/.json file adapters
+
+Mismatches (a line whose syllables do not fit its chords, a measure_start that could
+not be inferred) come back as `Mismatch` records on the result — measure range, target
+staff ids, kind, counts and a ready-made sentence — so callers never parse text to
+learn what happened.
 """
 
 from __future__ import annotations
 
 import json
 import re
-import sys
+from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional, Tuple
 
 from lxml import etree
 
+# --------------------------------------------------------------------------- #
+# What a caller gets back
+# --------------------------------------------------------------------------- #
+
+TOO_MANY = "too_many"          # more syllables than eligible chords in the range
+TOO_FEW = "too_few"            # fewer syllables than eligible chords
+NO_SYSTEMS = "no_systems"      # null measure_start, but the score has no system breaks
+NO_SYSTEM_FOR_LINE = "no_system_for_line"   # more null lines than printed systems
+BLOCK_COUNT = "block_count"    # lines vs systems disagree, so the fill may be off
+
+
+@dataclass(frozen=True)
+class Mismatch:
+    """One thing the caller should look at, in fields rather than prose."""
+
+    kind: str
+    message: str
+    measure_start: int = 0          # 1-based; 0 when not tied to a measure range
+    measure_end: int = 0            # 1-based inclusive
+    staff_ids: Tuple[int, ...] = ()
+    syllables: int = 0
+    slots: int = 0
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "kind": self.kind,
+            "message": self.message,
+            "measure_start": self.measure_start,
+            "measure_end": self.measure_end,
+            "staff_ids": list(self.staff_ids),
+            "syllables": self.syllables,
+            "slots": self.slots,
+        }
+
+
+@dataclass(frozen=True)
+class LyricImport:
+    """The outcome of placing lyrics: what was placed, and what did not fit."""
+
+    mismatches: List[Mismatch] = field(default_factory=list)
+    filled_measure_starts: List[int] = field(default_factory=list)
+
+    @property
+    def ok(self) -> bool:
+        return not self.mismatches
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "mismatches": [m.to_dict() for m in self.mismatches],
+            "filled_measure_starts": list(self.filled_measure_starts),
+        }
+
+
+@dataclass(frozen=True)
+class EditorPart:
+    """One lyric-bearing output part, as the manual editor lists it."""
+
+    id: int
+    name: str
+
+
+@dataclass(frozen=True)
+class EditorSystem:
+    """One printed system, as 1-based inclusive measure numbers."""
+
+    index: int
+    start: int
+    end: int
+
+
+@dataclass(frozen=True)
+class EditorGrid:
+    """The manual editor's projection: a text cell per (printed system, part)."""
+
+    parts: List[EditorPart] = field(default_factory=list)
+    systems: List[EditorSystem] = field(default_factory=list)
+    cells: Dict[int, Dict[str, str]] = field(default_factory=dict)
+
+    def text(self, system_index: int, part_name: str) -> str:
+        return self.cells.get(system_index, {}).get(part_name, "")
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "parts": [{"name": p.name, "id": p.id} for p in self.parts],
+            "systems": [{"index": s.index, "start": s.start, "end": s.end}
+                        for s in self.systems],
+            "prefill": {str(si): dict(cells) for si, cells in self.cells.items()},
+        }
+
 # Default mapping from JSON part keys (e.g. S1, A2) to staff id. Overridable.
-DEFAULT_PART_TO_STAFF: Dict[str, int] = {"S1": 1, "S2": 2, "A1": 3, "A2": 4}
+_DEFAULT_PART_TO_STAFF: Dict[str, int] = {"S1": 1, "S2": 2, "A1": 3, "A2": 4}
 
 
 # Duration type to ticks (fraction of whole). Division from score multiplies this.
@@ -165,7 +270,7 @@ def _merge_tokens(tokens: List[str]) -> str:
 
 
 def _tokenize_line(line: str) -> List[str]:
-    """Split a line into tokens (space-separated, hyphen-merged). Same logic as parse_txt."""
+    """Split a line into tokens (space-separated, hyphen-merged). Same logic as _parse_txt."""
     tokens: List[str] = []
     for part in line.split():
         part = part.strip()
@@ -224,7 +329,7 @@ def _get_chord_counts_per_measure(score: etree._Element) -> Dict[int, Dict[int, 
     return out
 
 
-def read_lyrics_staff_map(score_root: etree._Element) -> Dict[int, List[int]]:
+def _read_lyrics_staff_map(score_root: etree._Element) -> Dict[int, List[int]]:
     """
     Read the printed-staff -> output-staff map persisted by clean_score in the
     'lyricsStaffMap' metaTag (format "1:1,2;2:3;3:4,5;4:6"). Returns {} if absent.
@@ -254,7 +359,7 @@ def read_lyrics_staff_map(score_root: etree._Element) -> Dict[int, List[int]]:
     return result
 
 
-def read_lyrics_system_map(
+def _read_lyrics_system_map(
     score_root: etree._Element,
 ) -> Optional[List[Dict[str, Any]]]:
     """
@@ -298,7 +403,7 @@ def _map_for_measure(
     return {}
 
 
-def read_part_name_map(score_root: etree._Element) -> Dict[str, int]:
+def _read_part_name_map(score_root: etree._Element) -> Dict[str, int]:
     """
     Map a part NAME (trackName, e.g. "T1", "B") to its output staff id, read from the
     score's Parts. Lets lyric JSON address voices by name — robust to printed-staff
@@ -362,7 +467,7 @@ def _derive_target_staves(
     return list(outs)
 
 
-def convert_lyrics_format_to_legacy(
+def _convert_lyrics_format_to_legacy(
     data: List[Dict[str, Any]],
     staff_map: Optional[Dict[int, List[int]]] = None,
     system_map: Optional[List[Dict[str, Any]]] = None,
@@ -436,7 +541,7 @@ def convert_lyrics_format_to_legacy(
     return result
 
 
-def parse_json_txt(
+def _parse_json_txt(
     json_str: str,
     staff_map: Optional[Dict[int, List[int]]] = None,
     system_map: Optional[List[Dict[str, Any]]] = None,
@@ -455,23 +560,26 @@ def parse_json_txt(
     first = data[0]
     if not isinstance(first, dict) or "measure_start" not in first:
         return []
-    return convert_lyrics_format_to_legacy(
+    return _convert_lyrics_format_to_legacy(
         data, staff_map=staff_map, system_map=system_map, name_map=name_map
     )
 
 
-def json_lines_to_by_measure(
+def _json_lines_to_by_measure(
     json_data: List[Dict[str, Any]],
     chord_counts: Dict[int, Dict[int, int]],
     part_to_staff: Optional[Dict[str, int]] = None,
-) -> Dict[int, Dict[int, List[str]]]:
+) -> Tuple[Dict[int, Dict[int, List[str]]], List[Mismatch]]:
     """
     Convert line-by-line JSON (measure_start + part text per line) into by_measure[measure][staff_id] = tokens.
     Part keys can be "1", "2" (staff id) or names mapped via part_to_staff. Expands each line to syllables,
     distributes by chord count, then converts each measure's chunk back to tokens.
+
+    Returns the by-measure tokens plus one `Mismatch` per (range, kind) whose syllable
+    count did not match the chords available there.
     """
     if part_to_staff is None:
-        part_to_staff = DEFAULT_PART_TO_STAFF
+        part_to_staff = _DEFAULT_PART_TO_STAFF
     by_measure: Dict[int, Dict[int, List[str]]] = {}
     token_mismatches: List[Tuple[int, int, int, str, int, int]] = []  # (m_start, m_end, staff_id, kind, n_syl, slots)
     # Collect part keys from all rows so a part that appears only in later measures (e.g. "4") is not ignored
@@ -539,30 +647,33 @@ def json_lines_to_by_measure(
                 total_slots = sum(counts.get(m, 0) for m in range(m_start, m_end))
                 n_syllables = len(syllables)
                 if n_syllables > total_slots:
-                    token_mismatches.append((m_start, m_end, staff_id, "too_many", n_syllables, total_slots))
+                    token_mismatches.append((m_start, m_end, staff_id, TOO_MANY, n_syllables, total_slots))
                 elif n_syllables < total_slots:
-                    token_mismatches.append((m_start, m_end, staff_id, "too_few", n_syllables, total_slots))
-    # Emit one summary warning per distinct (range, kind) with staffs listed
-    if token_mismatches:
-        key_to_staffs: Dict[Tuple[int, int, str, int, int], List[int]] = {}
-        for m_start, m_end, staff_id, kind, n_syl, slots in token_mismatches:
-            key = (m_start, m_end, kind, n_syl, slots)
-            key_to_staffs.setdefault(key, []).append(staff_id)
-        for (m_start, m_end, kind, n_syl, slots), staff_ids in sorted(key_to_staffs.items()):
-            staffs_str = ", ".join(str(s) for s in sorted(set(staff_ids)))
-            if kind == "too_many":
-                print(
-                    f"Warning: Measures {m_start}-{m_end - 1} (staffs {staffs_str}): too many tokens "
-                    f"({n_syl} syllables, {slots} slots); the extra are kept on the last note — fix the count.",
-                    file=sys.stderr,
-                )
-            else:
-                print(
-                    f"Warning: Measures {m_start}-{m_end - 1} (staffs {staffs_str}): too few tokens "
-                    f"({n_syl} syllables, {slots} slots); some slots will be empty.",
-                    file=sys.stderr,
-                )
-    return by_measure
+                    token_mismatches.append((m_start, m_end, staff_id, TOO_FEW, n_syllables, total_slots))
+    # One record per distinct (range, kind), with every staff it affects listed.
+    key_to_staffs: Dict[Tuple[int, int, str, int, int], List[int]] = {}
+    for m_start, m_end, staff_id, kind, n_syl, slots in token_mismatches:
+        key_to_staffs.setdefault((m_start, m_end, kind, n_syl, slots), []).append(staff_id)
+    mismatches: List[Mismatch] = []
+    for (m_start, m_end, kind, n_syl, slots), staff_ids in sorted(key_to_staffs.items()):
+        ids = tuple(sorted(set(staff_ids)))
+        staffs_str = ", ".join(str(s) for s in ids)
+        if kind == TOO_MANY:
+            message = (
+                f"Measures {m_start}-{m_end - 1} (staffs {staffs_str}): too many tokens "
+                f"({n_syl} syllables, {slots} slots); the extra are kept on the last note — fix the count."
+            )
+        else:
+            message = (
+                f"Measures {m_start}-{m_end - 1} (staffs {staffs_str}): too few tokens "
+                f"({n_syl} syllables, {slots} slots); some slots will be empty."
+            )
+        mismatches.append(Mismatch(
+            kind=kind, message=message,
+            measure_start=m_start, measure_end=m_end - 1,
+            staff_ids=ids, syllables=n_syl, slots=slots,
+        ))
+    return by_measure, mismatches
 
 
 def _iter_voice0_chords(staff: etree._Element, division: int):
@@ -604,14 +715,14 @@ def _iter_voice0_chords(staff: etree._Element, division: int):
                     time_pos += _resolve_duration_ticks(frac_el.text, "0", division)
 
 
-def lyrics_by_measure_staff(score_root: etree._Element) -> Dict[int, Dict[int, List[str]]]:
+def _lyrics_by_measure_staff(score_root: etree._Element) -> Dict[int, Dict[int, List[str]]]:
     """Build by_measure_staff[measure_index][staff_id] = [tokens] from the score.
 
     Tokens are the TXT-format syllable tokens (begin/middle end with '-', '_' for an
     eligible chord with no lyric). Voice 0, verse 1; slur/tie-continuation notes are
     skipped. Shared by the TXT export and the manual-editor prefill.
     """
-    add_rests_to_empty_measures(score_root)
+    _add_rests_to_empty_measures(score_root)
     score = score_root if score_root.tag == "Score" else score_root.find(".//Score")
     if score is None:
         return {}
@@ -655,12 +766,12 @@ def lyrics_by_measure_staff(score_root: etree._Element) -> Dict[int, Dict[int, L
     return by_measure_staff
 
 
-def export_mscx_to_txt(score_root: etree._Element) -> str:
+def export_lyrics(score_root: etree._Element) -> str:
     """
     Export lyrics from a MuseScore score element (root of parsed .mscx) to TXT format.
     Only voice 0, verse 1. Slur-continuation notes get no token.
     """
-    by_measure_staff = lyrics_by_measure_staff(score_root)
+    by_measure_staff = _lyrics_by_measure_staff(score_root)
     lines: List[str] = []
     measure_indices = sorted(by_measure_staff.keys())
     for mi in measure_indices:
@@ -674,7 +785,7 @@ def export_mscx_to_txt(score_root: etree._Element) -> str:
     return "\n".join(lines) if lines else ""
 
 
-def parse_txt(txt: str) -> List[Dict[str, Any]]:
+def _parse_txt(txt: str) -> List[Dict[str, Any]]:
     """
     Parse TXT format into a list of blocks: each has 'measure' (1-based) and 'staff_lines' { staff_id: list of tokens (split, not merged) }.
     """
@@ -896,12 +1007,12 @@ def _clear_all_verse1_lyrics(score_root: etree._Element) -> None:
         _clear_verse1_lyrics(chord)
 
 
-def import_txt_into_mscx(
+def _import_txt_into_mscx(
     score_root: etree._Element,
     txt: Optional[str] = None,
     by_measure: Optional[Dict[int, Dict[int, List[str]]]] = None,
     clear_existing: bool = False,
-) -> None:
+) -> LyricImport:
     """
     Import TXT lyrics into the score (in-place). Verse 1, voice 0. Slur-continuation chords are skipped (no lyric).
     Hyphenated tokens (e.g. il-man) are expanded to begin/end syllables on consecutive chords.
@@ -916,16 +1027,16 @@ def import_txt_into_mscx(
     imported lyrics should fully supersede. When False, measures/staves not in the input keep
     their existing lyrics (partial edit).
     """
-    add_rests_to_empty_measures(score_root)
+    _add_rests_to_empty_measures(score_root)
     score = score_root if score_root.tag == "Score" else score_root.find(".//Score")
     if score is None:
-        return
+        return LyricImport()
     if clear_existing:
         _clear_all_verse1_lyrics(score_root)
     if by_measure is None:
         if txt is None:
-            return
-        blocks = parse_txt(txt)
+            return LyricImport()
+        blocks = _parse_txt(txt)
         by_measure = {b["measure"]: b["staff_lines"] for b in blocks}
 
     staffs = score.findall(".//Staff")
@@ -948,10 +1059,10 @@ def import_txt_into_mscx(
             voice = voices[0]
             voice_children = list(voice)
             # Whether we will place lyrics in this measure (partial JSON may omit measures)
-            place_lyrics = (
+            placing = (
                 one_based in by_measure and staff_id in by_measure[one_based]
             )
-            if place_lyrics:
+            if placing:
                 staff_tokens = by_measure[one_based][staff_id]
                 prev_measure_tokens = (by_measure.get(one_based - 1) or {}).get(staff_id) or []
                 first_syllabic_continuation = _last_token_ends_with_hyphen(prev_measure_tokens)
@@ -965,7 +1076,7 @@ def import_txt_into_mscx(
                 if el.tag != "Chord":
                     continue
                 if _is_continuation_no_lyric(el):
-                    if place_lyrics:
+                    if placing:
                         _clear_verse1_lyrics(el)
                     if _is_slur_continuation(el):
                         slur_active = False
@@ -973,14 +1084,14 @@ def import_txt_into_mscx(
                         tie_active = False
                     continue
                 if slur_active and not _has_slur_start(el) and not _is_slur_continuation(el):
-                    if place_lyrics:
+                    if placing:
                         _clear_verse1_lyrics(el)
                     continue  # middle of slur
                 if tie_active and not _has_tie_start(el) and not _is_tie_continuation(el):
-                    if place_lyrics:
+                    if placing:
                         _clear_verse1_lyrics(el)
                     continue  # middle of tie
-                if not place_lyrics:
+                if not placing:
                     if _has_slur_start(el):
                         slur_active = True
                     if _has_tie_start(el):
@@ -1030,6 +1141,7 @@ def import_txt_into_mscx(
         for chord in score.findall(".//Chord"):
             if _is_continuation_no_lyric(chord):
                 _clear_verse1_lyrics(chord)
+    return LyricImport()
 
 
 def _apply_split_to_by_measure(
@@ -1056,58 +1168,66 @@ def _apply_split_to_by_measure(
     return new_by_measure
 
 
-def _fill_missing_measure_starts(json_str: str, score_root: etree._Element) -> str:
+def _fill_missing_measure_starts(
+    json_str: str, score_root: etree._Element
+) -> Tuple[str, List[Mismatch], List[int]]:
     """Infer null `measure_start` values from the score's printed systems.
 
     The JSON has one block per printed line (system) in order. Blocks whose
     `measure_start` is null (no measure number printed) are assigned the start
     measure of the system at the same position. Explicit values are left alone.
-    Returns the (possibly rewritten) JSON string.
+    Returns the (possibly rewritten) JSON string, any diagnostics, and the measure
+    numbers that were filled in.
     """
     try:
         data = json.loads(json_str)
     except ValueError:
-        return json_str
+        return json_str, [], []
     if not isinstance(data, list):
-        return json_str
+        return json_str, [], []
     blocks = [b for b in data if isinstance(b, dict) and "measure_start" in b]
     if not any(b.get("measure_start") is None for b in blocks):
-        return json_str  # nothing to infer
+        return json_str, [], []  # nothing to infer
 
     from .utils.per_system import system_ranges
     starts = [r.start for r in system_ranges(score_root)]
     if not starts:
-        print("Warning: lyric lines have null measure_start but the score has no "
-              "system breaks to infer from; those lines were skipped.", file=sys.stderr)
-        return json_str
+        return json_str, [Mismatch(
+            kind=NO_SYSTEMS,
+            message="Lyric lines have null measure_start but the score has no system "
+                    "breaks to infer from; those lines were skipped.",
+        )], []
 
-    filled = []
+    notes: List[Mismatch] = []
+    filled: List[int] = []
     for i, block in enumerate(blocks):
         if block.get("measure_start") is None:
             if i < len(starts):
                 block["measure_start"] = starts[i]
                 filled.append(starts[i])
             else:
-                print(f"Warning: lyric line {i + 1} has null measure_start and there "
-                      f"is no system {i + 1} to infer from; it was skipped.", file=sys.stderr)
-    if filled:
-        if len(blocks) != len(starts):
-            print(f"Warning: auto-filled {len(filled)} null measure_start value(s), but the "
-                  f"number of lyric lines ({len(blocks)}) doesn't match the score's systems "
-                  f"({len(starts)}) — verify the alignment.", file=sys.stderr)
-        else:
-            print(f"Note: auto-filled {len(filled)} null measure_start value(s) from the "
-                  f"score's systems.", file=sys.stderr)
-    return json.dumps(data)
+                notes.append(Mismatch(
+                    kind=NO_SYSTEM_FOR_LINE,
+                    message=f"Lyric line {i + 1} has null measure_start and there is no "
+                            f"system {i + 1} to infer from; it was skipped.",
+                ))
+    if filled and len(blocks) != len(starts):
+        notes.append(Mismatch(
+            kind=BLOCK_COUNT,
+            message=f"Auto-filled {len(filled)} null measure_start value(s), but the number "
+                    f"of lyric lines ({len(blocks)}) doesn't match the score's systems "
+                    f"({len(starts)}) — verify the alignment.",
+        ))
+    return json.dumps(data), notes, filled
 
 
-def import_json_txt_into_mscx(
+def _import_json_txt_into_mscx(
     score_root: etree._Element,
-    json_str: str,
+    source: Any,
     part_to_staff: Optional[Dict[str, int]] = None,
     split: Optional[List[int]] = None,
     clear_existing: bool = False,
-) -> None:
+) -> LyricImport:
     """
     Import line-by-line JSON lyrics into the score. JSON format: array of objects with
     'measure_start' (measure number where the line starts) and either part keys whose values are
@@ -1119,28 +1239,32 @@ def import_json_txt_into_mscx(
     If split is given (e.g. [3, 4]), those input parts are each duplicated to two staves:
     part 3 -> staffs 3 and 4, part 4 -> staffs 5 and 6.
     clear_existing: remove all existing verse 1 lyrics first (full replace).
+
+    `source` is the JSON text or the already-parsed blocks (what the manual editor builds).
     """
-    add_rests_to_empty_measures(score_root)
+    _add_rests_to_empty_measures(score_root)
     score = score_root if score_root.tag == "Score" else score_root.find(".//Score")
     if score is None:
-        return
-    staff_map = read_lyrics_staff_map(score_root)
-    system_map = read_lyrics_system_map(score_root)
-    name_map = read_part_name_map(score_root)
-    json_str = _fill_missing_measure_starts(json_str, score_root)
-    json_data = parse_json_txt(
+        return LyricImport()
+    json_str = source if isinstance(source, str) else json.dumps(source)
+    staff_map = _read_lyrics_staff_map(score_root)
+    system_map = _read_lyrics_system_map(score_root)
+    name_map = _read_part_name_map(score_root)
+    json_str, notes, filled = _fill_missing_measure_starts(json_str, score_root)
+    json_data = _parse_json_txt(
         json_str, staff_map=staff_map, system_map=system_map, name_map=name_map
     )
     if not json_data:
-        return
+        return LyricImport(mismatches=notes, filled_measure_starts=filled)
     chord_counts = _get_chord_counts_per_measure(score)
-    by_measure = json_lines_to_by_measure(json_data, chord_counts, part_to_staff)
+    by_measure, mismatches = _json_lines_to_by_measure(json_data, chord_counts, part_to_staff)
     if split:
         by_measure = _apply_split_to_by_measure(by_measure, split)
-    import_txt_into_mscx(score_root, by_measure=by_measure, clear_existing=clear_existing)
+    _import_txt_into_mscx(score_root, by_measure=by_measure, clear_existing=clear_existing)
+    return LyricImport(mismatches=notes + mismatches, filled_measure_starts=filled)
 
 
-def add_rests_to_empty_measures(score_root: etree._Element) -> None:
+def _add_rests_to_empty_measures(score_root: etree._Element) -> None:
     """
     Add a full-measure rest to any voice that has no Chord and no Rest in that measure.
     Modifies the score in place. Uses the measure's time signature (or 4/4 if none).
@@ -1186,13 +1310,108 @@ def add_rests_to_empty_measures(score_root: etree._Element) -> None:
                 measure.append(voice)
 
 
-def load_mscx(path: str) -> etree._Element:
+# --------------------------------------------------------------------------- #
+# The interface: placement, the editor's projection, and the file adapters
+# --------------------------------------------------------------------------- #
+
+def place_lyrics(
+    score_root: etree._Element,
+    source: Any,
+    fmt: Optional[str] = None,
+    replace: bool = False,
+    split: Optional[List[int]] = None,
+    part_to_staff: Optional[Dict[str, int]] = None,
+) -> LyricImport:
+    """Put lyrics into the score, in place, and report what did not fit.
+
+    `source` is TXT, JSON text, or the already-parsed JSON blocks the manual editor
+    builds; `fmt` ("txt"/"json") overrides the format sniff. `replace` clears every
+    verse-1 lyric first (a full replace); without it, measures and staves the source
+    does not name keep what they have. `split` duplicates a part onto two staves
+    (JSON only). Returns the mismatches — nothing is written to stdout or stderr.
+    """
+    if fmt is None:
+        fmt = "txt" if isinstance(source, str) and not source.lstrip().startswith("[") else "json"
+    if fmt == "json":
+        return _import_json_txt_into_mscx(
+            score_root, source, part_to_staff=part_to_staff,
+            split=split, clear_existing=replace,
+        )
+    return _import_txt_into_mscx(score_root, txt=source, clear_existing=replace)
+
+
+# Staves that carry no lyrics: the click/spacer track added for recording.
+_NON_LYRIC_PART_WORDS = ("drum", "click", "rest")
+
+
+def editor_grid(score_root: etree._Element) -> EditorGrid:
+    """The manual editor's projection: one text cell per (printed system, output part).
+
+    Parts come from the score's own track names (click/spacer staves excluded), systems
+    from the printed line breaks, and each cell is prefilled with the lyrics already in
+    the score for that part over that system's measures — the same syllable rules the
+    TXT export uses, so what the editor shows round-trips back through `place_lyrics`.
+    """
+    from .utils.per_system import system_ranges
+
+    score = score_root.find(".//Score") if score_root.tag != "Score" else score_root
+    parts: List[EditorPart] = []
+    for p in score.findall("Part"):
+        st = p.find("Staff")
+        sid = int(st.get("id")) if st is not None and st.get("id") else 0
+        name = (p.findtext("trackName") or p.findtext("Instrument/trackName") or "").strip()
+        if any(w in name.lower() for w in _NON_LYRIC_PART_WORDS):
+            continue
+        parts.append(EditorPart(id=sid, name=name or f"staff {sid}"))
+    parts.sort(key=lambda p: p.id)
+
+    systems = [EditorSystem(index=r.index, start=r.start, end=r.end)
+               for r in system_ranges(score_root)]
+    by_measure = _lyrics_by_measure_staff(score_root)
+    cells: Dict[int, Dict[str, str]] = {}
+    for system in systems:
+        for part in parts:
+            tokens: List[str] = []
+            for mi in range(system.start - 1, system.end):
+                tokens += [t for t in by_measure.get(mi, {}).get(part.id, []) if t != "_"]
+            text = _merge_tokens(tokens).strip()
+            if text:
+                cells.setdefault(system.index, {})[part.name] = text
+    return EditorGrid(parts=parts, systems=systems, cells=cells)
+
+
+def blocks_from_cells(
+    grid: EditorGrid, cells: Dict[Any, Dict[str, str]]
+) -> List[Dict[str, Any]]:
+    """Turn the editor's typed cells into lyric JSON blocks, one per printed system.
+
+    `cells` is {system index: {part name: text}} as typed. Blank cells are left out —
+    this editor expresses a lyric line starting in a system, not an instruction to
+    clear one isolated cell — and each line addresses its part by NAME, which is
+    immune to printed-staff order. The result is the same JSON `place_lyrics` takes
+    from a paste, so both editors go through one path.
+    """
+    blocks: List[Dict[str, Any]] = []
+    for system in grid.systems:
+        typed = cells.get(system.index, cells.get(str(system.index), {})) or {}
+        lyrics = [
+            {"parts": [part.name], "text": typed[part.name].strip()}
+            for part in grid.parts
+            if isinstance(typed.get(part.name), str) and typed[part.name].strip()
+        ]
+        # Cells naming a part the score doesn't have simply never match a grid part.
+        if lyrics:
+            blocks.append({"measure_start": system.start, "lyrics": lyrics})
+    return blocks
+
+
+def _load_mscx(path: str) -> etree._Element:
     """Load .mscx file and return root element."""
     with open(path, "r", encoding="utf-8") as f:
         return etree.fromstring(f.read().encode("utf-8"))
 
 
-def save_mscx(root: etree._Element, path: str) -> None:
+def _save_mscx(root: etree._Element, path: str) -> None:
     """Write score XML to file."""
     with open(path, "wb") as f:
         f.write(etree.tostring(root, encoding="utf-8", xml_declaration=True, pretty_print=True))
@@ -1200,8 +1419,8 @@ def save_mscx(root: etree._Element, path: str) -> None:
 
 def export_file(mscx_path: str, txt_path: str) -> None:
     """Export lyrics from an .mscx file to a .txt file."""
-    root = load_mscx(mscx_path)
-    txt = export_mscx_to_txt(root)
+    root = _load_mscx(mscx_path)
+    txt = export_lyrics(root)
     with open(txt_path, "w", encoding="utf-8") as f:
         f.write(txt)
 
@@ -1212,14 +1431,17 @@ def import_file(
     mscx_path_out: str,
     split: Optional[List[int]] = None,
     replace: bool = False,
-) -> None:
+) -> LyricImport:
     """Import lyrics from .txt or .json into a copy of the .mscx file. split only applies to .json (e.g. [3, 4]).
-    replace=True clears all existing verse 1 lyrics first (full replace)."""
+    replace=True clears all existing verse 1 lyrics first (full replace).
+    Returns the placement result, so a caller can report mismatches without reading logs."""
     with open(txt_path, "r", encoding="utf-8") as f:
         content = f.read()
-    root = load_mscx(mscx_path_in)
-    if txt_path.lower().endswith(".json"):
-        import_json_txt_into_mscx(root, content, split=split, clear_existing=replace)
-    else:
-        import_txt_into_mscx(root, txt=content, clear_existing=replace)
-    save_mscx(root, mscx_path_out)
+    root = _load_mscx(mscx_path_in)
+    result = place_lyrics(
+        root, content,
+        fmt="json" if txt_path.lower().endswith(".json") else "txt",
+        replace=replace, split=split,
+    )
+    _save_mscx(root, mscx_path_out)
+    return result

--- a/src/clean_score/tests/scorebuilder.py
+++ b/src/clean_score/tests/scorebuilder.py
@@ -1,0 +1,56 @@
+"""Small synthetic scores for lyric tests, plus reading the placed lyrics back."""
+
+import json
+
+from lxml import etree
+
+from src.clean_score.lyric_txt import export_lyrics
+
+
+def build_score(staff_ids=(1, 2, 3, 4, 5, 6), measures=2, chords=8, names=None,
+                staff_map=None, system_map=None, line_breaks=()):
+    """A minimal score: one voice per staff, `chords` lyric slots in every measure.
+
+    `line_breaks` are 1-based measure numbers that end a printed system (the unit the
+    lyric JSON is written in).
+    """
+    xml = ["<museScore><Score>"]
+    if staff_map:
+        xml.append(f'<metaTag name="lyricsStaffMap">{staff_map}</metaTag>')
+    if system_map:
+        xml.append('<metaTag name="lyricsSystemMap">'
+                   + json.dumps(system_map, separators=(",", ":")) + "</metaTag>")
+    for sid in staff_ids:
+        name = (names or {}).get(sid, f"P{sid}")
+        xml.append(f'<Part><trackName>{name}</trackName><Staff id="{sid}"/></Part>')
+    for sid in staff_ids:
+        xml.append(f'<Staff id="{sid}">')
+        for m in range(1, measures + 1):
+            xml.append("<Measure><voice>")
+            for _ in range(chords):
+                xml.append("<Chord><durationType>eighth</durationType>"
+                           "<Note><pitch>60</pitch></Note></Chord>")
+            xml.append("</voice>")
+            if m in line_breaks and sid == staff_ids[0]:
+                xml.append("<LayoutBreak><subtype>line</subtype></LayoutBreak>")
+            xml.append("</Measure>")
+        xml.append("</Staff>")
+    xml.append("</Score></museScore>")
+    return etree.fromstring("".join(xml).encode("utf-8"))
+
+
+def placed_lyrics(root):
+    """{staff_id: "the words that ended up there"} — read back out of the score."""
+    out = {}
+    measure = None
+    for line in export_lyrics(root).splitlines():
+        line = line.strip()
+        if line.startswith("# Measure"):
+            measure = int(line.split()[-1])
+        elif line and measure is not None:
+            head, _, tokens = line.partition(":")
+            sid = int(head.split("[")[0].strip())
+            words = " ".join(t for t in tokens.split() if t != "_")
+            if words:
+                out[sid] = (out.get(sid, "") + " " + words).strip()
+    return out

--- a/src/clean_score/tests/test_json_staff_mapping.py
+++ b/src/clean_score/tests/test_json_staff_mapping.py
@@ -1,199 +1,144 @@
 """
-Unit tests for mapping PDF-derived JSON lyrics (staff_number + position) to output
-staff ids via the clean_score 'lyricsStaffMap' metaTag.
+Routing tests: which output staff a PDF-derived lyric line lands on.
+
+The JSON the LLM produces addresses printed staves (`staff_number` + `position`) or
+part names; the score carries the maps that translate those to output staves. These
+drive the real placement interface — build a score, place lyrics, read back where the
+words ended up — rather than the conversion step inside it.
 """
 
-from lxml import etree
+from src.clean_score.lyric_txt import place_lyrics
 
-from src.clean_score.lyric_txt import (
-    convert_lyrics_format_to_legacy,
-    read_lyrics_staff_map,
-    read_lyrics_system_map,
-)
-
+from .scorebuilder import build_score, placed_lyrics
 
 # Laulun aika layout: printed staff 1 -> output 1,2 (divisi); 2 -> 3; 3 -> 4,5 (divisi); 4 -> 6.
-STAFF_MAP = {1: [1, 2], 2: [3], 3: [4, 5], 4: [6]}
+STAFF_MAP = "1:1,2;2:3;3:4,5;4:6"
+
+# Per-system map: printed staff numbering shifts per system as parts are omitted.
+SYSTEM_MAP = [
+    {"start": 1, "end": 6, "map": {"1": [1, 2], "2": [4]}},
+    {"start": 26, "end": 29, "map": {"1": [1], "2": [2], "3": [4]}},
+]
 
 
-def test_read_lyrics_staff_map():
-    score = etree.fromstring(
-        b"<museScore><Score>"
-        b'<metaTag name="composer"/>'
-        b'<metaTag name="lyricsStaffMap">1:1,2;2:3;3:4,5;4:6</metaTag>'
-        b"</Score></museScore>"
-    )
-    assert read_lyrics_staff_map(score) == STAFF_MAP
+def _place(root, lyrics, measure_start=1):
+    place_lyrics(root, [{"measure_start": measure_start, "lyrics": lyrics}], replace=True)
+    return placed_lyrics(root)
 
 
-def test_read_lyrics_staff_map_absent():
-    score = etree.fromstring(b"<museScore><Score/></museScore>")
-    assert read_lyrics_staff_map(score) == {}
-
+# --------------------------------------------------------------------------- #
+# printed staff + position -> output staves
+# --------------------------------------------------------------------------- #
 
 def test_unison_single_position_maps_to_both_divisi_staves():
     """Printed divisi staff with only 'below' in the block -> both output voices (unison)."""
-    data = [
-        {
-            "measure_start": 1,
-            "lyrics": [
-                {"staff_number": 1, "position": "below", "text": "Nyt u-kot"},
-            ],
-        }
-    ]
-    legacy = convert_lyrics_format_to_legacy(data, staff_map=STAFF_MAP)
-    assert legacy == [{"measure_start": 1, "1": "Nyt u-kot", "2": "Nyt u-kot"}]
+    root = build_score(staff_map=STAFF_MAP)
+    placed = _place(root, [{"staff_number": 1, "position": "below", "text": "Nyt u-kot"}])
+    assert placed == {1: "Nyt u-kot", 2: "Nyt u-kot"}
 
 
 def test_true_divisi_both_positions_split_upper_lower():
     """Printed divisi staff with both 'above' and 'below' in the block -> upper/lower split."""
-    data = [
-        {
-            "measure_start": 20,
-            "lyrics": [
-                {"staff_number": 1, "position": "above", "text": "ylä"},
-                {"staff_number": 1, "position": "below", "text": "ala"},
-            ],
-        }
-    ]
-    legacy = convert_lyrics_format_to_legacy(data, staff_map=STAFF_MAP)
-    assert legacy == [{"measure_start": 20, "1": "ylä", "2": "ala"}]
+    root = build_score(staff_map=STAFF_MAP)
+    placed = _place(root, [
+        {"staff_number": 1, "position": "above", "text": "y-lä"},
+        {"staff_number": 1, "position": "below", "text": "a-la"},
+    ])
+    assert placed == {1: "y-lä", 2: "a-la"}
 
 
 def test_divisi_is_per_block_not_global():
     """A staff that splits in one block stays unison in a block that has only one position."""
-    data = [
-        {"measure_start": 1, "lyrics": [{"staff_number": 1, "position": "below", "text": "uni"}]},
-        {
-            "measure_start": 20,
-            "lyrics": [
-                {"staff_number": 1, "position": "above", "text": "hi"},
-                {"staff_number": 1, "position": "below", "text": "lo"},
-            ],
-        },
-    ]
-    legacy = convert_lyrics_format_to_legacy(data, staff_map=STAFF_MAP)
-    # block 1: unison -> both 1 and 2; block 20: split -> 1=hi, 2=lo
-    assert legacy[0] == {"measure_start": 1, "1": "uni", "2": "uni"}
-    assert legacy[1] == {"measure_start": 20, "1": "hi", "2": "lo"}
+    root = build_score(staff_map=STAFF_MAP, measures=4)
+    place_lyrics(root, [
+        {"measure_start": 1, "lyrics": [
+            {"staff_number": 1, "position": "below", "text": "u-ni"}]},
+        {"measure_start": 3, "lyrics": [
+            {"staff_number": 1, "position": "above", "text": "hi"},
+            {"staff_number": 1, "position": "below", "text": "lo"}]},
+    ], replace=True)
+    placed = placed_lyrics(root)
+    # block 1 unison -> both voices; block 2 split -> 1=hi, 2=lo
+    assert placed[1] == "u-ni hi"
+    assert placed[2] == "u-ni lo"
 
 
 def test_single_output_staff():
-    data = [{"measure_start": 1, "lyrics": [{"staff_number": 2, "position": "below", "text": "x"}]}]
-    legacy = convert_lyrics_format_to_legacy(data, staff_map=STAFF_MAP)
-    assert legacy == [{"measure_start": 1, "3": "x"}]
+    root = build_score(staff_map=STAFF_MAP)
+    assert _place(root, [{"staff_number": 2, "position": "below", "text": "x"}]) == {3: "x"}
 
 
-def test_explicit_parts_override_wins():
-    """An explicit parts list overrides the staff_number/position derivation."""
-    data = [
-        {
-            "measure_start": 1,
-            "lyrics": [
-                {"staff_number": 1, "position": "below", "text": "y", "parts": [4, 5]},
-            ],
-        }
-    ]
-    legacy = convert_lyrics_format_to_legacy(data, staff_map=STAFF_MAP)
-    assert legacy == [{"measure_start": 1, "4": "y", "5": "y"}]
+def test_explicit_parts_override_the_positional_map():
+    root = build_score(staff_map=STAFF_MAP)
+    placed = _place(root, [
+        {"staff_number": 1, "position": "below", "text": "y", "parts": [4, 5]}])
+    assert placed == {4: "y", 5: "y"}
 
 
-def test_verse_2_ignored():
-    data = [
-        {
-            "measure_start": 1,
-            "lyrics": [
-                {"staff_number": 2, "position": "below", "text": "v1"},
-                {"staff_number": 2, "position": "below", "text": "v2", "verse": 2},
-            ],
-        }
-    ]
-    legacy = convert_lyrics_format_to_legacy(data, staff_map=STAFF_MAP)
-    assert legacy == [{"measure_start": 1, "3": "v1"}]
+def test_verse_2_is_ignored():
+    root = build_score(staff_map=STAFF_MAP)
+    placed = _place(root, [
+        {"staff_number": 2, "position": "below", "text": "v1"},
+        {"staff_number": 2, "position": "below", "text": "v2", "verse": 2},
+    ])
+    assert placed == {3: "v1"}
 
 
 def test_no_staff_map_falls_back_to_staff_number():
-    """Without a map (unsplit score), staff_number is used as the output staff id directly."""
-    data = [{"measure_start": 1, "lyrics": [{"staff_number": 2, "position": "below", "text": "z"}]}]
-    legacy = convert_lyrics_format_to_legacy(data, staff_map={})
-    assert legacy == [{"measure_start": 1, "2": "z"}]
+    """Without a map (unsplit score), staff_number is the output staff id directly."""
+    root = build_score()  # no lyricsStaffMap metaTag
+    assert _place(root, [{"staff_number": 2, "position": "below", "text": "z"}]) == {2: "z"}
 
 
-# Per-system map: printed staff numbering shifts per system as parts are omitted.
-SYSTEM_MAP = [
-    {"start": 1, "end": 6, "map": {1: [1, 2], 2: [4]}},
-    {"start": 26, "end": 29, "map": {1: [1], 2: [2], 3: [4]}},
-]
+# --------------------------------------------------------------------------- #
+# per-system map: the printed numbering shifts as parts drop out
+# --------------------------------------------------------------------------- #
 
-
-def test_read_lyrics_system_map():
-    score = etree.fromstring(
-        b"<museScore><Score>"
-        b'<metaTag name="lyricsSystemMap">'
-        b'[{"start":1,"end":6,"map":{"1":[1,2],"2":[4]}},'
-        b'{"start":26,"end":29,"map":{"1":[1],"2":[2],"3":[4]}}]'
-        b"</metaTag></Score></museScore>"
-    )
-    assert read_lyrics_system_map(score) == SYSTEM_MAP
-
-
-def test_read_lyrics_system_map_absent():
-    score = etree.fromstring(b"<museScore><Score/></museScore>")
-    assert read_lyrics_system_map(score) is None
-
-
-def test_system_map_routes_block_by_measure_range():
-    """A lyric's block uses the map for the system covering its measure_start."""
-    data = [
+def test_system_map_routes_each_block_by_its_measure_range():
+    root = build_score(staff_ids=(1, 2, 3, 4), measures=30, system_map=SYSTEM_MAP)
+    place_lyrics(root, [
         # m1-6: printed 1 (divisi, unison) -> output 1,2 ; printed 2 -> output 4 (B).
         {"measure_start": 1, "lyrics": [
             {"staff_number": 1, "position": "below", "text": "ten"},
-            {"staff_number": 2, "position": "below", "text": "bass"},
-        ]},
+            {"staff_number": 2, "position": "below", "text": "bass"}]},
         # m26-29: T3 omitted, so printed 3 -> output 4 (B), NOT output 3 (T3).
         {"measure_start": 26, "lyrics": [
-            {"staff_number": 3, "position": "below", "text": "lowvoice"},
-        ]},
-    ]
-    legacy = convert_lyrics_format_to_legacy(data, system_map=SYSTEM_MAP)
-    assert legacy[0] == {"measure_start": 1, "1": "ten", "2": "ten", "4": "bass"}
-    assert legacy[1] == {"measure_start": 26, "4": "lowvoice"}
+            {"staff_number": 3, "position": "below", "text": "low-voice"}]},
+    ], replace=True)
+    placed = placed_lyrics(root)
+    assert placed[1] == "ten" and placed[2] == "ten"
+    assert placed[4] == "bass low-voice"
+    assert 3 not in placed  # T3 sings nothing here
 
 
-# Part-name mapping: address voices by trackName (robust to printed-staff order).
-def _named_score():
-    parts = [("T1", 1), ("T2", 2), ("T3", 3), ("B", 4)]
-    xml = b"<museScore><Score>"
-    for name, sid in parts:
-        xml += (f'<Part><trackName>{name}</trackName><Staff id="{sid}"/></Part>').encode()
-    xml += b"</Score></museScore>"
-    return etree.fromstring(xml)
+# --------------------------------------------------------------------------- #
+# part names: immune to printed order
+# --------------------------------------------------------------------------- #
 
-
-def test_read_part_name_map():
-    from src.clean_score.lyric_txt import read_part_name_map
-    assert read_part_name_map(_named_score()) == {"T1": 1, "T2": 2, "T3": 3, "B": 4}
+NAMES = {1: "T1", 2: "T2", 3: "T3", 4: "B"}
 
 
 def test_parts_by_name_resolve_to_output_staves():
-    name_map = {"T1": 1, "T2": 2, "T3": 3, "B": 4}
-    data = [
-        {"measure_start": 20, "lyrics": [
-            {"parts": ["T3"], "text": "kuol-leet-kin"},
-            {"parts": ["T1", "T2"], "text": "kuol-leet-kin-me"},
-        ]},
-    ]
-    legacy = convert_lyrics_format_to_legacy(data, name_map=name_map)
-    # T3 -> staff 3, T1/T2 -> staves 1 and 2 (no swap, regardless of printed order)
-    assert legacy[0] == {"measure_start": 20, "1": "kuol-leet-kin-me",
-                         "2": "kuol-leet-kin-me", "3": "kuol-leet-kin"}
+    root = build_score(staff_ids=(1, 2, 3, 4), names=NAMES)
+    placed = _place(root, [
+        {"parts": ["T3"], "text": "kuol-leet-kin"},
+        {"parts": ["T1", "T2"], "text": "kuol-leet-kin-me"},
+    ])
+    assert placed == {1: "kuol-leet-kin-me", 2: "kuol-leet-kin-me", 3: "kuol-leet-kin"}
 
 
-def test_parts_mixes_names_and_ids_and_singular_part():
-    name_map = {"T1": 1, "B": 4}
-    data = [{"measure_start": 1, "lyrics": [
+def test_parts_mixes_names_and_ids_and_a_singular_part():
+    root = build_score(staff_ids=(1, 2, 3, 4), names=NAMES)
+    placed = _place(root, [
         {"part": "B", "text": "bass"},
         {"parts": ["T1", 4], "text": "both"},
-    ]}]
-    legacy = convert_lyrics_format_to_legacy(data, name_map=name_map)
-    assert legacy[0] == {"measure_start": 1, "1": "both", "4": "bass both"}
+    ])
+    assert placed[1] == "both"
+    assert placed[4] == "bass both"
+
+
+def test_names_win_over_a_printed_map_that_disagrees():
+    """An ossia printed on top breaks staff_number order; names bypass it."""
+    root = build_score(staff_ids=(1, 2, 3, 4), names=NAMES, staff_map="1:3;2:1;3:2;4:4")
+    placed = _place(root, [{"parts": ["T3"], "staff_number": 2, "text": "mine"}])
+    assert placed == {3: "mine"}

--- a/src/clean_score/tests/test_lyric_diagnostics.py
+++ b/src/clean_score/tests/test_lyric_diagnostics.py
@@ -1,0 +1,157 @@
+"""
+What comes back from placing lyrics: structured mismatches, and the manual editor's
+projection round-tripping through the same interface.
+
+These are the two things a caller used to have to recover from printed text.
+"""
+
+from src.clean_score.lyric_txt import (
+    BLOCK_COUNT,
+    NO_SYSTEMS,
+    TOO_FEW,
+    TOO_MANY,
+    blocks_from_cells,
+    editor_grid,
+    place_lyrics,
+)
+
+from .scorebuilder import build_score, placed_lyrics
+
+
+def _line(text, measure_start=1, parts=("P1",)):
+    return [{"measure_start": measure_start,
+             "lyrics": [{"parts": list(parts), "text": text}]}]
+
+
+# --------------------------------------------------------------------------- #
+# Mismatches, in fields
+# --------------------------------------------------------------------------- #
+
+def test_a_line_that_fits_reports_nothing():
+    root = build_score(staff_ids=(1,), measures=1, chords=3)
+    result = place_lyrics(root, _line("yk-si kak"), replace=True)
+    assert result.ok and result.mismatches == []
+
+
+def test_too_few_syllables_reports_the_range_staff_and_counts():
+    root = build_score(staff_ids=(1,), measures=1, chords=8)
+    result = place_lyrics(root, _line("yk-si"), replace=True)
+    assert len(result.mismatches) == 1
+    m = result.mismatches[0]
+    assert m.kind == TOO_FEW
+    assert (m.measure_start, m.measure_end) == (1, 1)
+    assert m.staff_ids == (1,)
+    assert (m.syllables, m.slots) == (2, 8)
+    assert "too few tokens" in m.message and not result.ok
+
+
+def test_too_many_syllables_reports_counts_and_keeps_the_overflow():
+    root = build_score(staff_ids=(1,), measures=1, chords=2)
+    result = place_lyrics(root, _line("yk-si kak-si kol-me"), replace=True)
+    m = result.mismatches[0]
+    assert m.kind == TOO_MANY
+    assert (m.syllables, m.slots) == (6, 2)
+    assert "too many tokens" in m.message
+    # Overflow stays visible in the score instead of being dropped.
+    assert "kol" in placed_lyrics(root)[1]
+
+
+def test_one_mismatch_lists_every_staff_it_affects():
+    """Staves that share a range and counts are reported once, together."""
+    root = build_score(staff_ids=(1, 2), measures=1, chords=8, names={1: "P1", 2: "P2"})
+    result = place_lyrics(root, _line("yk-si", parts=("P1", "P2")), replace=True)
+    assert len(result.mismatches) == 1
+    assert result.mismatches[0].staff_ids == (1, 2)
+
+
+def test_mismatch_survives_serialization_for_the_browser():
+    root = build_score(staff_ids=(1,), measures=1, chords=8)
+    d = place_lyrics(root, _line("yk-si"), replace=True).mismatches[0].to_dict()
+    assert d == {
+        "kind": TOO_FEW, "message": d["message"], "measure_start": 1, "measure_end": 1,
+        "staff_ids": [1], "syllables": 2, "slots": 8,
+    }
+
+
+# --------------------------------------------------------------------------- #
+# Inferring a missing measure_start from the printed systems
+# --------------------------------------------------------------------------- #
+
+def test_null_measure_start_is_filled_from_the_systems():
+    root = build_score(staff_ids=(1,), measures=4, chords=3, line_breaks=(2,))
+    blocks = [
+        {"measure_start": None, "lyrics": [{"parts": ["P1"], "text": "en-sim mäi"}]},
+        {"measure_start": None, "lyrics": [{"parts": ["P1"], "text": "toi-nen ri"}]},
+    ]
+    result = place_lyrics(root, blocks, replace=True)
+    assert result.filled_measure_starts == [1, 3]  # the two systems start at m1 and m3
+    placed = placed_lyrics(root)
+    assert "en-sim" in placed[1] and "toi-nen" in placed[1]
+
+
+def test_a_score_without_line_breaks_is_one_system():
+    """No breaks means the whole score is a single printed system, so the fill still works."""
+    root = build_score(staff_ids=(1,), measures=2, chords=3)
+    result = place_lyrics(
+        root, [{"measure_start": None, "lyrics": [{"parts": ["P1"], "text": "yk-si kak"}]}],
+        replace=True,
+    )
+    assert result.filled_measure_starts == [1]
+    assert NO_SYSTEMS not in [m.kind for m in result.mismatches]
+    assert "yk-si" in placed_lyrics(root)[1]
+
+
+def test_nothing_to_infer_from_is_reported_rather_than_guessed():
+    root = build_score(staff_ids=(1,), measures=0)  # no measures at all
+    result = place_lyrics(
+        root, [{"measure_start": None, "lyrics": [{"parts": ["P1"], "text": "yk-si"}]}],
+        replace=True,
+    )
+    assert [m.kind for m in result.mismatches] == [NO_SYSTEMS]
+    assert result.filled_measure_starts == []
+
+
+def test_line_count_not_matching_system_count_is_flagged():
+    root = build_score(staff_ids=(1,), measures=4, chords=3, line_breaks=(2,))  # 2 systems
+    blocks = [{"measure_start": None, "lyrics": [{"parts": ["P1"], "text": "yk-si"}]}]
+    result = place_lyrics(root, blocks, replace=True)  # only 1 line for 2 systems
+    assert BLOCK_COUNT in [m.kind for m in result.mismatches]
+
+
+# --------------------------------------------------------------------------- #
+# The manual editor's projection
+# --------------------------------------------------------------------------- #
+
+def test_editor_grid_lists_parts_and_systems_and_skips_the_click_staff():
+    root = build_score(staff_ids=(1, 2, 3), measures=4, chords=3,
+                       names={1: "S", 2: "A", 3: "Click"}, line_breaks=(2,))
+    grid = editor_grid(root)
+    assert [p.name for p in grid.parts] == ["S", "A"]  # the click staff carries no lyrics
+    assert [(s.index, s.start, s.end) for s in grid.systems] == [(0, 1, 2), (1, 3, 4)]
+    assert grid.cells == {}  # nothing typed yet
+
+
+def test_editor_cells_round_trip_through_import_and_back():
+    """What the editor shows must come back unchanged after it is imported."""
+    root = build_score(staff_ids=(1, 2), measures=4, chords=3,
+                       names={1: "S", 2: "A"}, line_breaks=(2,))
+    typed = {0: {"S": "en-sim mäi", "A": "al-to yk"}, 1: {"S": "toi-nen ri"}}
+
+    grid = editor_grid(root)
+    blocks = blocks_from_cells(grid, typed)
+    assert blocks == [
+        {"measure_start": 1, "lyrics": [{"parts": ["S"], "text": "en-sim mäi"},
+                                        {"parts": ["A"], "text": "al-to yk"}]},
+        {"measure_start": 3, "lyrics": [{"parts": ["S"], "text": "toi-nen ri"}]},
+    ]
+    place_lyrics(root, blocks, replace=True)
+    assert editor_grid(root).cells == typed
+
+
+def test_blank_editor_cells_are_left_out_rather_than_clearing_a_part():
+    root = build_score(staff_ids=(1, 2), measures=2, chords=3, names={1: "S", 2: "A"})
+    grid = editor_grid(root)
+    assert blocks_from_cells(grid, {0: {"S": "  ", "A": ""}}) == []
+    assert blocks_from_cells(grid, {"0": {"S": "yk-si kak"}}) == [
+        {"measure_start": 1, "lyrics": [{"parts": ["S"], "text": "yk-si kak"}]}
+    ]

--- a/src/clean_score/tests/test_lyric_txt_spanner.py
+++ b/src/clean_score/tests/test_lyric_txt_spanner.py
@@ -78,8 +78,8 @@ def test_export_spanner_matches_result_file():
 
 
 def test_new_json_routes_each_printed_line_to_its_output_staves():
-    """new_json.json's (staff_number, position) lines must land on the staves the
-    converted fixture names — asserted through import + export, not the converter."""
+    """Every line of new_json.json must land, in full, on the staves that
+    new_json_converted.json names — asserted through import + export, not the converter."""
     with open(NEW_JSON, "r", encoding="utf-8") as f:
         new_content = f.read()
     with open(NEW_JSON_CONVERTED, "r", encoding="utf-8") as f:
@@ -89,8 +89,13 @@ def test_new_json_routes_each_printed_line_to_its_output_staves():
     place_lyrics(root, new_content, replace=True)
     by_measure = _staff_lines(export_lyrics(root))
 
-    # Each line the conversion fixture names must land on that staff, inside the block's
-    # measure range (a line starts at the first measure of the range that has chords).
+    # Every line the conversion fixture names must land on that staff, in full and in
+    # order. Compared as the bare syllable sequence: the TXT export re-hyphenates at
+    # barlines (a word split across a measure exports as "o-li- si"), which is a
+    # formatting detail of the export, not of the routing this test is about.
+    def syllables(text):
+        return "".join(str(text).split()).replace("-", "")
+
     starts = [b["measure_start"] for b in expected_blocks]
     checked = 0
     for i, block in enumerate(expected_blocks):
@@ -102,12 +107,13 @@ def test_new_json_routes_each_printed_line_to_its_output_staves():
             placed = " ".join(
                 by_measure.get(m, {}).get(int(key), "") for m in range(first_m, last_m + 1)
             )
-            head = str(text).split()[0].split("-")[0]
-            assert head in placed, (
-                f"Measures {first_m}-{last_m} staff {key} should carry {text!r}; got {placed!r}"
+            placed = " ".join(t for t in placed.split() if t != "_")
+            assert syllables(placed) == syllables(text), (
+                f"Measures {first_m}-{last_m} staff {key} should carry exactly {text!r}; "
+                f"got {placed!r}"
             )
             checked += 1
-    assert checked, "fixture should name at least one (measure, staff) line"
+    assert checked == 15, f"fixture should pin 15 (block, staff) lines, compared {checked}"
 
 
 def _mscx_has_end_man_followed_by_begin_vi(root: etree._Element) -> bool:

--- a/src/clean_score/tests/test_lyric_txt_spanner.py
+++ b/src/clean_score/tests/test_lyric_txt_spanner.py
@@ -11,20 +11,38 @@ import tempfile
 import pytest
 from lxml import etree
 
-from src.clean_score.lyric_txt import (
-    add_rests_to_empty_measures,
-    export_mscx_to_txt,
-    import_json_txt_into_mscx,
-    import_txt_into_mscx,
-    load_mscx,
-    parse_json_txt,
-    parse_txt,
-    save_mscx,
-)
-from src.clean_score.lyric_txt import (
-    _is_continuation_no_lyric,  # for test_cross_measure_*
-    _merge_tokens,
-)
+from src.clean_score.lyric_txt import export_lyrics, place_lyrics
+
+
+def _load(path):
+    """Parse a score the way a caller does; the module's own file I/O is internal."""
+    return etree.parse(path).getroot()
+
+
+def _is_continuation(chord):
+    """A chord under a slur/tie but not its first note — the format gives it no token.
+
+    Spelled out here rather than imported, so the test pins the documented rule
+    instead of whatever the module currently does.
+    """
+    return any(
+        spanner.find(".//prev") is not None
+        for kind in ("Slur", "Tie")
+        for spanner in chord.findall(".//Spanner[@type='%s']" % kind)
+    )
+
+
+def _staff_lines(txt):
+    """The TXT export read back as {measure: {staff_id: "merged tokens"}}."""
+    out, measure = {}, None
+    for line in txt.strip().splitlines():
+        line = line.strip()
+        if line.startswith("# Measure"):
+            measure = int(line.split()[-1])
+        elif line and measure is not None:
+            head, _, tokens = line.partition(":")
+            out.setdefault(measure, {})[int(head.split("[")[0].strip())] = tokens.strip()
+    return out
 
 
 CURRENT_DIR = os.path.dirname(os.path.abspath(__file__))
@@ -54,21 +72,42 @@ def test_export_spanner_matches_result_file():
     """spanner.mscx must export exactly to spanner_result.txt."""
     with open(SPANNER_RESULT_TXT, "r", encoding="utf-8") as f:
         expected = f.read().strip()
-    root = load_mscx(SPANNER_MSCX)
-    txt = export_mscx_to_txt(root).strip()
+    root = _load(SPANNER_MSCX)
+    txt = export_lyrics(root).strip()
     assert txt == expected, f"Export must match {SPANNER_RESULT_TXT}. Got:\n{txt}"
 
 
-def test_new_json_converts_to_legacy_format():
-    """new_json.json (measure_start + lyrics with parts) must convert to new_json_converted.json (measure_start + part keys)."""
+def test_new_json_routes_each_printed_line_to_its_output_staves():
+    """new_json.json's (staff_number, position) lines must land on the staves the
+    converted fixture names — asserted through import + export, not the converter."""
     with open(NEW_JSON, "r", encoding="utf-8") as f:
         new_content = f.read()
     with open(NEW_JSON_CONVERTED, "r", encoding="utf-8") as f:
-        expected = json.load(f)
-    converted = parse_json_txt(new_content)
-    assert converted == expected, (
-        f"Conversion of new_json.json must match new_json_converted.json. Got: {converted}"
-    )
+        expected_blocks = json.load(f)
+
+    root = _load(NEW_JSON_MSCX)
+    place_lyrics(root, new_content, replace=True)
+    by_measure = _staff_lines(export_lyrics(root))
+
+    # Each line the conversion fixture names must land on that staff, inside the block's
+    # measure range (a line starts at the first measure of the range that has chords).
+    starts = [b["measure_start"] for b in expected_blocks]
+    checked = 0
+    for i, block in enumerate(expected_blocks):
+        first_m = block["measure_start"]
+        last_m = (starts[i + 1] - 1) if i + 1 < len(starts) else max(by_measure)
+        for key, text in block.items():
+            if key == "measure_start" or not str(text).strip():
+                continue
+            placed = " ".join(
+                by_measure.get(m, {}).get(int(key), "") for m in range(first_m, last_m + 1)
+            )
+            head = str(text).split()[0].split("-")[0]
+            assert head in placed, (
+                f"Measures {first_m}-{last_m} staff {key} should carry {text!r}; got {placed!r}"
+            )
+            checked += 1
+    assert checked, "fixture should name at least one (measure, staff) line"
 
 
 def _mscx_has_end_man_followed_by_begin_vi(root: etree._Element) -> bool:
@@ -134,9 +173,9 @@ def test_new_json_import_export_measure_14_matches_expected():
     )
     expected_m14 = "\n".join(expected_lines[m14_start:m14_end])
 
-    root = load_mscx(NEW_JSON_MSCX)
-    import_json_txt_into_mscx(root, json_content)
-    txt = export_mscx_to_txt(root)
+    root = _load(NEW_JSON_MSCX)
+    place_lyrics(root, json_content)
+    txt = export_lyrics(root)
     got_lines = txt.strip().splitlines()
     got_start = next((i for i, ln in enumerate(got_lines) if ln.strip() == "# Measure 14"), None)
     assert got_start is not None, f"Export should contain '# Measure 14'. Got export (first 30 lines):\n" + "\n".join(got_lines[:30])
@@ -161,27 +200,25 @@ def test_new_json_import_measure_14_not_wrong_syllables():
     """
     with open(NEW_JSON, "r", encoding="utf-8") as f:
         json_content = f.read()
-    root = load_mscx(NEW_JSON_MSCX)
-    import_json_txt_into_mscx(root, json_content)
+    root = _load(NEW_JSON_MSCX)
+    place_lyrics(root, json_content)
     # Must not have (end, man) followed by (begin, vi) in the XML
     assert not _mscx_has_end_man_followed_by_begin_vi(root), (
         "Score must not contain Lyrics (end, man) followed by Lyrics (begin, vi) (distribution bug)."
     )
-    txt = export_mscx_to_txt(root)
-    blocks = parse_txt(txt)
-    by_measure = {b["measure"]: b["staff_lines"] for b in blocks}
+    by_measure = _staff_lines(export_lyrics(root))
     # Measure 14 must not show the wrong chunk 'il-man-vi-' (syllables from wrong offset)
     wrong_m14 = "il-man-vi-"
     for staff_id in (1, 2, 3):
-        if 14 in by_measure and staff_id in by_measure[14]:
-            merged = _merge_tokens(by_measure[14][staff_id])
+        merged = by_measure.get(14, {}).get(staff_id)
+        if merged is not None:
             assert merged != wrong_m14, (
                 f"Measure 14 staff {staff_id} must not be '{wrong_m14}' (distribution bug). Got: {merged!r}"
             )
     # Measure 15 must have 'öt-tä.' (or export form 'öt tä.') for staff 1
     assert 15 in by_measure, "Export should have measure 15"
     assert 1 in by_measure[15], "Export should have staff 1 in measure 15"
-    merged_15 = _merge_tokens(by_measure[15][1])
+    merged_15 = by_measure[15][1]
     assert "öt" in merged_15 and "tä" in merged_15, (
         f"Measure 15 staff 1 should contain öt-tä. Got: {merged_15!r}"
     )
@@ -193,9 +230,9 @@ def test_spanner_json_import_matches_original_export():
         expected = f.read().strip()
     with open(SPANNER_JSON, "r", encoding="utf-8") as f:
         json_content = f.read()
-    root = load_mscx(SPANNER_MSCX)
-    import_json_txt_into_mscx(root, json_content)
-    txt = export_mscx_to_txt(root).strip()
+    root = _load(SPANNER_MSCX)
+    place_lyrics(root, json_content)
+    txt = export_lyrics(root).strip()
     assert txt == expected, f"Import spanner.json then export must match {SPANNER_RESULT_TXT}. Got:\n{txt}"
 
 
@@ -203,9 +240,9 @@ def test_spanner_partial_json_only_edits_from_first_measure():
     """Partial JSON (measure_start=2 only): measure 1 must be unchanged, only measure 2 updated."""
     with open(SPANNER_PARTIAL_JSON, "r", encoding="utf-8") as f:
         json_content = f.read()
-    root = load_mscx(SPANNER_MSCX)
-    import_json_txt_into_mscx(root, json_content)
-    txt = export_mscx_to_txt(root)
+    root = _load(SPANNER_MSCX)
+    place_lyrics(root, json_content)
+    txt = export_lyrics(root)
     lines = [ln.strip() for ln in txt.strip().splitlines()]
     assert "# Measure 1" in lines and "# Measure 2" in lines
     m1_line = m2_line = None
@@ -221,8 +258,8 @@ def test_spanner_partial_json_only_edits_from_first_measure():
 
 
 def test_export_spanner_has_measure1_and_expected_line():
-    root = load_mscx(SPANNER_MSCX)
-    txt = export_mscx_to_txt(root)
+    root = _load(SPANNER_MSCX)
+    txt = export_lyrics(root)
     lines = [ln.strip() for ln in txt.strip().splitlines()]
     assert "# Measure 1" in lines, f"Expected '# Measure 1' in export. Got:\n{txt}"
     assert "# Measure 2" in lines, f"Expected '# Measure 2' in export. Got:\n{txt}"
@@ -231,24 +268,24 @@ def test_export_spanner_has_measure1_and_expected_line():
     assert len(data_lines) >= 3, f"Expected at least 3 staff lines. Got:\n{txt}"
     for i, line in enumerate(data_lines):
         assert re.match(r"^1\s*\[\d+\]\s*:", line), f"Staff line format. Got: {line}"
-    blocks = parse_txt(txt)
-    assert len(blocks) >= 3 and blocks[0]["measure"] == 1 and blocks[1]["measure"] == 2 and blocks[2]["measure"] == 3
+    by_measure = _staff_lines(txt)
+    assert sorted(by_measure)[:3] == [1, 2, 3]
 
 
 def test_import_roundtrip_ineligible_cleared():
     """Export -> import: verse 1 lyrics on ineligible chords (inside spanner) are cleared."""
-    root_orig = load_mscx(SPANNER_MSCX)
-    txt = export_mscx_to_txt(root_orig)
+    root_orig = _load(SPANNER_MSCX)
+    txt = export_lyrics(root_orig)
     assert "# Measure 1" in txt and "# Measure 2" in txt
 
-    root_copy = load_mscx(SPANNER_MSCX)
-    import_txt_into_mscx(root_copy, txt)
+    root_copy = _load(SPANNER_MSCX)
+    place_lyrics(root_copy, txt)
 
     # No chord that is inside spanner (continuation) may have verse 1 lyrics after import
     score = root_copy if root_copy.tag == "Score" else root_copy.find(".//Score")
     assert score is not None
     for chord in score.findall(".//Chord"):
-        if not _is_continuation_no_lyric(chord):
+        if not _is_continuation(chord):
             continue
         for lyrics in chord.findall(".//Lyrics"):
             no_el = lyrics.find("no")
@@ -260,9 +297,9 @@ def test_import_roundtrip_ineligible_cleared():
 
 def test_roundtrip_no_hups_in_result():
     """Export spanner.mscx -> TXT -> import into copy; result must contain no lyric text 'hups'."""
-    txt = export_mscx_to_txt(load_mscx(SPANNER_MSCX))
-    root = load_mscx(SPANNER_MSCX)
-    import_txt_into_mscx(root, txt)
+    txt = export_lyrics(_load(SPANNER_MSCX))
+    root = _load(SPANNER_MSCX)
+    place_lyrics(root, txt)
     score = root if root.tag == "Score" else root.find(".//Score")
     assert score is not None
     for lyrics in score.findall(".//Lyrics"):
@@ -277,8 +314,8 @@ def test_cross_measure_syllabic_continuation():
     of measure N+1 must be imported as syllabic 'end' (e.g. 'lu').
     """
     txt = f"# Measure 1\n1: {EXPECTED_TXT_1}\n# Measure 2\n1: {EXPECTED_TXT_2}\n# Measure 3\n1: {EXPECTED_TXT_3}"
-    root = load_mscx(SPANNER_MSCX)
-    import_txt_into_mscx(root, txt)
+    root = _load(SPANNER_MSCX)
+    place_lyrics(root, txt)
     score = root if root.tag == "Score" else root.find(".//Score")
     assert score is not None
     # Measures are under Score > Staff (the one that has Measure children), not under Part > Staff
@@ -293,7 +330,7 @@ def test_cross_measure_syllabic_continuation():
     for el in voice:
         if el.tag != "Chord":
             continue
-        if _is_continuation_no_lyric(el):
+        if _is_continuation(el):
             continue
         first_lyric_chord = el
         break
@@ -310,18 +347,12 @@ def test_cross_measure_syllabic_continuation():
     assert text == "lu", f"Expected text 'lu', got {text!r}"
 
 
-def test_parse_txt():
-    blocks = parse_txt("# Measure 1\n1: il-man kuu-ta ja")
-    assert len(blocks) == 1
-    assert blocks[0]["measure"] == 1
-    assert blocks[0]["staff_lines"][1] == ["il-man", "kuu-ta", "ja"]
-
-
-def test_parse_txt_accepts_syllable_count():
-    """Optional [syllable_count] is stripped; tokens are unchanged."""
-    blocks = parse_txt("# Measure 1\n1 [3]: il-man kuu-ta ja")
-    assert len(blocks) == 1
-    assert blocks[0]["staff_lines"][1] == ["il-man", "kuu-ta", "ja"]
+def test_txt_tokens_place_one_syllable_per_eligible_chord():
+    """Hyphenated tokens expand across chords; the optional [count] header is ignored."""
+    for header in ("1:", "1 [3]:"):
+        root = _load(SPANNER_MSCX)
+        place_lyrics(root, f"# Measure 1\n{header} il-man kuu-ta ja", replace=True)
+        assert _staff_lines(export_lyrics(root))[1][1].startswith("il-man kuu-ta ja")
 
 
 # --- multimeasure.mscx (4 staves, 3 measures, cross-measure his-to-ri- / aan!) ---
@@ -329,8 +360,8 @@ def test_parse_txt_accepts_syllable_count():
 
 def test_export_multimeasure_has_expected_structure():
     """Export multimeasure.mscx and assert measure 1 ends with his-to-ri-, measure 2 has aan!."""
-    root = load_mscx(MULTIMEASURE_MSCX)
-    txt = export_mscx_to_txt(root)
+    root = _load(MULTIMEASURE_MSCX)
+    txt = export_lyrics(root)
     lines = [ln.rstrip() for ln in txt.strip().splitlines()]
     assert "# Measure 1" in lines and "# Measure 2" in lines and "# Measure 3" in lines
     # Format: staffNum [syllable_count]: tokens. Staff 1,2,4 have his-to-ri- in M1; staff 3 has _ to-ri-
@@ -350,10 +381,10 @@ def test_multimeasure_cross_measure_syllabic_continuation():
     multimeasure.mscx: measure 1 ends with 'his-to-ri-' (last syllable must be begin/middle, not end);
     first syllable of measure 2 must be 'end' ('aan!') so the word continues across the bar.
     """
-    root = load_mscx(MULTIMEASURE_MSCX)
-    txt = export_mscx_to_txt(root)
-    root2 = load_mscx(MULTIMEASURE_MSCX)
-    import_txt_into_mscx(root2, txt)
+    root = _load(MULTIMEASURE_MSCX)
+    txt = export_lyrics(root)
+    root2 = _load(MULTIMEASURE_MSCX)
+    place_lyrics(root2, txt)
     score = root2 if root2.tag == "Score" else root2.find(".//Score")
     assert score is not None
     measures = score.findall(".//Measure")
@@ -367,7 +398,7 @@ def test_multimeasure_cross_measure_syllabic_continuation():
     for el in voices1[0]:
         if el.tag != "Chord":
             continue
-        if _is_continuation_no_lyric(el):
+        if _is_continuation(el):
             continue
         if el.find(".//Lyrics") is not None:
             last_lyric_chord_m1 = el
@@ -388,7 +419,7 @@ def test_multimeasure_cross_measure_syllabic_continuation():
     for el in voice:
         if el.tag != "Chord":
             continue
-        if _is_continuation_no_lyric(el):
+        if _is_continuation(el):
             continue
         first_lyric_chord = el
         break
@@ -408,9 +439,9 @@ def test_multimeasure_cross_measure_syllabic_continuation():
 def test_add_rests_to_empty_measure_multimeasure():
     """
     multimeasure.mscx has one measure with no voice (fully empty).
-    add_rests_to_empty_measures must add a voice with a full-measure rest so export/import work.
+    Export/import must give it a voice with a full-measure rest so the measure has a slot.
     """
-    root = load_mscx(MULTIMEASURE_MSCX)
+    root = _load(MULTIMEASURE_MSCX)
     score = root if root.tag == "Score" else root.find(".//Score")
     assert score is not None
     empty_measure = None
@@ -423,7 +454,7 @@ def test_add_rests_to_empty_measure_multimeasure():
             break
     assert empty_measure is not None, "multimeasure.mscx must contain one measure with no voice"
 
-    add_rests_to_empty_measures(root)
+    export_lyrics(root)  # placing/exporting fills empty measures so they have a slot
 
     voices = empty_measure.findall("voice")
     assert len(voices) == 1, "Empty measure must get exactly one voice"

--- a/src/song_app/pipeline.py
+++ b/src/song_app/pipeline.py
@@ -16,6 +16,7 @@ from typing import Callable, Dict, List, Optional, Tuple
 from lxml import etree
 
 from src.clean_score.main import main as clean_main
+from src.clean_score import lyric_txt
 from src.clean_score.lyric_txt import LyricImport, import_file
 from src.clean_score.utils import per_system
 
@@ -204,6 +205,17 @@ def render_score_pdf(mscx_path: str) -> str:
             + (result.stderr or result.stdout or "")
         )
     return out
+
+
+def lyric_grid(mscx_path: str) -> Dict:
+    """The manual editor's projection of a score: parts x printed systems, prefilled."""
+    return lyric_txt.editor_grid(etree.parse(mscx_path).getroot()).to_dict()
+
+
+def lyric_blocks(mscx_path: str, cells: Dict) -> List[Dict]:
+    """The editor's typed cells as lyric JSON blocks, addressed by part name."""
+    grid = lyric_txt.editor_grid(etree.parse(mscx_path).getroot())
+    return lyric_txt.blocks_from_cells(grid, cells)
 
 
 def run_lyric_import(

--- a/src/song_app/pipeline.py
+++ b/src/song_app/pipeline.py
@@ -6,10 +6,7 @@ non-interactively. No musical logic lives here; this only orchestrates.
 
 from __future__ import annotations
 
-import contextlib
-import io
 import os
-import re
 import shutil
 import subprocess
 import tempfile
@@ -19,7 +16,7 @@ from typing import Callable, Dict, List, Optional, Tuple
 from lxml import etree
 
 from src.clean_score.main import main as clean_main
-from src.clean_score.lyric_txt import import_file
+from src.clean_score.lyric_txt import LyricImport, import_file
 from src.clean_score.utils import per_system
 
 MUSESCORE_EXTS = (".mscz", ".mscx", ".musicxml", ".xml")
@@ -209,12 +206,8 @@ def render_score_pdf(mscx_path: str) -> str:
     return out
 
 
-_WARN_RE = re.compile(r"^Warning:\s*(.*)$", re.MULTILINE)
-
-
-def run_lyric_import(json_path: str, cleaned_path: str, replace: bool = True) -> List[str]:
-    """Import lyric JSON in place into the cleaned score; return any warning lines."""
-    buf = io.StringIO()
-    with contextlib.redirect_stderr(buf), contextlib.redirect_stdout(buf):
-        import_file(json_path, cleaned_path, cleaned_path, replace=replace)
-    return [m.strip() for m in _WARN_RE.findall(buf.getvalue())]
+def run_lyric_import(
+    json_path: str, cleaned_path: str, replace: bool = True
+) -> LyricImport:
+    """Import lyric JSON in place into the cleaned score; return the placement result."""
+    return import_file(json_path, cleaned_path, cleaned_path, replace=replace)

--- a/src/song_app/server.py
+++ b/src/song_app/server.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import json
 import os
 import subprocess
 import sys
@@ -420,40 +421,14 @@ def api_prompt() -> Dict:
 
 @app.get("/api/songs/{slug}/lyric-grid")
 def api_lyric_grid(slug: str) -> Dict:
-    """Structure for the manual lyric editor: the parts and the printed systems."""
+    """Structure for the manual lyric editor: the parts, the printed systems, the text."""
     song = _require(slug)
     cleaned = song.cleaned_path()
     if not cleaned or not os.path.exists(cleaned):
         raise HTTPException(400, "Clean the score first")
     from lxml import etree
-    root = etree.parse(cleaned).getroot()
-    score = root.find(".//Score") if root.tag != "Score" else root
-    parts = []
-    for p in score.findall("Part"):
-        st = p.find("Staff")
-        sid = int(st.get("id")) if st is not None and st.get("id") else 0
-        name = (p.findtext("trackName") or p.findtext("Instrument/trackName") or "").strip()
-        # Skip spacer/click staves (add_rest_track) — they never carry lyrics.
-        if any(w in name.lower() for w in ("drum", "click", "rest")):
-            continue
-        parts.append({"name": name or f"staff {sid}", "id": sid})
-    parts.sort(key=lambda x: x["id"])
-    sys_ranges = pipeline.system_ranges(root)
-    systems = [{"index": r.index, "start": r.start, "end": r.end} for r in sys_ranges]
-
-    # Prefill: the lyrics already in the score, as hyphenated text per (system, part).
-    from src.clean_score.lyric_txt import lyrics_by_measure_staff, _merge_tokens
-    bms = lyrics_by_measure_staff(root)
-    prefill: Dict[str, Dict[str, str]] = {}
-    for r in sys_ranges:
-        for part in parts:
-            toks = []
-            for mi in range(r.start - 1, r.end):
-                toks += [t for t in bms.get(mi, {}).get(part["id"], []) if t != "_"]
-            text = _merge_tokens(toks).strip()
-            if text:
-                prefill.setdefault(str(r.index), {})[part["name"]] = text
-    return {"parts": parts, "systems": systems, "prefill": prefill}
+    from src.clean_score.lyric_txt import editor_grid
+    return editor_grid(etree.parse(cleaned).getroot()).to_dict()
 
 
 @app.get("/api/songs/{slug}/lyrics-json")
@@ -468,27 +443,39 @@ def api_lyrics_json(slug: str):
 
 @app.post("/api/songs/{slug}/lyrics")
 def api_lyrics(slug: str, body: Dict) -> Dict:
+    """Import lyrics: either pasted JSON (`json`) or the manual editor's cells (`cells`)."""
     song = _require(slug)
     cleaned = song.cleaned_path()
     if not cleaned or not os.path.exists(cleaned):
         raise HTTPException(400, "Clean the score first")
-    json_text = (body or {}).get("json", "")
-    if not json_text.strip():
-        raise HTTPException(400, "Paste the lyric JSON first")
+    body = body or {}
+    cells = body.get("cells")
+    if cells:
+        from lxml import etree
+        from src.clean_score.lyric_txt import blocks_from_cells, editor_grid
+        grid = editor_grid(etree.parse(cleaned).getroot())
+        blocks = blocks_from_cells(grid, cells)
+        if not blocks:
+            raise HTTPException(400, "Nothing typed yet")
+        json_text = json.dumps(blocks, ensure_ascii=False, indent=2)
+    else:
+        json_text = body.get("json", "")
+        if not json_text.strip():
+            raise HTTPException(400, "Paste the lyric JSON first")
     json_path = song.path("lyrics.json")
     with open(json_path, "w", encoding="utf-8") as f:
         f.write(json_text)
     try:
-        warnings = pipeline.run_lyric_import(json_path, cleaned, replace=True)
+        result = pipeline.run_lyric_import(json_path, cleaned, replace=True)
     except Exception as exc:
         raise HTTPException(400, f"Import failed: {exc}")
     song.data["lyrics"] = {
         "json": "lyrics.json",
         "imported_against": state.file_fingerprint(cleaned),
-        "warnings": warnings,
+        "warnings": [m.to_dict() for m in result.mismatches],
     }
     song.data["cleaned_fingerprint"] = state.file_fingerprint(cleaned)
-    if not warnings:
+    if result.ok:
         song.set_stage("review")
     song.save()
     return _derived(song)

--- a/src/song_app/server.py
+++ b/src/song_app/server.py
@@ -426,9 +426,7 @@ def api_lyric_grid(slug: str) -> Dict:
     cleaned = song.cleaned_path()
     if not cleaned or not os.path.exists(cleaned):
         raise HTTPException(400, "Clean the score first")
-    from lxml import etree
-    from src.clean_score.lyric_txt import editor_grid
-    return editor_grid(etree.parse(cleaned).getroot()).to_dict()
+    return pipeline.lyric_grid(cleaned)
 
 
 @app.get("/api/songs/{slug}/lyrics-json")
@@ -451,10 +449,7 @@ def api_lyrics(slug: str, body: Dict) -> Dict:
     body = body or {}
     cells = body.get("cells")
     if cells:
-        from lxml import etree
-        from src.clean_score.lyric_txt import blocks_from_cells, editor_grid
-        grid = editor_grid(etree.parse(cleaned).getroot())
-        blocks = blocks_from_cells(grid, cells)
+        blocks = pipeline.lyric_blocks(cleaned, cells)
         if not blocks:
             raise HTTPException(400, "Nothing typed yet")
         json_text = json.dumps(blocks, ensure_ascii=False, indent=2)

--- a/src/song_app/static/app.js
+++ b/src/song_app/static/app.js
@@ -551,11 +551,22 @@ async function panelLyrics(panel, song, P, refresh) {
 }
 
 // Import mismatches come from the server as fields (kind, measure range, staff ids,
-// syllables, slots, message). Songs imported before that shipped hold plain strings;
-// they still render as text, they just can't be attached to a cell.
+// syllables, slots, message). Songs imported before that shipped hold the sentence as
+// a plain string; read the fields back out of it so those keep their cell markers too.
+const LEGACY_WARN = /^Measures (\d+)-(\d+) \(staffs ([\d,\s]+)\): (too many|too few) tokens \((\d+) syllables, (\d+) slots\)/;
+
 function lyricMismatches(song) {
-  return (song.lyrics?.warnings || []).map((w) =>
-    typeof w === "string" ? { message: w, staff_ids: [] } : w);
+  return (song.lyrics?.warnings || []).map((w) => {
+    if (typeof w !== "string") return w;
+    const m = w.match(LEGACY_WARN);
+    if (!m) return { message: w, staff_ids: [] };
+    return {
+      kind: m[4] === "too many" ? "too_many" : "too_few", message: w,
+      measure_start: +m[1], measure_end: +m[2],
+      staff_ids: m[3].split(",").map((s) => +s.trim()).filter(Number.isFinite),
+      syllables: +m[5], slots: +m[6],
+    };
+  });
 }
 
 function autoGrow(ta) {
@@ -612,8 +623,8 @@ async function lyricsManual(panel, song, P, refresh) {
   let grid;
   try { grid = await getJSON(`${P}/lyric-grid`); }
   catch (e) { holder.replaceChildren(el("p", { className: "err" }, e.message)); return; }
-  const { parts, systems, prefill } = grid;
-  const cellText = (si, name) => (prefill?.[si]?.[name]) || "";
+  const { parts, systems, cells } = grid;
+  const cellText = (si, name) => (cells?.[si]?.[name]) || "";
   const warns = lyricMismatches(song);
   // Attach a mismatch to the system where its line STARTS (a line can span several
   // systems if the part is blank in later ones); show the full measure range.
@@ -632,8 +643,7 @@ async function lyricsManual(panel, song, P, refresh) {
           ...cellWarns(sys, p).map((w) => el("div", { className: "lyerr" },
             `⚠ m${w.measure_start}–${w.measure_end}`
             + `${w.measure_end > sys.end ? " (spans later systems)" : ""}: `
-            + `${w.kind === "too_many" ? "too many" : "too few"} syllables `
-            + `(${w.syllables} for ${w.slots} note${w.slots === 1 ? "" : "s"})`)));
+            + `${w.message.split("): ").pop()}`)));
       }))));
   holder.querySelectorAll("textarea").forEach(autoGrow); // size to content (no scroll)
   if (lyricScroll != null) { panel.scrollTop = lyricScroll; lyricScroll = null; } // restore after re-import

--- a/src/song_app/static/app.js
+++ b/src/song_app/static/app.js
@@ -550,15 +550,12 @@ async function panelLyrics(panel, song, P, refresh) {
   return lyricsPaste(panel, song, P, refresh);
 }
 
-// Parse an import warning like "Measures 16-19 (staffs 1, 2): too many tokens …".
-function parseLyricWarning(w) {
-  const m = w.match(/^Measures (\d+)-(\d+) \(staffs ([\d,\s]+)\): (.+)$/);
-  if (!m) return null;
-  return {
-    mStart: +m[1], mEnd: +m[2],
-    staffIds: m[3].split(",").map((s) => +s.trim()).filter(Number.isFinite),
-    msg: m[4],
-  };
+// Import mismatches come from the server as fields (kind, measure range, staff ids,
+// syllables, slots, message). Songs imported before that shipped hold plain strings;
+// they still render as text, they just can't be attached to a cell.
+function lyricMismatches(song) {
+  return (song.lyrics?.warnings || []).map((w) =>
+    typeof w === "string" ? { message: w, staff_ids: [] } : w);
 }
 
 function autoGrow(ta) {
@@ -567,10 +564,10 @@ function autoGrow(ta) {
 }
 
 async function lyricsPaste(panel, song, P, refresh) {
-  const warns = song.lyrics?.warnings || [];
+  const warns = lyricMismatches(song);
   if (warns.length) {
     panel.append(el("p", { className: "sub" }, "Mismatches (often a note problem — check the measure in MuseScore):"),
-      el("ul", { className: "warnlist" }, warns.map((w) => el("li", {}, w))));
+      el("ul", { className: "warnlist" }, warns.map((w) => el("li", {}, w.message))));
   }
   panel.append(el("p", { className: "sub" }, "No API key needed — your AI does the reading, this catches the result."));
   const ta = el("textarea", { rows: 12, placeholder: "Paste the lyric JSON from your AI chat here…" });
@@ -617,11 +614,11 @@ async function lyricsManual(panel, song, P, refresh) {
   catch (e) { holder.replaceChildren(el("p", { className: "err" }, e.message)); return; }
   const { parts, systems, prefill } = grid;
   const cellText = (si, name) => (prefill?.[si]?.[name]) || "";
-  const warns = (song.lyrics?.warnings || []).map(parseLyricWarning).filter(Boolean);
-  // Attach a warning to the system where its line STARTS (a line can span several
+  const warns = lyricMismatches(song);
+  // Attach a mismatch to the system where its line STARTS (a line can span several
   // systems if the part is blank in later ones); show the full measure range.
   const cellWarns = (sys, p) => warns.filter((w) =>
-    w.staffIds.includes(p.id) && w.mStart >= sys.start && w.mStart <= sys.end);
+    (w.staff_ids || []).includes(p.id) && w.measure_start >= sys.start && w.measure_start <= sys.end);
 
   holder.replaceChildren(...systems.map((sys) =>
     el("div", { className: "sysblock" },
@@ -633,7 +630,10 @@ async function lyricsManual(panel, song, P, refresh) {
         return el("div", { className: "lyrow" },
           el("label", {}, p.name), ta,
           ...cellWarns(sys, p).map((w) => el("div", { className: "lyerr" },
-            `⚠ m${w.mStart}–${w.mEnd}${w.mEnd > sys.end ? " (spans later systems)" : ""}: ${w.msg}`)));
+            `⚠ m${w.measure_start}–${w.measure_end}`
+            + `${w.measure_end > sys.end ? " (spans later systems)" : ""}: `
+            + `${w.kind === "too_many" ? "too many" : "too few"} syllables `
+            + `(${w.syllables} for ${w.slots} note${w.slots === 1 ? "" : "s"})`)));
       }))));
   holder.querySelectorAll("textarea").forEach(autoGrow); // size to content (no scroll)
   if (lyricScroll != null) { panel.scrollTop = lyricScroll; lyricScroll = null; } // restore after re-import
@@ -643,21 +643,14 @@ async function lyricsManual(panel, song, P, refresh) {
     panel.querySelectorAll("textarea[data-sys]").forEach((t) => {
       (map[t.dataset.sys] ||= {})[t.dataset.part] = t.value.trim();
     });
-    const data = [];
-    for (const sys of systems) {
-      const lyrics = [];
-      for (const p of parts) {
-        const t = map[sys.index]?.[p.name];
-        if (t) lyrics.push({ parts: [p.name], text: t });
-      }
-      if (lyrics.length) data.push({ measure_start: sys.start, lyrics });
+    if (!Object.values(map).some((row) => Object.values(row).some((t) => t))) {
+      appendLog("Nothing typed yet.", true); return;
     }
-    if (!data.length) { appendLog("Nothing typed yet.", true); return; }
     btn.disabled = true;
     lyricScroll = panel.scrollTop; // preserve scroll across the re-render
     appendLog("Importing lyrics…");
     try {
-      const fresh = await postJSON(`${P}/lyrics`, { json: JSON.stringify(data) });
+      const fresh = await postJSON(`${P}/lyrics`, { cells: map });
       Object.assign(song, fresh);
       const w = song.lyrics?.warnings || [];
       appendLog(w.length ? `Imported with ${w.length} warning(s).` : "Imported cleanly. Ready for review.");

--- a/src/song_app/tests/test_clean_flow.py
+++ b/src/song_app/tests/test_clean_flow.py
@@ -78,3 +78,60 @@ def test_grid_answers_clean_headless_into_parts_and_lyric_routing(song_dir):
 def test_clean_without_answers_reports_no_output(song_dir):
     with pytest.raises(RuntimeError, match="no parts declared"):
         pipeline.run_clean(_source(song_dir), song_dir, per_system=True)
+
+
+# --------------------------------------------------------------------------- #
+# The lyric stage: the manual editor's cells go in, structured mismatches come out
+# --------------------------------------------------------------------------- #
+
+def _cleaned_song(song_dir):
+    """Clean the fixture so there is a score to put lyrics into."""
+    src = _source(song_dir)
+    pipeline.save_system_answers(src, ANSWERS)
+    cleaned, _ = pipeline.run_clean(src, song_dir, per_system=True)
+    return cleaned
+
+
+def test_editor_cells_become_lyrics_in_the_cleaned_score(song_dir):
+    from lxml import etree
+
+    from src.clean_score.lyric_txt import blocks_from_cells, editor_grid
+
+    cleaned = _cleaned_song(song_dir)
+    grid = editor_grid(etree.parse(cleaned).getroot())
+    assert [p.name for p in grid.parts] == ["T1", "T2", "T3", "B"]
+
+    cells = {0: {"T1": "en-sim mäi-nen", "B": "bas-so"}}
+    blocks = blocks_from_cells(grid, cells)
+    json_path = os.path.join(song_dir, "lyrics.json")
+    with open(json_path, "w", encoding="utf-8") as f:
+        json.dump(blocks, f, ensure_ascii=False)
+
+    result = pipeline.run_lyric_import(json_path, cleaned, replace=True)
+    # Mismatches are fields, not text scraped off stderr.
+    assert all(hasattr(m, "kind") and m.staff_ids for m in result.mismatches)
+    back = editor_grid(etree.parse(cleaned).getroot())
+    assert back.text(0, "T1").startswith("en-sim")
+    assert back.text(0, "B").startswith("bas-so")
+
+
+def test_import_reports_a_too_short_line_against_its_own_system(song_dir):
+    from lxml import etree
+
+    from src.clean_score.lyric_txt import TOO_FEW, blocks_from_cells, editor_grid
+
+    cleaned = _cleaned_song(song_dir)
+    grid = editor_grid(etree.parse(cleaned).getroot())
+    system = grid.systems[0]
+    blocks = blocks_from_cells(grid, {0: {"T1": "yk"}})  # one syllable for a whole system
+    json_path = os.path.join(song_dir, "lyrics.json")
+    with open(json_path, "w", encoding="utf-8") as f:
+        json.dump(blocks, f, ensure_ascii=False)
+
+    result = pipeline.run_lyric_import(json_path, cleaned, replace=True)
+    short = [m for m in result.mismatches if m.kind == TOO_FEW]
+    assert short, "a one-syllable line over a whole system must be reported"
+    m = short[0]
+    assert m.measure_start == system.start          # attaches to the system it starts in
+    assert m.staff_ids == (1,)                      # T1 is output staff 1
+    assert m.syllables == 1 and m.slots > 1


### PR DESCRIPTION
Closes #2.

## Summary

`src/clean_score/lyric_txt.py` becomes the single owner of lyric placement behind six public names — `export_lyrics`, `place_lyrics`, `editor_grid`, `blocks_from_cells`, `export_file`, `import_file` — plus the result types. Format normalization, target routing, chord eligibility, syllable distribution and XML placement are internal; ~15 previously public helpers are now private, and no caller reaches past the interface.

**Diagnostics are returned, not printed.** `place_lyrics` gives back a `LyricImport` carrying `Mismatch(kind, message, measure_start, measure_end, staff_ids, syllables, slots)` plus `filled_measure_starts`. The chain the issue described is gone: `pipeline.py` no longer redirects stdout/stderr and regexes `Warning:` lines, the server persists the fields, and `app.js` lost `parseLyricWarning` — it reads `staff_ids` / `measure_start` directly. The CLI wrapper prints the same sentences it always did.

**The editor projection moved out of `server.py`.** `editor_grid()` owns the parts × printed-systems projection (which previously reached for the private `_merge_tokens`), and the browser now posts its raw cells for `blocks_from_cells()` to turn into lyric JSON — which is what makes `editor_grid → cells → blocks → place_lyrics → editor_grid` testable in Python.

Behaviour is unchanged, checked rather than asserted: importing `new_json.json`, `spanner.json` and `spanner_partial.json` through a pre-change worktree and through this branch produces **byte-identical `.mscx`**, the TXT export is byte-identical, and the four warning sentences match verbatim.

## Review

Reviewed at `6c9acf4`, effort `high`: 3 correctness lanes + 6 architecture lanes, then 1 lane re-checking the fixes (clean). First pass on this branch — no prior review record. Two interface decisions (single deepened module rather than a package; editor block-building server-side) were settled with the repo owner before implementation and the lanes were told so.

**Correctness: 1 gated finding, fixed.**
- *(conf 88)* The replacement for the old exact converter-fixture test compared only the first 1–2 characters of each line, so a converter mis-routing anything past the first token would still pass. Now compares the full syllable sequence per (block, staff) — normalized only for the hyphen/space placement the TXT export changes at barlines. Verified by sabotage: truncating each converted line to its first word makes the test fail.
- *(conf 55, sub-threshold, fixed anyway)* The CLI printed the generic "auto-filled …" note on top of the block-count warning that already says it, where the old code printed one or the other.

**Architecture verdict: Reconsider** — Right problem 88, Right approach 78, Use cases/UX 82 `sound`; Right place 70 and Scope & blast radius 74 `questionable`; Over-engineering 62 below the confidence gate. Two gated flags is mechanically a `Reconsider`; both were placement/scope opinions rather than defects, and the substantive ones were fixed.

Fixed from the architecture lanes:
- Legacy string warnings (songs whose `.song.json` predates this) no longer vanish from the manual editor — `app.js` reads the fields back out of the stored sentence, so cell markers survive.
- The inline cell warning shows the server's sentence again; the field-built version had dropped the actionable tail ("the extra are kept on the last note — fix the count").
- `EditorGrid.to_dict()` emits `"cells"` — its own field name — instead of the browser's `"prefill"`.
- The web layer goes through the pipeline glue (`pipeline.lyric_grid` / `lyric_blocks`) rather than importing `clean_score` directly, matching the per-system path and CLAUDE.md's description of `pipeline.py`.
- Two function-local `from .utils.per_system import system_ranges` became one module-level import (no cycle exists); dead `LyricImport.to_dict()` removed; a docstring note that the TXT path reports no mismatches.
- `CLAUDE.md` / `DESIGN.md`: the privatized helper names, and the new persisted `warnings` shape.

Deliberately skipped:
- **Collapsing `EditorPart`/`EditorSystem` into plain dicts** (Over-engineering, conf 62). They are the vocabulary the interface advertises, tests read them by attribute, and the lane rated this below the gate. Revisit if the editor grows more shapes.
- **Removing the `fmt` sniff on `place_lyrics`** (Right approach, non-blocking). `import_file` passes `fmt` explicitly and the server passes a list, so the sniff only serves direct callers; it is one documented line. Worth removing if a caller ever passes a JSON object rather than an array.
- **Reverting `lyrics.json` to compact JSON** for the editor path (Scope, item 3). It is now pretty-printed server-side; that file is served verbatim for the user to read, so indentation is an improvement rather than a regression.
- **`part_to_staff` having no production caller** — carried over verbatim from the previous public signature, not added here.

**Beyond the ask:**
- The `/api/songs/{slug}/lyrics` request shape gained a `cells` body, and `.song.json`'s `warnings` changed from `List[str]` to `List[dict]` (`src/song_app/server.py`). Both follow from the two sanctioned decisions, but they are the change's real blast radius: old songs are handled by a compatibility path rather than a migration.
- `lyrics.json` written by the editor path is now pretty-printed (`src/song_app/server.py`). Separable.
- The ~15-name privatization and `export_mscx_to_txt` → `export_lyrics` rename (`src/clean_score/lyric_txt.py`). In scope under the agreed module shape, but it is the bulk of the line count.
- `src/clean_score/tests/scorebuilder.py` — a shared synthetic-score helper; the card asked for interface-level tests, and routing needs scores with varying staff/system maps that the fixed `.mscx` fixtures don't provide.

**Fast check:** `.venv/bin/python -m pytest src/clean_score/tests/ src/song_app/tests/ -q` → 82 passed (was 73); `node --check src/song_app/static/app.js` clean; the editor path exercised end-to-end over HTTP.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H5kKorL2a8NxRGzKjtkPjS
