### PR TITLE
Apply a song's recorded fixes when it is cleaned

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -124,6 +124,22 @@ staff, measure and chord, and says **why**. Applying is strict: an entry that no
 longer matches raises, so a pipeline change that moves the note fails the build
 instead of quietly leaving the defect in.
 
+**Every song gets this, not just the fixture.** `run_clean` applies
+`<song dir>/fixes.json` right after cleaning (`pipeline.apply_recorded_fixes`), so a
+recorded edit survives a re-clean. Before that it did not: cleaning rebuilds from the
+source, so a hand edit made afterwards vanished the next time anyone cleaned, and the
+same three page-verified rests were typed into Kaksi laulua krapulasta twice in one
+session. Replaying a recorded fix is not the pipeline guessing — the judgement was
+already made and written down. A fix that no longer matches fails the clean with the
+entry named, rather than being skipped.
+
+Three kinds: `undot` and `slur` name a chord, and `append` works on the end of a bar
+(`drop` takes off the rest a scan padded with in place of notes it lost). Appending
+rather than rewriting keeps what the tokens cannot carry — a triplet bracket, a tie —
+and every kind checks what the bar reads **now** (`from`) before touching it, tuplet
+brackets included. A note's spelling is derived from its pitch: the first fixes to
+carry one by hand got three of four wrong.
+
 ```bash
 fixtures/virta-venhetta-vie/reset.sh        # drop it into songs/ at the furthest stage
 fixtures/virta-venhetta-vie/reset.sh 00     # or: just registered, ready to clean

--- a/fixtures/virta-venhetta-vie/build.py
+++ b/fixtures/virta-venhetta-vie/build.py
@@ -9,7 +9,6 @@ one.  Needs MUSESCORE_CLI_PATH (the MusicXML -> .mscx conversion).  The lyric
 text itself is not generated here: 20-lyrics/lyrics.json is a committed
 artifact (see STEPS.md, step 3).
 """
-import json
 import os
 import shutil
 import sys
@@ -69,22 +68,15 @@ def main() -> int:
 
     # --- Stage: clean (server.py api_clean) -------------------------------
     print("clean:")
+    # Score edits a person authorised go in beside the song first: cleaning applies
+    # them itself, the same way it does for any song, so this build exercises that
+    # path rather than a second copy of it.
+    src_fixes = os.path.join(FIXTURE, "10-cleaned", "fixes.json")
+    if os.path.exists(src_fixes):
+        shutil.copyfile(src_fixes, song.path("fixes.json"))
     xml = song.source_path("xml")
     cleaned, _ = pipeline.run_clean(xml, song.dir, per_system=(song.mode == "per-system"), log=print)
     song.data["cleaned"] = os.path.relpath(cleaned, song.dir)
-    # Score edits a person authorised, applied before the health check so the
-    # snapshot shows the score as it stands after the manual step.
-    src_fixes = os.path.join(FIXTURE, "10-cleaned", "fixes.json")
-    if os.path.exists(src_fixes):
-        from lxml import etree
-        from src.clean_score.utils.score_fixes import apply_fixes
-        with open(src_fixes, encoding="utf-8") as f:
-            entries = json.load(f)
-        tree = etree.parse(cleaned)
-        for line in apply_fixes(tree.getroot(), entries):
-            print("  fix:", line[:100])
-        tree.write(cleaned, encoding="UTF-8", xml_declaration=True)
-        shutil.copyfile(src_fixes, song.path("fixes.json"))
 
     song.data["cleaned_fingerprint"] = state.file_fingerprint(cleaned)
     found = health.scan(cleaned)

--- a/src/clean_score/tests/test_score_fixes.py
+++ b/src/clean_score/tests/test_score_fixes.py
@@ -93,3 +93,84 @@ def test_the_fixtures_recorded_fix_still_applies():
     m26 = staff.findall("Measure")[25]
     v = m26.find("voice") if m26.find("voice") is not None else m26
     assert _voice_len(v) == Fraction(1)       # 4/4, like the other three voices
+
+
+# --------------------------------------------------------------------------- #
+# Writing a bar: the edits undot and slur cannot express
+# --------------------------------------------------------------------------- #
+
+def _tokens(root):
+    from src.clean_score.utils.score_fixes import _bar_tokens
+    return _bar_tokens(root.find(".//Measure"))
+
+
+def test_append_leaves_the_start_of_the_bar_alone():
+    """What the tokens cannot say — a triplet bracket, a tie — has to survive."""
+    root = _score([("quarter", 0, 60)])
+    voice = root.find(".//voice")
+    etree.SubElement(voice, "Tuplet")
+    apply_fixes(root, [{"kind": "append", "staff": 3, "measure": 1,
+                        "from": ["quarter:60", "[tuplet"], "add": ["quarter:57"],
+                        "why": "x"}])
+    assert _tokens(root) == ["quarter:60", "[tuplet", "quarter:57"]
+    assert voice.find("Tuplet") is not None
+
+
+def test_a_triplet_bracket_is_part_of_what_the_bar_reads():
+    """Two bars differing only by a bracket are different bars; the fix must not apply."""
+    root = _score([("quarter", 0, 60)])
+    etree.SubElement(root.find(".//voice"), "Tuplet")
+    with pytest.raises(FixError):
+        apply_fixes(root, [{"kind": "append", "staff": 3, "measure": 1,
+                            "from": ["quarter:60"], "add": ["quarter:57"], "why": "x"}])
+
+
+def test_append_can_drop_the_padding_the_scan_left():
+    """A scan that loses notes pads with a rest; appending alone overfills the bar."""
+    root = _score([("quarter", 0, 60)])
+    etree.SubElement(etree.SubElement(root.find(".//voice"), "Rest"),
+                     "durationType").text = "half"
+    apply_fixes(root, [{"kind": "append", "staff": 3, "measure": 1,
+                        "from": ["quarter:60", "half:R"], "drop": 1,
+                        "add": ["quarter:59", "quarter:57"], "why": "x"}])
+    assert _tokens(root) == ["quarter:60", "quarter:59", "quarter:57"]
+
+
+def test_drop_refuses_to_take_a_note_off():
+    """Removing a note is a musical decision, and can strand a tie or a bracket."""
+    root = _score([("quarter", 0, 60), ("quarter", 0, 62)])
+    with pytest.raises(FixError):
+        apply_fixes(root, [{"kind": "append", "staff": 3, "measure": 1,
+                            "from": ["quarter:60", "quarter:62"], "drop": 1,
+                            "add": ["quarter:59"], "why": "x"}])
+    assert _tokens(root) == ["quarter:60", "quarter:62"]
+
+
+def test_a_bar_that_no_longer_reads_as_recorded_raises():
+    """A pipeline change that moves this bar must fail the build, not overwrite it."""
+    root = _score([("quarter", 0, 60)])
+    with pytest.raises(FixError) as caught:
+        apply_fixes(root, [{"kind": "append", "staff": 3, "measure": 1,
+                            "from": ["half:60"], "add": ["quarter:60"], "why": "x"}])
+    assert "staff 3 m1" in str(caught.value)      # says which entry, not just what
+    assert _tokens(root) == ["quarter:60"]        # and nothing was written
+
+
+def test_the_spelling_is_derived_from_the_pitch():
+    """Hand-written spellings were wrong three times out of four, so there is no field."""
+    root = _score([("quarter", 0, 60)])
+    apply_fixes(root, [{"kind": "append", "staff": 3, "measure": 1,
+                        "from": ["quarter:60"],
+                        "add": ["quarter:57", "quarter:59"], "why": "x"}])
+    tpcs = [n.findtext("tpc") for n in root.findall(".//Note")]
+    assert tpcs[1:] == ["17", "19"]               # A and B, not G and A
+
+
+def test_a_whole_bar_rest_can_be_read_but_not_written():
+    """It needs the bar's own length, which a recorded fix has no way to know."""
+    root = _score([])
+    etree.SubElement(etree.SubElement(root.find(".//voice"), "Rest"),
+                     "durationType").text = "measure"
+    with pytest.raises(FixError):
+        apply_fixes(root, [{"kind": "append", "staff": 3, "measure": 1,
+                            "from": ["measure:R"], "add": ["measure:R"], "why": "x"}])

--- a/src/clean_score/utils/score_fixes.py
+++ b/src/clean_score/utils/score_fixes.py
@@ -11,12 +11,32 @@ erases. Each entry carries a `why`, because six months later the diff will not s
 why a note lost its dot.
 
     [{"kind": "undot", "staff": 3, "measure": 26, "index": 0, "why": "..."},
-     {"kind": "slur",  "staff": 4, "measure": 32, "index": 0, "span": 1, "why": "..."}]
+     {"kind": "slur",  "staff": 4, "measure": 32, "index": 0, "span": 1, "why": "..."},
+     {"kind": "append", "staff": 2, "measure": 73,
+      "from": ["eighth:50", "eighth:50", "eighth:50", "eighth:R"],
+      "add":  ["quarter:R"],
+      "why": "..."}]
 
 `staff` and `measure` are 1-based and refer to the **cleaned** score, where each
 staff carries one voice. `index` counts chords in that measure from 0. Applying is
 strict: an entry that does not match raises, because a silently skipped fix would
 leave the score looking repaired when it is not.
+
+`append` works on the end of a bar, which is where every edit the other two kinds
+cannot express has landed so far: the trailing rest an engraver drew once for two
+voices, or the notes a scan dropped and padded over (`"drop": 1` takes the padding
+rest off first). `from` is what the bar reads **now**, and the fix refuses to apply
+unless it still reads that way — so a pipeline change that alters the bar fails the
+build instead of quietly writing an old answer over a new one.
+
+Tokens are `duration[.]:pitch` (`eighth:50`, `quarter.:60` for a dotted quarter),
+`duration[.]:R` for a rest, and `+` between the notes of a chord. `[tuplet` and
+`tuplet]` mark a triplet bracket: they appear in `from` and cannot be written. A
+whole-bar rest reads as `measure:R` and cannot be written either — it needs the bar's
+own length, which a fix has no way to know, so write the rests out instead. The
+note's **spelling** (MuseScore's tpc) is derived from the pitch and is deliberately
+not part of the token: the first fixes to carry one by hand got three of four wrong,
+which puts a note on the wrong line while it still sounds right.
 """
 import logging
 from fractions import Fraction
@@ -38,7 +58,7 @@ class FixError(ValueError):
     """A recorded fix does not match the score it was recorded against."""
 
 
-def _chords(root: etree._Element, staff_id: int, measure_no: int) -> List[etree._Element]:
+def _measure(root: etree._Element, staff_id: int, measure_no: int) -> etree._Element:
     staves = [s for s in root.findall(".//Score/Staff")
               if s.get("id") == str(staff_id) and s.find("Measure") is not None]
     if not staves:
@@ -46,7 +66,11 @@ def _chords(root: etree._Element, staff_id: int, measure_no: int) -> List[etree.
     measures = staves[0].findall("Measure")
     if measure_no < 1 or measure_no > len(measures):
         raise FixError(f"staff {staff_id} has no measure {measure_no}")
-    measure = measures[measure_no - 1]
+    return measures[measure_no - 1]
+
+
+def _chords(root: etree._Element, staff_id: int, measure_no: int) -> List[etree._Element]:
+    measure = _measure(root, staff_id, measure_no)
     body = measure.find("voice") if measure.find("voice") is not None else measure
     return [el for el in body if el.tag == "Chord"]
 
@@ -83,23 +107,133 @@ def _slur(chords: List[etree._Element], start: int, span: int) -> str:
     return f"slurred {span} note(s) from chord {start}"
 
 
+# A bar as tokens, so a recorded fix can say what it expects to find and what it
+# should read afterwards. Rests are "R"; a chord's notes join with "+". Tuplet
+# brackets are marked, because two bars that differ only by one are different bars
+# and a fix recorded against the other one must not quietly apply.
+
+
+def _token(el: etree._Element) -> str:
+    dur = (el.findtext("durationType") or "").strip()
+    dots = int((el.findtext("dots") or "0").strip() or 0)
+    dur += "." * dots
+    if el.tag == "Rest":
+        return f"{dur}:R"
+    return f"{dur}:" + "+".join(n.findtext("pitch") or "?" for n in el.findall("Note"))
+
+
+_MARKERS = {"Tuplet": "[tuplet", "endTuplet": "tuplet]"}
+
+
+def _bar_tokens(measure: etree._Element) -> List[str]:
+    body = measure.find("voice") if measure.find("voice") is not None else measure
+    out: List[str] = []
+    for el in body:
+        if el.tag in ("Chord", "Rest"):
+            out.append(_token(el))
+        elif el.tag in _MARKERS:
+            out.append(_MARKERS[el.tag])
+    return out
+
+
+def _write_token(voice: etree._Element, token: str) -> None:
+    dur, _, notes = token.partition(":")
+    dots = dur.count(".")
+    dur = dur.replace(".", "")
+    if dur == "measure":
+        raise FixError(
+            f"cannot write {token!r}: a measure rest needs the bar's own length, which a "
+            "fix cannot know. Write the rests out (e.g. 'quarter:R'). Reading one in a "
+            "'from' list is fine.")
+    if dur not in _DUR:
+        raise FixError(f"unknown duration {dur!r} in {token!r}")
+    el = etree.SubElement(voice, "Rest" if notes.strip().upper() == "R" else "Chord")
+    etree.SubElement(el, "durationType").text = dur
+    if dots:
+        etree.SubElement(el, "dots").text = str(dots)
+    if el.tag == "Chord":
+        for part in notes.split("+"):
+            try:
+                pitch_no = int(part)
+            except ValueError:
+                raise FixError(f"bad pitch {part!r} in {token!r}")
+            note = etree.SubElement(el, "Note")
+            etree.SubElement(note, "pitch").text = str(pitch_no)
+            etree.SubElement(note, "tpc").text = str(_SPELLING[pitch_no % 12])
+
+
+# MuseScore's tpc is the note's spelling: 14 is C and each step of one is a fifth
+# up, so 15 is G and 21 is C sharp. Derived from the pitch, never written by hand —
+# the first fixes to carry a hand-written spelling got three of four values wrong,
+# which puts the note on the wrong line of the staff while sounding correct.
+_SPELLING = {0: 14, 1: 21, 2: 16, 3: 23, 4: 18, 5: 13,
+             6: 20, 7: 15, 8: 22, 9: 17, 10: 24, 11: 19}
+
+
+def _append_bar(measure: etree._Element, expect: List[str], add: List[str],
+                drop: int = 0) -> str:
+    """Work on the end of a bar, leaving the rest of it exactly as it was.
+
+    Every recorded fix so far concerns the end of a bar: the rest an engraver drew
+    once for two voices, or the notes a scan dropped and padded over. Working there
+    keeps whatever came earlier — a triplet bracket, a tie — which a fix that rewrote
+    the bar from tokens could not carry.
+
+    `drop` takes that many rests off the end first, for the common case where the scan
+    padded with a rest in place of the notes it lost: appending alone would leave the
+    padding and overfill the bar. Only rests: dropping a note is a musical decision
+    that wants writing out, and a dropped note can leave a tie or a tuplet bracket
+    pointing at nothing.
+    """
+    found = _bar_tokens(measure)
+    if found != list(expect):
+        raise FixError(f"bar reads {found} now, but the fix was recorded against {list(expect)}")
+    body = measure.find("voice")
+    if body is None:
+        body = etree.SubElement(measure, "voice")
+    if drop:
+        items = [el for el in body if el.tag in ("Chord", "Rest")]
+        if drop > len(items):
+            raise FixError(f"cannot drop {drop} from a bar with {len(items)} notes/rests")
+        going = items[-drop:]
+        not_rests = [el.tag for el in going if el.tag != "Rest"]
+        if not_rests:
+            raise FixError(
+                f"drop only takes rests off the end; this would remove {not_rests}. "
+                "Removing a note is a musical decision — write the bar out by hand.")
+        for el in going:
+            body.remove(el)
+    for token in add:
+        _write_token(body, token)
+    dropped = f"dropped the last {drop} and " if drop else ""
+    return f"{dropped}added {list(add)} to the end of the bar"
+
+
 def apply_fixes(root: etree._Element, fixes: List[Dict]) -> List[str]:
     """Apply each recorded fix. Returns one line per fix, for the build log."""
     done: List[str] = []
     for fix in fixes:
         kind = fix.get("kind")
         staff, measure = int(fix["staff"]), int(fix["measure"])
-        index = int(fix.get("index", 0))
-        chords = _chords(root, staff, measure)
-        if index >= len(chords):
-            raise FixError(
-                f"staff {staff} m{measure} has {len(chords)} chords, no index {index}")
-        if kind == "undot":
-            what = _undot(chords[index])
-        elif kind == "slur":
-            what = _slur(chords, index, int(fix.get("span", 1)))
-        else:
-            raise FixError(f"unknown fix kind {kind!r}")
+        try:
+            if kind == "append":
+                # No chord index: a bar this fix repairs may have no chords at all yet.
+                what = _append_bar(_measure(root, staff, measure), fix.get("from", []),
+                                   fix.get("add", []), int(fix.get("drop", 0)))
+            elif kind in ("undot", "slur"):
+                index = int(fix.get("index", 0))
+                chords = _chords(root, staff, measure)
+                if index >= len(chords):
+                    raise FixError(
+                        f"staff {staff} m{measure} has {len(chords)} chords, no index {index}")
+                what = (_undot(chords[index]) if kind == "undot"
+                        else _slur(chords, index, int(fix.get("span", 1))))
+            else:
+                raise FixError(f"unknown fix kind {kind!r}")
+        except FixError as exc:
+            # Say which entry, not just what went wrong: two bars of the same song can
+            # read identically, and the message is all the reader gets.
+            raise FixError(f"staff {staff} m{measure} ({kind}): {exc}") from None
         line = f"staff {staff} m{measure}: {what} — {fix.get('why', 'no reason recorded')}"
         logger.debug(line)
         done.append(line)

--- a/src/song_app/pipeline.py
+++ b/src/song_app/pipeline.py
@@ -6,6 +6,7 @@ non-interactively. No musical logic lives here; this only orchestrates.
 
 from __future__ import annotations
 
+import json
 import os
 import shutil
 import subprocess
@@ -20,6 +21,7 @@ from src.clean_score.main import main as clean_main
 from src.clean_score import lyric_txt
 from src.clean_score.lyric_txt import LyricImport, import_file
 from src.clean_score.utils import per_system
+from src.clean_score.utils.score_fixes import FixError, apply_fixes
 
 MUSESCORE_EXTS = (".mscz", ".mscx", ".musicxml", ".xml")
 Logger = Callable[[str], None]
@@ -116,17 +118,75 @@ def run_clean(
     base = os.path.splitext(os.path.basename(mscx_path))[0]
     cleaned = os.path.join(out_dir, base + "_cleaned.mscx")
     log("Cleaning score" + (" (per-system)" if per_system else ""))
+    # Build beside the real file and move it in only once the recorded fixes have
+    # gone back on. A fix that no longer matches then leaves the previous cleaned
+    # score exactly where it was, instead of a freshly rebuilt one with the
+    # page-verified edits missing and nothing on disk saying so.
+    building = cleaned + ".building"
     clean_main(
-        mscx_path, cleaned,
+        mscx_path, building,
         add_staffs=add_staffs or "",
         interactive=False,
         per_system=per_system,
         voicing=voicing,
     )
-    if not os.path.exists(cleaned):
+    if not os.path.exists(building):
         raise RuntimeError("Cleaning produced no output (no parts declared?).")
+    try:
+        apply_recorded_fixes(building, out_dir, log)
+    except Exception:
+        os.remove(building)
+        raise
+    os.replace(building, cleaned)
     log("Cleaned score written.")
     return cleaned, mscx_path
+
+
+def apply_recorded_fixes(cleaned_path: str, song_dir: str, log: Logger = _noop) -> int:
+    """Re-apply the song's authorised score edits (`fixes.json`). Returns how many.
+
+    Cleaning rebuilds the score from the source, so a hand edit made after the last
+    clean is gone the moment anyone cleans again — which is how three page-verified
+    rests had to be typed in twice on Kaksi laulua krapulasta. A recorded fix is a
+    judgement someone already made about the printed page, so replaying it is not
+    the pipeline guessing; it is the pipeline not forgetting.
+
+    Strict on purpose: if a fix no longer matches the bar it was recorded against,
+    this raises rather than skipping it. A silently dropped fix leaves a score
+    looking repaired when it is not, and the whole point of the file is that nothing
+    downstream can tell the difference.
+    """
+    path = os.path.join(song_dir, "fixes.json")
+    if not os.path.exists(path):
+        return 0
+    try:
+        with open(path, encoding="utf-8") as f:
+            entries = json.load(f)
+    except ValueError as exc:
+        raise RuntimeError(f"fixes.json is not valid JSON: {exc}") from exc
+    if not entries:
+        return 0
+    # Every entry has to be applicable. Skipping the ones that are not would leave a
+    # score looking repaired when it is not — which is the failure this file exists
+    # to prevent — and an entry with a mistyped key would vanish in silence.
+    unusable = [e for e in entries if not isinstance(e, dict) or not e.get("kind")]
+    if unusable:
+        raise RuntimeError(
+            f"{len(unusable)} entry/entries in fixes.json have no 'kind' and cannot be "
+            f"applied: {unusable[:1]}. Give each one a kind, or take it out of the file.")
+    tree = etree.parse(cleaned_path)
+    try:
+        lines = apply_fixes(tree.getroot(), entries)
+    except FixError as exc:
+        raise RuntimeError(
+            f"A recorded fix in fixes.json no longer matches the score: {exc}. "
+            "Re-read the page and update (or remove) that entry before cleaning again."
+        ) from exc
+    tree.write(cleaned_path, encoding="UTF-8", xml_declaration=True)
+    log(f"Re-applied {len(lines)} recorded fix(es) from fixes.json")
+    for line in lines:
+        log("  " + line[:120])
+    return len(lines)
 
 
 def strip_lyrics_copy(mscx_path: str) -> str:


### PR DESCRIPTION
## Summary

`fixes.json` records score edits authorised after reading the printed page, each with its reason — but for a song, nothing read it. Cleaning rebuilds from the source, so every re-clean discarded the edits; the same three page-verified rests were typed into *Kaksi laulua krapulasta* twice in one session. `run_clean` now applies the song folder's `fixes.json` itself.

- A failed fix is a **no-op**: the clean builds beside the real file and moves it in only once the fixes are back on, so a stale entry leaves the previous cleaned score untouched instead of a rebuilt one with the edits silently missing.
- New `append` kind (with `drop`) for the edits `undot`/`slur` cannot express. It appends rather than rewriting the bar, because the tokens cannot carry a triplet bracket or a tie — both of which sit in the bar *Laulun aika* needed repaired.
- The fixture build now puts its `fixes.json` beside the song and lets cleaning apply it, exercising the same path every song uses.

Verified by round-tripping two real songs: clean → fixes re-applied by themselves → no health issues → lyrics import with zero mismatches. The Virta fixture still builds clean (2 fixes re-applied, 0 issues, 0 mismatches). 203 tests pass; the 5 browser failures and 3 `test_record_panel_ui` errors are pre-existing on `main` (verified by stashing this change).

## Review

Reviewed at sha `64343dc` (working tree). Two correctness lanes plus one architecture lane covering all six dimensions — combined into one lane because the diff is ~250 lines on a single mechanism; noted here rather than left implicit.

**Verdict: Reconsider** — the UX dimension found a bug I had already shipped into a song, and it was right.

Fixed:
- **Three of four hand-written note spellings were wrong** (`tpc` 15 for A, 17 for B), which puts a note on the wrong line of the staff while it still sounds right — and they were already baked into *Laulun aika*'s cleaned score and its 4K videos. The `@tpc` field is gone; spelling is derived from the pitch, which was correct in every observed case. Song re-cleaned and re-rendered.
- **`set-bar` deleted.** It was subsumed by `append`+`drop` and destroyed exactly the markup the other kind exists to preserve.
- **A tuplet bracket is now part of what a bar reads**, so a `from` check can no longer pass against a bar that differs by one. This immediately caught a stale entry of my own.
- **`drop` refuses anything but a rest** — removing a note can strand a tie or a bracket.
- **A whole-bar rest can be read but not written** (it needs the bar's length, which a fix cannot know).
- **Entries without a `kind` now raise** instead of being skipped, which was the one behaviour the module's own docstring forbids.
- **Errors name the entry** (staff, measure, kind): two bars of one song can read identically.
- Dead `import json` removed from the fixture build; docs corrected where they overstated what the pass does.

Skipped:
- **Dropping the `+` chord syntax** (Over-engineering, 78) — no recorded fix writes a chord yet, but `from` must read one to match a divisi bar, and removing write support while keeping read support is a worse asymmetry than the unused branch.
- **An assertion that `out_dir` is the song directory** (Right place, 72) — true for all five callers; noted rather than enforced.

## Beyond the card

- The `append`/`drop` kind and the bar-token reader (`src/clean_score/utils/score_fixes.py`) are a new capability, not just a replay mechanism — but no recorded fix in the repo could be replayed without them.
- The fixture build rewrite (`fixtures/virta-venhetta-vie/build.py`) could have shipped separately; it is what proves the production path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)