### PR TITLE
Repair per-system scores like any other, and split divisi chords

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -428,7 +428,13 @@ against the `laulun_aika.mscx` and `simple_1` fixtures.
    the target, requires a voice that already fills it as a witness, and strips only
    what is **not music**: a `location` gap or a trailing rest, and only when it
    accounts for the overrun exactly. It never removes, shortens or adds a note; a
-   voice that would need one is left for the health check. Lengths count `location`
+   voice that would need one is left for the health check. The one thing it writes
+   rather than removes is the length of **silence**: a voice resting through the bar
+   was written to the length the override declared, so once the override goes it
+   overruns the corrected bar and MuseScore plays the measure longer than it is
+   engraved. No health check sees that — it showed up as a scrolling video the
+   renderer refused, 92% of the played notes having no highlight — so such a voice
+   becomes a measure rest of the real bar. Lengths count `location`
    gaps, or a voice looks complete on its notes while the file has it occupying more
    of the bar. The fixture's m26 cost two wrong versions before that shape — see its
    STEPS.md.
@@ -506,9 +512,25 @@ root (gitignored) via `save_answers`/`saved_answers`/`has_answers`; the file its
 internal (swap it in tests with `use_answer_file(path)`). A complete
 answer set lets per-system mode run **non-interactively** (no TTY) — that is how the web
 app cleans headless after the grid is submitted, and how the tests drive it. `main()`
-handles per-system mode in an early branch: it calls `clean_per_system` (handing it the
-prompt adapter only when there is a TTY) and writes the file — the rebuild details and
-the metadata are the module's.
+handles per-system mode in an early branch: it runs the OCR measure repairs
+(`preprocess_corrupted_measures`, `fix_overfull_measures`), then calls
+`clean_per_system` (handing it the prompt adapter only when there is a TTY) and writes
+the file — the rebuild details and the metadata are the module's. The repairs used to
+sit below the branch, so a per-system score kept every spurious `len` the scanner
+wrote: on Kaksi-laulua-krapulasta a bar the page prints as 3/4 stayed 4/4 and ran a
+beat long in the practice track, while an ordinary clean of the same file repaired it.
+Voice-anomaly resolution stays out on purpose — the answers already say what each
+voice is.
+
+**Divisi written as a chord.** An engraver writes two singers holding a chord together
+as one voice with the noteheads stacked, so a staff can carry two declared parts
+without having two `<voice>` elements. `_max_voices_in_range` therefore counts a chord's
+noteheads as parts, and the rebuild gives each declared part its own notehead (top
+first). Copying the voice whole instead handed both notes to the upper part and left
+the lower one silent — on Kaksi-laulua-krapulasta the lower bass lost the "duu" in m22
+entirely, which no health check catches (a chord is well-formed and so is a rest). Where
+the stack narrows to one notehead the parts converge in unison rather than one of them
+falling silent.
 
 Because the PDF's printed staff numbering
 **shifts per system** as parts are omitted (e.g. with T3 absent, the bass becomes
@@ -632,9 +654,14 @@ Interface — everything else is an implementation detail of this one call:
 ```python
 build_videos(mscx_path, out_dir, parts=None, height=2160, width=3840,
              fps=60, with_audio=True, keep_silent=False, emphasise=False,
-             spacer_per_quarter=2, smooth_seconds=2.0, basename=None,
-             log=...) -> [video paths]
+             combined=True, spacer_per_quarter=2, smooth_seconds=2.0,
+             basename=None, log=...) -> [video paths]
 ```
+
+`combined` also writes **"&lt;base&gt; ALL"** — the same picture with every voice at equal
+volume (`render_mix(focus=None)`, muxed like any other track). It is a mix, not a part,
+so it never goes through `part_names`; downstream reads the part out of the file name,
+which is why it is called ALL, the name the screen recorder always used.
 
 Three MuseScore CLI calls feed it, and each output answers one question:
 

--- a/scroll_video.py
+++ b/scroll_video.py
@@ -46,6 +46,8 @@ def main() -> None:
                         help="seconds to average the scroll speed over (0 disables)")
     parser.add_argument("--emphasise", action="store_true",
                         help="light each voice's own notes brighter; re-encodes per voice (slow)")
+    parser.add_argument("--no-combined", action="store_true",
+                        help="skip the extra ALL video (every voice at equal volume)")
     args = parser.parse_args()
 
     out_dir = args.out_dir or os.path.join(os.path.dirname(os.path.abspath(args.score)),
@@ -57,6 +59,7 @@ def main() -> None:
         written = build_videos(args.score, out_dir, parts=args.parts, height=args.height,
                                width=width, fps=args.fps, with_audio=not args.no_audio,
                                keep_silent=args.keep_silent, emphasise=args.emphasise,
+                               combined=not args.no_combined,
                                spacer_per_quarter=args.spacer, smooth_seconds=args.smooth,
                                log=lambda m: print(m, flush=True))
     except NotImplementedError as exc:

--- a/src/clean_score/main.py
+++ b/src/clean_score/main.py
@@ -223,6 +223,16 @@ def main(
     # Per-system mode: rebuild the score from per-system part declarations instead of
     # the normal split. For badly-parsed scores where staves change role per system.
     if per_system:
+        # The OCR measure repairs below the branch never ran here, so a per-system
+        # score kept every bogus `len` override the scanner wrote: on
+        # Kaksi-laulua-krapulasta a bar the page prints as 3/4 stayed 4/4 and ran a
+        # beat long in the practice track, while an ordinary clean of the same file
+        # repaired it. They read the source staves, which is the same shape the
+        # rebuild reads, so they belong on both paths. Voice-anomaly resolution
+        # deliberately stays out: per-system answers already say what each voice is.
+        preprocess_corrupted_measures(root)
+        fix_overfull_measures(root)
+
         can_prompt = interactive and sys.stdin.isatty()
         result = clean_per_system(
             root,

--- a/src/clean_score/tests/test_overfull_measures.py
+++ b/src/clean_score/tests/test_overfull_measures.py
@@ -138,3 +138,30 @@ def test_the_reference_measure():
         assert _voice_len(v) == Fraction(1), f"staff {sid} is not 4/4"
     b1 = staves["3"].findall("Measure")[25]
     assert len(b1.findall(".//Chord")) == 6             # six notes, six syllables
+
+
+def test_a_staff_resting_through_the_bar_is_relengthened_with_the_override():
+    """The rest was written to the wrong length the override declared.
+
+    Left alone it overruns the corrected bar, and MuseScore then plays the measure
+    longer than it is engraved — a practice video that drifts, not a health issue.
+    """
+    four = [("Chord", "quarter")] * 3
+    root = _timesig(_score([four, four + [("Rest", "quarter")], [("Rest", "whole")]],
+                           length="4/4"), 3, 4)
+    assert fix_overfull_measures(root) == 1
+    silent = list(root.iter("voice"))[-1]
+    # A measure rest, which every reader (MuseScore, the health check) takes as the
+    # whole bar however long the bar turns out to be.
+    assert silent.find("Rest/durationType").text == "measure"
+    assert silent.find("Rest/duration").text == "3/4"
+    assert len(silent.findall("Rest")) == 1
+
+
+def test_a_silent_staff_already_the_right_length_is_untouched():
+    four = [("Chord", "quarter")] * 3
+    root = _timesig(_score([four, four + [("Rest", "quarter")],
+                            [("Rest", "quarter")] * 3], length="4/4"), 3, 4)
+    assert fix_overfull_measures(root) == 1
+    silent = list(root.iter("voice"))[-1]
+    assert [r.find("durationType").text for r in silent.findall("Rest")] == ["quarter"] * 3

--- a/src/clean_score/tests/test_per_system.py
+++ b/src/clean_score/tests/test_per_system.py
@@ -326,3 +326,87 @@ def test_prompted_answers_are_recorded_for_the_next_run():
     # A later run needs no prompting at all.
     again = clean_per_system(_load(), input_path=FIXTURE)
     assert again.parts == ["T1", "T2", "T3", "B"]
+
+
+# --------------------------------------------------------------------------- #
+# Divisi written as a chord in one voice
+# --------------------------------------------------------------------------- #
+
+def _stacked_score(pitches=("43", "50")):
+    """One measure, one staff, one voice, whose chord stacks two noteheads.
+
+    What an engraver writes when two singers hold a chord together — the shape that
+    used to hand both notes to the upper part and leave the lower one silent.
+    """
+    root = etree.Element("museScore")
+    score = etree.SubElement(root, "Score")
+    part = etree.SubElement(score, "Part")
+    etree.SubElement(part, "trackName").text = "B"
+    etree.SubElement(part, "Staff", id="1")
+    staff = etree.SubElement(score, "Staff", id="1")
+    measure = etree.SubElement(staff, "Measure")
+    voice = etree.SubElement(measure, "voice")
+    chord = etree.SubElement(voice, "Chord")
+    etree.SubElement(chord, "durationType").text = "whole"
+    for pitch in pitches:
+        etree.SubElement(etree.SubElement(chord, "Note"), "pitch").text = pitch
+    return root
+
+
+def _by_part(root):
+    return {p.find("trackName").text: s
+            for p, s in zip(root.findall(".//Part"), root.findall(".//Score/Staff"))}
+
+
+def test_two_parts_on_a_stacked_chord_take_one_notehead_each():
+    root = _stacked_score()
+    clean_per_system(root, answers_from=lambda _l: {0: {1: "B1,B2"}})
+    staves = _by_part(root)
+    assert _pitches(staves["B1"], 0) == ["50"]   # upper notehead
+    assert _pitches(staves["B2"], 0) == ["43"]   # lower one, which used to be silence
+
+
+def test_where_the_stack_narrows_the_parts_sing_in_unison():
+    """Inside a stacked bar, a lone notehead is the two voices converging, not a rest."""
+    root = _stacked_score()
+    voice = root.find(".//Score/Staff/Measure/voice")
+    single = etree.SubElement(voice, "Chord")
+    etree.SubElement(single, "durationType").text = "whole"
+    etree.SubElement(etree.SubElement(single, "Note"), "pitch").text = "48"
+    clean_per_system(root, answers_from=lambda _l: {0: {1: "B1,B2"}})
+    staves = _by_part(root)
+    assert _pitches(staves["B1"], 0) == ["50", "48"]
+    assert _pitches(staves["B2"], 0) == ["43", "48"]   # not a bar of silence
+
+
+def test_one_voice_with_no_stack_is_left_to_rest():
+    """One printed line in a bar of a two-voice staff: unison or a tacit voice is a
+    reading of the page, so the rebuild declines to guess and the second part rests."""
+    root = _stacked_score(pitches=("50",))
+    staff = root.find(".//Score/Staff")
+    lower = etree.SubElement(staff.find("Measure"), "voice")   # a real second voice
+    chord = etree.SubElement(lower, "Chord")
+    etree.SubElement(chord, "durationType").text = "whole"
+    etree.SubElement(etree.SubElement(chord, "Note"), "pitch").text = "43"
+    measure2 = etree.SubElement(staff, "Measure")              # ...absent in the next bar
+    single = etree.SubElement(etree.SubElement(measure2, "voice"), "Chord")
+    etree.SubElement(single, "durationType").text = "whole"
+    etree.SubElement(etree.SubElement(single, "Note"), "pitch").text = "48"
+
+    clean_per_system(root, answers_from=lambda _l: {0: {1: "B1,B2"}})
+    staves = _by_part(root)
+    assert _pitches(staves["B1"], 1) == ["48"]
+    assert _pitches(staves["B2"], 1) == []        # a measure rest, as before the change
+
+
+def test_a_staff_with_its_own_second_voice_is_left_alone():
+    """Two real voices still copy verbatim: chords there are genuine double stops."""
+    root = _stacked_score()
+    voice2 = etree.SubElement(root.find(".//Measure"), "voice")
+    chord = etree.SubElement(voice2, "Chord")
+    etree.SubElement(chord, "durationType").text = "whole"
+    etree.SubElement(etree.SubElement(chord, "Note"), "pitch").text = "38"
+    clean_per_system(root, answers_from=lambda _l: {0: {1: "B1,B2"}})
+    staves = _by_part(root)
+    assert _pitches(staves["B1"], 0) == ["43", "50"]   # voice 1, both noteheads
+    assert _pitches(staves["B2"], 0) == ["38"]         # voice 2

--- a/src/clean_score/utils/overfull_measures.py
+++ b/src/clean_score/utils/overfull_measures.py
@@ -9,9 +9,17 @@ This pass handles the other case, and takes the **prevailing time signature** as
 truth rather than a vote among the voices. A voice must already fill it exactly for
 anything to happen — that witness is the evidence the override is wrong.
 
-**It only removes things that are not music**: a `location` gap (MuseScore holding a
-voice's place) or a trailing rest, and only when that item accounts for the overrun
-exactly. It never deletes a note, never shortens one, and never pads.
+**It only touches things that are not music**: it removes a `location` gap (MuseScore
+holding a voice's place) or a trailing rest, and only when that item accounts for the
+overrun exactly. It never deletes a note, never shortens one, and never pads a voice
+that has any.
+
+One thing it writes rather than removes: a voice resting through the whole bar was
+written to the length the override declared, so once the override goes that rest
+overruns the corrected bar. MuseScore then *plays* the measure longer than it is
+engraved, which no health check sees — it surfaced as a practice video the renderer
+refused because a twelfth of the played notes had no highlight. Silence makes no
+musical claim, so such a voice is re-lengthed to a measure rest of the real bar.
 
 Those limits are the scars of getting this measure wrong twice. The first version
 deleted a "repeated" notehead and destroyed a real note — the voice was singing six
@@ -110,6 +118,30 @@ def _drop_trailing_rest(voice: etree._Element, excess: Fraction) -> bool:
     return False
 
 
+def _resize_silent_voice(voice: etree._Element, target: Fraction) -> bool:
+    """A voice of nothing but rests becomes one measure rest of `target`.
+
+    Only for voices with no notes at all: a bar of silence says nothing about the
+    music, so its length is bookkeeping rather than a musical claim.
+    """
+    rests = voice.findall("Rest")
+    if not rests or voice.find("Chord") is not None:
+        return False
+    if _voice_len(voice) == target:
+        return False
+    for rest in rests[1:]:
+        voice.remove(rest)
+    keep = rests[0]
+    # Only the length is ours to change: a hidden rest (<visible>0</visible>) or one
+    # the engraver moved stays as it was, or a bar of silence would reappear on the
+    # page because its duration was wrong.
+    for child in keep.findall("durationType") + keep.findall("duration") + keep.findall("dots"):
+        keep.remove(child)
+    etree.SubElement(keep, "durationType").text = "measure"
+    etree.SubElement(keep, "duration").text = f"{target.numerator}/{target.denominator}"
+    return True
+
+
 def fix_overfull_measures(root: etree._Element) -> int:
     """Strip non-musical padding from measures carrying a spurious `len`.
 
@@ -165,6 +197,13 @@ def fix_overfull_measures(root: etree._Element) -> int:
         if sum(1 for n in now if n == target) * 2 > len(now):
             for _, m in marked:
                 del m.attrib["len"]
+                # A staff resting through the bar was written to the old, wrong length
+                # (a whole rest under len="4/4"). Left alone it now overruns the bar the
+                # override was hiding, and MuseScore plays the measure longer than it is
+                # engraved — which is not a health issue, it is a video that drifts out
+                # of sync. Silence carries no music, so re-length it to the real bar.
+                for voice in m.findall("voice"):
+                    _resize_silent_voice(voice, target)
             fixed += 1
             logger.debug("Measure %d: len override removed, nominal is %s", mi + 1, target)
     return fixed

--- a/src/clean_score/utils/per_system.py
+++ b/src/clean_score/utils/per_system.py
@@ -250,12 +250,20 @@ def system_ranges(root: etree._Element) -> List[SystemRange]:
 
 
 def _max_voices_in_range(staff: etree._Element, a: int, b: int) -> int:
-    """Max number of note-bearing voices (ignoring all-rest voices) across the range."""
+    """How many parts this staff can carry across the range.
+
+    Note-bearing voices (all-rest voices don't count), but a chord counts as one part
+    per notehead: an engraver writes two singers holding a chord together as a single
+    voice with the notes stacked, and a staff that is only ever asked for one name
+    there hands both notes to the upper part and leaves the lower one silent.
+    """
     measures = staff.findall("Measure")
     best = 0
     for m in range(a, b + 1):
-        n = sum(1 for v in measures[m].findall("voice") if v.find("Chord") is not None)
-        best = max(best, n)
+        voices = [v for v in measures[m].findall("voice") if v.find("Chord") is not None]
+        stacked = max((len(ch.findall("Note"))
+                       for v in voices for ch in v.findall("Chord")), default=0)
+        best = max(best, len(voices), stacked if len(voices) == 1 else 0)
     return best
 
 
@@ -372,6 +380,37 @@ def _set_clef(staff: etree._Element, letter: str) -> None:
                 child.text = clef_type
 
 
+def _has_chord_stack(voice: etree._Element) -> bool:
+    """True if any chord here stacks more than one notehead (divisi in one voice)."""
+    return any(len(ch.findall("Note")) > 1 for ch in voice.findall("Chord"))
+
+
+def _voice_at_notehead(voice: etree._Element, rank: int) -> List[etree._Element]:
+    """This voice with each chord reduced to one notehead: `rank` 0 = top, 1 = next.
+
+    For the bar where the engraver writes two singers as one stack of notes. A chord
+    with fewer noteheads than `rank` asks for is a moment where the two converge, so
+    the part takes the lowest note there rather than falling silent — silence would
+    leave a hole in that singer's practice track.
+    """
+    out: List[etree._Element] = []
+    for el in voice:
+        if el.tag in _SKELETON_KEEP:
+            continue
+        copy = deepcopy(el)
+        if copy.tag == "Chord":
+            notes = copy.findall("Note")
+            if len(notes) > 1:
+                by_pitch = sorted(notes, key=lambda n: int(n.findtext("pitch") or 0),
+                                  reverse=True)
+                keep = by_pitch[rank] if rank < len(by_pitch) else by_pitch[-1]
+                for note in notes:
+                    if note is not keep:
+                        copy.remove(note)
+        out.append(copy)
+    return out
+
+
 def _build_parts(
     root: etree._Element, bounds: List[Tuple[int, int]], decls: _Decls
 ) -> List[str]:
@@ -432,7 +471,28 @@ def _build_parts(
                 if src_staff is not None:
                     src_measure = src_staff.findall("Measure")[mi]
                     src_voices = src_measure.findall("voice")
-                    if src[1] < len(src_voices):
+                    declared_here = sum(1 for (sid, _) in decls.get(system, {})
+                                        if sid == src[0])
+                    # Divisi written as a chord: the staff declares more parts than it
+                    # has voices here, and the notes really are stacked in one voice.
+                    # Each part takes its own notehead — copying the voice whole would
+                    # give the upper part both notes and leave the lower one silent.
+                    # The stack itself has to be there: a staff that simply has one
+                    # voice in this bar is a bar where the page shows one line, and
+                    # whether that means unison or a tacit voice is a reading of the
+                    # page, not something to infer here (a wrong guess is silent —
+                    # a note and a rest are both well-formed).
+                    stacked = (declared_here > len(src_voices) and bool(src_voices)
+                               and _has_chord_stack(src_voices[0]))
+                    if stacked:
+                        for el in _voice_at_notehead(src_voices[0], src[1]):
+                            voice.append(el)
+                        placed = True
+                        logger.debug(
+                            "Measure %d staff %d: %s takes notehead %d of a shared chord",
+                            mi + 1, src[0], part, src[1],
+                        )
+                    elif src[1] < len(src_voices):
                         for el in src_voices[src[1]]:
                             if el.tag not in _SKELETON_KEEP:
                                 voice.append(deepcopy(el))

--- a/src/scrollvideo/build.py
+++ b/src/scrollvideo/build.py
@@ -42,6 +42,11 @@ JUMP_MARKUP = ("Jump",)
 ALIGNMENT_TOLERANCE = 0.2
 ALIGNMENT_REQUIRED = 0.98
 
+# The name of the every-voice mix. Downstream (review, YouTube titles, delete) reads
+# the part out of the file name, so this is also what the combined video is called
+# there — the same name the old screen recorder used.
+COMBINED = "ALL"
+
 
 def _noop(_msg: str) -> None:
     pass
@@ -88,7 +93,7 @@ def alignment(events: Sequence, midi_path: str) -> float:
 def build_videos(mscx_path: str, out_dir: str, *, parts: Optional[Sequence[str]] = None,
                  height: int = 2160, width: int = 3840, fps: int = 60,
                  with_audio: bool = True, keep_silent: bool = False,
-                 emphasise: bool = False,
+                 emphasise: bool = False, combined: bool = True,
                  spacer_per_quarter: int = spacing_mod.DEFAULT_PER_QUARTER,
                  smooth_seconds: float = SMOOTH_SECONDS,
                  basename: Optional[str] = None,
@@ -100,6 +105,10 @@ def build_videos(mscx_path: str, out_dir: str, *, parts: Optional[Sequence[str]]
     dominates the cost — 18s of a 21s render — so this is roughly 3x faster for a
     four-part score. `emphasise=True` instead re-renders per voice with that
     voice's notes lit brighter than the rest, which costs a full encode each.
+
+    `combined` also writes "<base> ALL", the same picture with every voice at equal
+    volume — what a singer listens to once they know their own line, and what the
+    old screen recorder always produced.
     """
     # Checked before the work, not at the encode: engraving, rasterising and the
     # audio mixes take minutes, and failing at the end with a bare FileNotFoundError
@@ -189,18 +198,27 @@ def build_videos(mscx_path: str, out_dir: str, *, parts: Optional[Sequence[str]]
             anchors = smooth_scroll(*anchors, fps=fps, seconds=smooth_seconds,
                                     page_width=layout.width)
 
+        # Each output is (file name, the voice its mix leans on). "ALL" leans on no
+        # voice: render_mix(focus=None) is already the even mix, and render() with no
+        # focus_staff already lights every voice equally. Asking for one part is asking
+        # for one video, so ALL only rides along when the whole score was asked for.
+        mixes = [(name, name) for name in wanted]
+        if combined and with_audio and len(wanted) > 1:
+            mixes.append((COMBINED, None))
+
         tracks: dict = {}
         if with_audio:
-            log(f"Rendering {len(wanted)} audio mix(es)")
-            with ThreadPoolExecutor(max_workers=min(4, len(wanted))) as pool:
-                futures = {name: pool.submit(audio_mod.render_mix, source, name,
+            log(f"Rendering {len(mixes)} audio mix(es)")
+            with ThreadPoolExecutor(max_workers=min(4, len(mixes))) as pool:
+                futures = {name: pool.submit(audio_mod.render_mix, source, focus,
                                              os.path.join(tmp, f"{name}.wav"))
-                           for name in wanted}
+                           for name, focus in mixes}
                 tracks = {name: future.result() for name, future in futures.items()}
 
         if emphasise:
-            for name in wanted:
-                staff = names.index(name) if len(layout.staff_tops) == len(names) else None
+            for name, focus in mixes:
+                staff = (names.index(focus)
+                         if focus and len(layout.staff_tops) == len(names) else None)
                 log(f"{name}: rendering video (emphasised)")
                 out = os.path.join(out_dir, f"{base} {name}.mp4")
                 render(strip, placed, anchors, out, px_per_unit=px_per_unit, width=width,
@@ -214,7 +232,7 @@ def build_videos(mscx_path: str, out_dir: str, *, parts: Optional[Sequence[str]]
         shared = os.path.join(tmp, "shared.mp4")
         render(strip, placed, anchors, shared, px_per_unit=px_per_unit, width=width, fps=fps,
                coverage=coverage)
-        for name in wanted:
+        for name, _focus in mixes:
             out = os.path.join(out_dir, f"{base} {name}.mp4")
             if tracks.get(name):
                 mux(shared, tracks[name], out)

--- a/src/scrollvideo/tests/test_build.py
+++ b/src/scrollvideo/tests/test_build.py
@@ -92,3 +92,25 @@ def test_a_wholesale_drift_is_still_caught(tmp_path):
     late = [NoteEvent(n, t + 10 * ALIGNMENT_TOLERANCE, t + 1)
             for n, t in (("a", 0.0), ("b", 1.0), ("c", 2.0))]
     assert alignment(late, path) < 0.5
+
+
+# --------------------------------------------------------------------------- #
+# The every-voice mix
+# --------------------------------------------------------------------------- #
+
+def test_the_combined_mix_is_named_all_and_is_not_a_part():
+    """ALL is a mix, not a voice: it must never be looked up among the part names."""
+    from src.scrollvideo.build import COMBINED
+    from src.scrollvideo.audio import part_names, set_mix, FOCUS_VOLUME
+    from lxml import etree
+
+    root = etree.fromstring(
+        b"<museScore><Score>"
+        b"<Part><trackName>T1</trackName><Instrument><Channel/></Instrument></Part>"
+        b"<Part><trackName>B1</trackName><Instrument><Channel/></Instrument></Part>"
+        b"</Score></museScore>")
+    assert COMBINED not in part_names(root)
+    # focus=None, which is what ALL renders with, leaves every voice equally loud.
+    set_mix(root, None)
+    volumes = {c.get("value") for c in root.iter("controller")}
+    assert volumes == {str(FOCUS_VOLUME)}


### PR DESCRIPTION
## Summary

Three fixes found by taking *Kaksi laulua krapulasta* through the workflow from scratch — a per-system score, which HANDOFF.md named as the least-exercised path.

- **Per-system cleaning never ran the OCR measure repairs.** It returned before them, so a bar the page prints as 3/4 stayed 4/4 and ran a beat long in the practice track, while an ordinary clean of the same file repaired it.
- **Repairing the length exposed a second bug.** A staff resting through that bar kept a rest written to the old length, so MuseScore played the measure longer than it was engraved. No health check sees that; it surfaced as a scrolling video the renderer refused, 92% of played notes having no highlight. Silence is now re-lengthed with the bar — only its length, not its markup.
- **Divisi written as a chord left the lower singer silent.** Two singers holding a chord are one voice with stacked noteheads; the rebuild gave the upper part both notes. Each declared part now takes its own notehead, and the stack has to really be there.
- **Scrolling videos lost the ALL track** when they became the Record default. `build_videos` writes it from the even mix; `--no-combined` turns it off.

Verified end to end on the song: no health issues, no lyric mismatches, and five 4K videos including ALL. The Virta fixture still builds clean. 196 tests pass (11 new).

## Review

Reviewed at sha `0b6239c` (working tree). Correctness: 3 lanes; architecture: 6 dimensions.

**Verdict: Reconsider** — driven by scope, and the scope findings were acted on.

Fixed:
- The divisi branch fired wherever a staff had fewer voices than declared names — on this song 14 bars with no stack at all, where the lower part started doubling the upper one instead of resting. Now gated on an actual chord stack, which also puts the orphaned `_has_chord_stack` helper to work.
- The ALL video was gated on the score's parts rather than the requested ones, so `--parts T1` still rendered it.
- `_resize_silent_voice` wiped every child of the rest it kept, so a hidden rest would have reappeared.
- `combined` was unreachable from either caller; `scroll_video.py` now has `--no-combined`.
- The `emphasise` path had a duplicated render block; collapsed into the main loop.
- `overfull_measures`' docstring and CLAUDE.md still said the pass never writes anything. They now say what it does.

Skipped:
- **Moving `_resize_silent_voice` out of `overfull_measures.py`** (Right place, 72). Only that loop knows the target and that the override just went, so the trigger belongs there; the invariant is documented instead. Revisit if a second caller ever wants it.
- **Splitting this into three commits** (Scope, 85). Fair, but the second fix only exists because the first one exposed it, and the third is four lines of the diff.

## Beyond the card

- `_resize_silent_voice` (`src/clean_score/utils/overfull_measures.py`) also changes the **ordinary** clean path: four other songs in `songs/` produce different output on a re-clean (18 measures in one of them). It could have shipped separately, but it is what the video renderer's own sync check demanded.
- Counting noteheads as parts (`src/clean_score/utils/per_system.py`) changes what the clean-stage grid form **shows** for any per-system score whose chords stack — the Voices column can now read 2 where it read 1. Answers already recorded are unaffected.
- `--no-combined` on `scroll_video.py` — nobody asked for the knob; it exists so the parameter is reachable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)