### PR TITLE
Add a browser test for the clean → lyrics journey

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -99,7 +99,16 @@ python rename_parts.py score.mscx SSAA -o score_renamed.mscx
 ### Tests
 
 ```bash
-.venv/bin/python -m pytest src/clean_score/tests/ src/song_app/tests/ -q   # 82 tests, all passing
+.venv/bin/python -m pytest src/clean_score/tests/ src/song_app/tests/ -q   # 84 tests, all passing
+```
+
+Two of those are **browser tests** (`src/song_app/tests/test_ui_flow.py`, Playwright).
+They need one extra install and skip cleanly without it, so the command above works
+either way:
+
+```bash
+.venv/bin/pip install pytest-playwright
+.venv/bin/playwright install chromium      # ~95 MB, into ~/Library/Caches/ms-playwright
 ```
 
 `pyproject.toml` only sets `log_cli_level=DEBUG`. Key test modules:
@@ -127,6 +136,15 @@ python rename_parts.py score.mscx SSAA -o score_renamed.mscx
   to the same rebuild.
 - `src/song_app/tests/test_clean_flow.py` — the song-app path: grid answers →
   `save_system_answers` → headless `run_clean` → rebuilt parts + lyric routing.
+- `src/song_app/tests/test_ui_flow.py` — the **SPA itself**, in a real browser: it
+  starts the actual server on a free port with its own `songs/` folder and answer
+  file, then walks New song → per-system grid → clean → manual lyric entry → import,
+  and asserts the mismatch is attached to the cell that caused it. A second test pins
+  the grid's answer rules (blank inherits, `-` clears, both flagged before cleaning).
+  Score previews are switched off (`MUSESCORE_CLI_PATH` points at nothing) — the
+  renderer is not under test and a real MuseScore run would make it slow and
+  host-dependent. Both were verified by sabotage: breaking the cell attachment or the
+  `-` rule in `app.js` fails the matching test.
 - `test_missing_tuplets.py` — the dropped-tuplet cross-voice auto-fix (mirror
   within/across staves; well-formed and donor-less voices left untouched).
 - `test_revoice.py` / `test_interactive.py` — the re-voicing plan and the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -99,19 +99,25 @@ python rename_parts.py score.mscx SSAA -o score_renamed.mscx
 ### Tests
 
 ```bash
-.venv/bin/python -m pytest src/clean_score/tests/ src/song_app/tests/ -q   # 84 tests, all passing
+.venv/bin/python -m pytest src/clean_score/tests/ src/song_app/tests/ -q
+# 82 passed, 1 skipped   — a fresh checkout (the browser tests skip)
+# 84 passed              — once Playwright is installed
 ```
 
-Two of those are **browser tests** (`src/song_app/tests/test_ui_flow.py`, Playwright).
-They need one extra install and skip cleanly without it, so the command above works
-either way:
+The two extra are **browser tests** (`src/song_app/tests/test_ui_flow.py`, Playwright),
+marked `browser`. They need a two-step install, and the module skips unless **both**
+steps are done — the pip package alone is not enough, so a half install still skips
+rather than erroring:
 
 ```bash
 .venv/bin/pip install pytest-playwright
 .venv/bin/playwright install chromium      # ~95 MB, into ~/Library/Caches/ms-playwright
+
+.venv/bin/python -m pytest ... -m "not browser"   # skip them even when installed
 ```
 
-`pyproject.toml` only sets `log_cli_level=DEBUG`. Key test modules:
+`pyproject.toml` sets `log_cli_level=DEBUG` and registers the `browser` marker.
+Key test modules:
 
 - `test_lyric_txt_spanner.py` — asserts lyric export→import round-trips back to
   the original XML (the real behavioral coverage), driven through `export_lyrics` /

--- a/pip-requirements.txt
+++ b/pip-requirements.txt
@@ -8,3 +8,5 @@ pyautogui
 fastapi
 uvicorn[standard]
 python-multipart
+# Browser tests only (src/song_app/tests/test_ui_flow.py); they skip when it is absent:
+#   pip install pytest-playwright && playwright install chromium

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,5 @@
 [tool.pytest.ini_options]
 log_cli_level="DEBUG"
+markers = [
+    "browser: drives the app in a real browser (Playwright); slow, needs a browser install",
+]

--- a/src/song_app/tests/test_ui_flow.py
+++ b/src/song_app/tests/test_ui_flow.py
@@ -10,7 +10,8 @@ Needs Playwright, which is not part of the default install:
     .venv/bin/pip install pytest-playwright
     .venv/bin/playwright install chromium
 
-Without it the whole module skips, so the normal test command is unaffected.
+The module skips unless both the packages and a browser are present, so the normal
+test command is unaffected either way.
 """
 
 import os
@@ -25,11 +26,40 @@ _NEEDS = "pip install pytest-playwright && playwright install chromium"
 pytest.importorskip("playwright.sync_api", reason=_NEEDS)
 pytest.importorskip("pytest_playwright", reason=_NEEDS)  # supplies the `page` fixture
 
+
+def _browser_installed() -> bool:
+    """The pip packages are only half the install; the browser is a separate download.
+
+    Launching is the honest check: `chromium.executable_path` names the full Chromium
+    build, but a headless run starts `chrome-headless-shell`, which is downloaded
+    separately and can be missing on its own — so only a real launch proves the tests
+    can run.
+
+    It runs at import, which costs a browser start (~0.5s) on every collection of this
+    file, `-m "not browser"` included. Running it from a fixture instead does not work:
+    pytest-playwright has its own Playwright session by then, and a second one inside it
+    fails — which the guard would read as "no browser" and skip tests that would pass.
+    """
+    from playwright.sync_api import sync_playwright
+
+    try:
+        with sync_playwright() as p:
+            p.chromium.launch().close()
+        return True
+    except Exception:
+        return False
+
+
+if not _browser_installed():
+    pytest.skip(_NEEDS, allow_module_level=True)
+
 import uvicorn
 from playwright.sync_api import expect
 
 from src.clean_score.tests.test_per_system import ANSWERS
 from src.clean_score.utils.per_system import use_answer_file
+
+pytestmark = pytest.mark.browser
 
 FIXTURE = os.path.join(
     os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))),
@@ -41,6 +71,14 @@ def _free_port():
     with socket.socket() as s:
         s.bind(("127.0.0.1", 0))
         return s.getsockname()[1]
+
+
+@pytest.fixture
+def own_answers(tmp_path):
+    """Answers are keyed by the score's file name, and both tests upload the same score,
+    so give each test its own file — otherwise the second one opens the first's grid."""
+    with use_answer_file(str(tmp_path / "answers.json")):
+        yield
 
 
 @pytest.fixture(scope="module")
@@ -62,22 +100,23 @@ def live_app(tmp_path_factory):
         server.app, host="127.0.0.1", port=port, log_level="warning",
     ))
     thread = threading.Thread(target=srv.run, daemon=True)
-    with use_answer_file(str(tmp / "answers.json")):
+    try:
         thread.start()
         deadline = time.time() + 30
         while not srv.started and time.time() < deadline:
             time.sleep(0.05)
         assert srv.started, "the app did not start"
-        try:
-            yield f"http://127.0.0.1:{port}"
-        finally:
-            srv.should_exit = True
-            thread.join(timeout=10)
-            state.SONGS_DIR = previous_dir
-            if previous_cli is None:
-                os.environ.pop("MUSESCORE_CLI_PATH", None)
-            else:
-                os.environ["MUSESCORE_CLI_PATH"] = previous_cli
+        yield f"http://127.0.0.1:{port}"
+    finally:
+        # Everything below is global to the process, so it is restored even when the
+        # app never came up — otherwise the rest of the session runs against a tmp dir.
+        srv.should_exit = True
+        thread.join(timeout=10)
+        state.SONGS_DIR = previous_dir
+        if previous_cli is None:
+            os.environ.pop("MUSESCORE_CLI_PATH", None)
+        else:
+            os.environ["MUSESCORE_CLI_PATH"] = previous_cli
 
 
 def _new_song(page, base, name, per_system=True):
@@ -92,7 +131,7 @@ def _new_song(page, base, name, per_system=True):
     expect(page.locator(".stagebar")).to_be_visible()
 
 
-def test_per_system_answers_clean_the_score_and_lyrics_land_on_their_cell(live_app, page):
+def test_per_system_answers_clean_the_score_and_lyrics_land_on_their_cell(live_app, own_answers, page):
     """The whole journey: create → answer the grid → clean → type lyrics → see the mismatch."""
     _new_song(page, live_app, "Laulun aika")
 
@@ -140,7 +179,7 @@ def test_per_system_answers_clean_the_score_and_lyrics_land_on_their_cell(live_a
     expect(page.locator('textarea[data-sys="0"][data-part="T1"]')).to_have_value("yk")
 
 
-def test_grid_marks_cleared_and_inherited_staves(live_app, page):
+def test_grid_marks_cleared_and_inherited_staves(live_app, own_answers, page):
     """A blank cell inherits the staff's previous answer; '-' says it is silent."""
     _new_song(page, live_app, "Grid rules")
 
@@ -159,12 +198,11 @@ def test_grid_marks_cleared_and_inherited_staves(live_app, page):
     expect(staff1(3)).to_have_class(re.compile(r"\bunset\b"))
 
     # Cleaning warns about exactly those dropped slots before it runs.
+    # The handler has to be registered before the click: the dialog blocks the page,
+    # so a wrapper that waits around the click would deadlock with it.
     dropped = []
-    page.on("dialog", lambda d: (dropped.append(d.message), d.dismiss()))
+    page.once("dialog", lambda d: (dropped.append(d.message), d.dismiss()))
     page.get_by_role("button", name="Run clean").click()
-    deadline = time.time() + 10
-    while not dropped and time.time() < deadline:
-        page.wait_for_timeout(100)
     assert dropped, "cleaning with unnamed staves must confirm first"
     assert "staff 1 · system 3" in dropped[0], dropped[0]
     assert "staff 1 · system 4" in dropped[0], dropped[0]

--- a/src/song_app/tests/test_ui_flow.py
+++ b/src/song_app/tests/test_ui_flow.py
@@ -1,0 +1,170 @@
+"""
+Browser test of the song app: the clean → lyrics journey, driven through the real UI.
+
+This is the layer the Python tests can't reach — the vanilla-JS SPA in
+`src/song_app/static/app.js`, where the per-system grid's answers are typed and where
+import mismatches are attached to the cell that caused them.
+
+Needs Playwright, which is not part of the default install:
+
+    .venv/bin/pip install pytest-playwright
+    .venv/bin/playwright install chromium
+
+Without it the whole module skips, so the normal test command is unaffected.
+"""
+
+import os
+import re
+import socket
+import threading
+import time
+
+import pytest
+
+_NEEDS = "pip install pytest-playwright && playwright install chromium"
+pytest.importorskip("playwright.sync_api", reason=_NEEDS)
+pytest.importorskip("pytest_playwright", reason=_NEEDS)  # supplies the `page` fixture
+
+import uvicorn
+from playwright.sync_api import expect
+
+from src.clean_score.tests.test_per_system import ANSWERS
+from src.clean_score.utils.per_system import use_answer_file
+
+FIXTURE = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))),
+    "clean_score", "tests", "test_files", "laulun_aika.mscx",
+)
+
+
+def _free_port():
+    with socket.socket() as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+@pytest.fixture(scope="module")
+def live_app(tmp_path_factory):
+    """The real server, on its own port, with its own songs folder and answer file."""
+    from src.song_app import server, state
+
+    tmp = tmp_path_factory.mktemp("songapp")
+    songs = tmp / "songs"
+    songs.mkdir()
+    previous_dir, state.SONGS_DIR = state.SONGS_DIR, str(songs)
+    # Point the renderer at nothing: the score previews are not under test, and a real
+    # MuseScore run would add seconds per page and a dependency on the host's install.
+    previous_cli = os.environ.get("MUSESCORE_CLI_PATH")
+    os.environ["MUSESCORE_CLI_PATH"] = str(tmp / "no-musescore-here")
+
+    port = _free_port()
+    srv = uvicorn.Server(uvicorn.Config(
+        server.app, host="127.0.0.1", port=port, log_level="warning",
+    ))
+    thread = threading.Thread(target=srv.run, daemon=True)
+    with use_answer_file(str(tmp / "answers.json")):
+        thread.start()
+        deadline = time.time() + 30
+        while not srv.started and time.time() < deadline:
+            time.sleep(0.05)
+        assert srv.started, "the app did not start"
+        try:
+            yield f"http://127.0.0.1:{port}"
+        finally:
+            srv.should_exit = True
+            thread.join(timeout=10)
+            state.SONGS_DIR = previous_dir
+            if previous_cli is None:
+                os.environ.pop("MUSESCORE_CLI_PATH", None)
+            else:
+                os.environ["MUSESCORE_CLI_PATH"] = previous_cli
+
+
+def _new_song(page, base, name, per_system=True):
+    """Walk the New song form and land in the workspace."""
+    page.goto(base)
+    page.get_by_role("button", name="+ New song").click()
+    page.get_by_placeholder("Song name").fill(name)
+    page.locator("input[type=file]").first.set_input_files(FIXTURE)
+    if per_system:
+        page.locator("input[type=checkbox]").check()
+    page.get_by_role("button", name="Create").click()
+    expect(page.locator(".stagebar")).to_be_visible()
+
+
+def test_per_system_answers_clean_the_score_and_lyrics_land_on_their_cell(live_app, page):
+    """The whole journey: create → answer the grid → clean → type lyrics → see the mismatch."""
+    _new_song(page, live_app, "Laulun aika")
+
+    # --- the per-system grid: one block per printed system, staves that sound in it ---
+    expect(page.locator(".sysblock")).to_have_count(7)
+    first = page.locator(".sysblock").first
+    expect(first.locator("h4")).to_contain_text("System 1 — measures 1–6")
+    expect(first.locator("input[data-sys]")).to_have_count(2)
+
+    # Answer every staff of every system exactly as the fixture reads.
+    for system, staves in ANSWERS.items():
+        for staff_id, answer in staves.items():
+            page.locator(f'input[data-sys="{system}"][data-staff="{staff_id}"]').fill(answer)
+
+    page.get_by_role("button", name="Save assignments").click()
+    expect(page.get_by_role("button", name="Saved ✓")).to_be_visible()
+
+    # --- clean: the server works in the background and pings the page when done ---
+    page.get_by_role("button", name="Run clean").click()
+    # The panel re-renders on the state ping, so wait for what that leaves behind:
+    # the button now offers a re-clean, and the Clean step is marked done.
+    expect(page.get_by_role("button", name="Re-clean (discards manual edits)")).to_be_visible(
+        timeout=60_000
+    )
+    expect(page.locator(".stagebar .step", has_text="Clean")).to_have_class(re.compile(r"\bdone\b"))
+
+    # --- lyrics: type one short line into the first system's top part ---
+    page.locator(".stagebar .step", has_text="Lyrics").click()
+    page.get_by_role("button", name="Type by system").click()
+    cell = page.locator('textarea[data-sys="0"][data-part="T1"]')
+    expect(cell).to_be_visible()
+    cell.fill("yk")  # one syllable for a whole system: too few
+    page.get_by_role("button", name="Import lyrics").click()
+
+    # The mismatch is attached to the cell that caused it, and says what is wrong.
+    warning = page.locator(".lyrow", has=page.locator('textarea[data-part="T1"]')).locator(".lyerr")
+    expect(warning.first).to_be_visible(timeout=30_000)
+    expect(warning.first).to_contain_text("too few tokens")
+    expect(warning.first).to_contain_text("m1–")
+    # ...and only there: the parts nobody typed into carry no warning.
+    other = page.locator(".lyrow", has=page.locator('textarea[data-part="T2"]')).first
+    expect(other.locator(".lyerr")).to_have_count(0)
+
+    # What was typed survives the re-render, read back out of the score.
+    expect(page.locator('textarea[data-sys="0"][data-part="T1"]')).to_have_value("yk")
+
+
+def test_grid_marks_cleared_and_inherited_staves(live_app, page):
+    """A blank cell inherits the staff's previous answer; '-' says it is silent."""
+    _new_song(page, live_app, "Grid rules")
+
+    staff1 = lambda system: page.locator(f'input[data-sys="{system}"][data-staff="1"]')
+    staff1(0).fill("T1,T2")
+    staff1(1).fill("")           # blank: inherits
+    staff1(2).fill("-")          # cleared from here on
+    staff1(3).fill("")           # still cleared, not inherited from system 1
+    staff1(0).blur()
+
+    # The inherited cell shows what it will inherit and is not flagged.
+    expect(staff1(1)).to_have_attribute("placeholder", "T1,T2")
+    expect(staff1(1)).not_to_have_class(re.compile(r"\bunset\b"))
+    # The cleared cell and the blank one after it are both flagged as dropped.
+    expect(staff1(2)).to_have_class(re.compile(r"\bunset\b"))
+    expect(staff1(3)).to_have_class(re.compile(r"\bunset\b"))
+
+    # Cleaning warns about exactly those dropped slots before it runs.
+    dropped = []
+    page.on("dialog", lambda d: (dropped.append(d.message), d.dismiss()))
+    page.get_by_role("button", name="Run clean").click()
+    deadline = time.time() + 10
+    while not dropped and time.time() < deadline:
+        page.wait_for_timeout(100)
+    assert dropped, "cleaning with unnamed staves must confirm first"
+    assert "staff 1 · system 3" in dropped[0], dropped[0]
+    assert "staff 1 · system 4" in dropped[0], dropped[0]


### PR DESCRIPTION
## Summary

The SPA in `src/song_app/static/app.js` had no test coverage of any kind, and the last two PRs both changed logic that lives only there: the mismatch→cell attachment (#5) and the per-system grid's blank-inherits / `-`-clears rule (#4), which is a hand-mirrored copy of the backend's rule with no Python equivalent.

`src/song_app/tests/test_ui_flow.py` starts the real server on a free port — its own `songs/` folder, its own answer file — and drives Chromium through two journeys:

1. **New song → per-system grid → clean → manual lyric entry → import**, asserting the mismatch lands on the cell that caused it (and *not* on the part nobody typed into), and that the typed text survives the re-render.
2. **The grid's answer rules**: a blank cell inherits the staff's previous answer, `-` clears it, and both cleared and never-named slots are listed in the confirm before cleaning.

Score previews are switched off (`MUSESCORE_CLI_PATH` points at nothing) — the renderer is not under test and a real MuseScore run would make this slow and host-dependent.

Both tests were verified by sabotage before review: stubbing `cellWarns` to return `[]` fails test 1; removing the `-` branch from `cascade()` fails test 2.

## Review

Reviewed at `c6f2176`, effort `high`: 3 correctness lanes + 3 architecture lanes (six dimensions), then 1 lane re-checking the fixes. First pass on this branch. No issue card — the ask was "let's build a playwright test" plus the accepted proposal (cover the clean → lyrics journey, Python runner, skipped when Playwright is absent).

**Correctness: 2 findings, both fixed.**
- *(conf 90, reproduced by the lane)* With the pip packages installed but no browser downloaded, the module **errored** instead of skipping — contradicting the docstring and CLAUDE.md. `importorskip` only covers imports. There is now a launch-based guard; I verified all four states by moving the browser cache aside: present → 84 passed, missing → 82 passed + 1 skipped with the install hint, `-m "not browser"` → 82 passed + 2 deselected.
- *(conf 55)* The fixture swapped `state.SONGS_DIR` and `MUSESCORE_CLI_PATH` before the `try`, so a startup failure would leave the rest of the session pointed at a temp dir with the server thread still running. Both are now restored on every path.

**Architecture verdict: Questionable** — Right problem 72, Scope 78, Right place 82, Over-engineering 80 `sound`; Use cases/UX 76 `questionable`; Right approach 68 below the confidence gate. One gated flag, and it was fixed.

Also fixed:
- **Test isolation** (Right approach, 68): answers are keyed by score file name and both tests upload the same score, so the second test's grid opened prefilled with the first's answers — it passed only because its assertions are substring checks. Each test now gets its own answer file.
- **Deselection** (Right place nit): the module is marked `browser` and the marker is registered in `pyproject.toml`.
- **Docs** (UX, 76): CLAUDE.md now gives both counts and says plainly that a half install still skips; `pip-requirements.txt` points at the optional install.
- **Dialog handling**: registered before the click instead of polled after it.

Deliberately skipped:
- **`page.expect_event("dialog")`** instead of a pre-registered handler (Right approach, minor). Tried it — it deadlocks: the modal blocks the click the wrapper wraps, so the wrapper never resolves. A one-shot `page.once` handler registered before the click is the working form, and the code says why.
- **Moving the browser guard out of module scope** so `-m "not browser"` avoids its ~0.5s cost (fix-lane note). Tried it — inside a fixture, `sync_playwright()` collides with pytest-playwright's own session, the guard reads that as "no browser", and tests that would pass get skipped. The cost stays, and the docstring records the trade-off.
- **The fix lane's claim that the guard's justification is wrong** — it argued `chromium.executable_path` and the launched binary are the same. They are not: removing only `chromium_headless_shell-*` (leaving the full `chromium-*` build in place) makes the tests fail and the guard correctly skip, which is exactly what the comment says.

**Beyond the ask:**
- The second test (the grid's answer rules) is an adjacent journey, not the clean → lyrics one that was asked for (`src/song_app/tests/test_ui_flow.py`). It shares the fixture and is ~30 lines; it could have shipped separately.
- `pytest-playwright` and a ~95 MB browser were installed into the dev environment; the dependency is recorded only as a comment in `pip-requirements.txt` and prose in CLAUDE.md, deliberately, so a fresh checkout still runs the documented command.
- `pyproject.toml` gained a `markers` entry (needed for the marker, but it is the first one this repo has).

**Fast check:** `.venv/bin/python -m pytest src/clean_score/tests/ src/song_app/tests/ -q` → 84 passed, stable over three consecutive runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H5kKorL2a8NxRGzKjtkPjS
