### PR TITLE
Make the full test suite reproducibly green

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,10 +69,7 @@ backup/                  Gitignored .mscz backups (created by backup.sh)
 - Install deps: `.venv/bin/pip install -r pip-requirements.txt`
   (lxml, pytest, dotenv, google-api-python-client, google-auth-oauthlib, pillow,
   pyautogui, fastapi, uvicorn, python-multipart; recording also needs
-  `obsws-python`, `ffmpeg`/`ffprobe` on PATH, and macOS with MuseScore 3 +
-  QuickRecorder). **Dependency-file gap:** `create_video.py` imports
-  `obsws_python`, but `obsws-python` is not currently listed in
-  `pip-requirements.txt`; install it separately in a fresh environment.
+  `ffmpeg`/`ffprobe` on PATH, and macOS with MuseScore 3 + QuickRecorder).
 - Config is via `.env` (falls back to `.env.default`). Keys:
   `MUSESCORE_CLI_PATH`, `MUSESCORE_EXPORT_PATH`, `VIDEO_EXPORT_PATH`,
   `YOUTUBE_CLIENT_SECRETS_PATH`. Never commit real secrets;

--- a/SETUP.md
+++ b/SETUP.md
@@ -34,9 +34,6 @@ do `from src...import`, so **run them from the repo root** — `./song.py`,
 `./clean_score.py`, not from inside `src/`. Use `.venv/bin/python` directly
 rather than activating.
 
-If you plan to use the old screen recorder, also `pip install obsws-python` —
-`create_video.py` imports it but it is not in `pip-requirements.txt`.
-
 ## 3. Things that are not pip packages
 
 ```bash

--- a/fixtures/virta-venhetta-vie/00-registered/.song.json
+++ b/fixtures/virta-venhetta-vie/00-registered/.song.json
@@ -5,7 +5,7 @@
   "mode": "normal",
   "sources": {
     "xml": "Virta-venhetta-vie.xml",
-    "pdf": "Virta venhettä vie.pdf"
+    "pdf": "Virta venhettä vie.pdf"
   },
   "created_at": 1787475359.460669,
   "updated_at": 1787475359.462615

--- a/fixtures/virta-venhetta-vie/10-cleaned/.song.json
+++ b/fixtures/virta-venhetta-vie/10-cleaned/.song.json
@@ -5,7 +5,7 @@
   "mode": "normal",
   "sources": {
     "xml": "Virta-venhetta-vie.xml",
-    "pdf": "Virta venhettä vie.pdf"
+    "pdf": "Virta venhettä vie.pdf"
   },
   "created_at": 1787475359.460669,
   "updated_at": 1787493656.879068,

--- a/fixtures/virta-venhetta-vie/20-lyrics/.song.json
+++ b/fixtures/virta-venhetta-vie/20-lyrics/.song.json
@@ -5,7 +5,7 @@
   "mode": "normal",
   "sources": {
     "xml": "Virta-venhetta-vie.xml",
-    "pdf": "Virta venhettä vie.pdf"
+    "pdf": "Virta venhettä vie.pdf"
   },
   "created_at": 1787475359.460669,
   "updated_at": 1787493656.9092,

--- a/src/song_app/tests/test_bounds_api.py
+++ b/src/song_app/tests/test_bounds_api.py
@@ -40,6 +40,9 @@ def client(tmp_path, monkeypatch):
 
 
 def test_bounds_come_back_with_the_score_count_to_check_against(client):
+    song = state.load(SLUG)
+    assert os.path.isfile(song.source_path("pdf")), (
+        "the overlaid fixture must retain a portable reference to its source PDF")
     r = client.get(f"/api/songs/{SLUG}/bounds")
     assert r.status_code == 200
     data = r.json()

--- a/src/song_app/tests/test_record_panel_ui.py
+++ b/src/song_app/tests/test_record_panel_ui.py
@@ -13,10 +13,10 @@ import time
 import pytest
 
 pytest.importorskip("playwright.sync_api")
+pytest.importorskip("pytest_playwright")
 pytest.importorskip("uvicorn")
 
 import uvicorn
-from playwright.sync_api import sync_playwright
 
 from src.song_app import server, state
 
@@ -67,24 +67,20 @@ def live(tmp_path_factory):
 
 
 @pytest.fixture
-def page(live):
+def record_panel(live, page):
     base, slug = live
-    with sync_playwright() as p:
-        browser = p.chromium.launch()
-        page = browser.new_page()
-        errors = []
-        page.on("pageerror", lambda e: errors.append(str(e)))
-        page.goto(f"{base}/#/song/{slug}")
-        page.wait_for_selector(".stagebar")
-        page.locator(".stagebar .step", has_text="Record").click()
-        page.wait_for_selector("text=How to make the videos")
-        yield page, slug, errors
-        assert not errors, f"the panel raised: {errors}"
-        browser.close()
+    errors = []
+    page.on("pageerror", lambda e: errors.append(str(e)))
+    page.goto(f"{base}/#/song/{slug}")
+    page.wait_for_selector(".stagebar")
+    page.locator(".stagebar .step", has_text="Record").click()
+    page.wait_for_selector("text=How to make the videos")
+    yield page, slug, errors
+    assert not errors, f"the panel raised: {errors}"
 
 
-def test_the_panel_offers_both_renderers_and_starts_on_the_scrolling_one(page):
-    view, _, _ = page
+def test_the_panel_offers_both_renderers_and_starts_on_the_scrolling_one(record_panel):
+    view, _, _ = record_panel
     assert view.get_by_text("Scrolling score", exact=True).is_visible()
     assert view.get_by_text("Screen recording", exact=True).is_visible()
     radios = view.locator("input[type=radio][name=renderer]")
@@ -93,8 +89,8 @@ def test_the_panel_offers_both_renderers_and_starts_on_the_scrolling_one(page):
     assert view.get_by_role("button", name="Render videos").is_visible()
 
 
-def test_choosing_the_screen_recorder_swaps_the_controls(page):
-    view, _, _ = page
+def test_choosing_the_screen_recorder_swaps_the_controls(record_panel):
+    view, _, _ = record_panel
     size = view.locator("select")           # the size choice, scrolling renderer only
     assert size.is_visible() and size.input_value() == "4k"
     assert not view.get_by_text("Audio sync offset (ms)").is_visible()
@@ -105,9 +101,9 @@ def test_choosing_the_screen_recorder_swaps_the_controls(page):
     assert not size.is_visible(), "the size choice does not apply to screen recording"
 
 
-def test_the_run_button_posts_the_chosen_renderer(page):
+def test_the_run_button_posts_the_chosen_renderer(record_panel):
     """What the server branches on has to actually leave the browser."""
-    view, slug, _ = page
+    view, slug, _ = record_panel
     sent = []
     view.route(f"**/api/songs/{slug}/record", lambda route: (
         sent.append(json.loads(route.request.post_data or "{}")),

--- a/src/song_app/tests/test_record_panel_ui.py
+++ b/src/song_app/tests/test_record_panel_ui.py
@@ -12,9 +12,26 @@ import time
 
 import pytest
 
-pytest.importorskip("playwright.sync_api")
-pytest.importorskip("pytest_playwright")
+_NEEDS = "pip install pytest-playwright && playwright install chromium"
+pytest.importorskip("playwright.sync_api", reason=_NEEDS)
+pytest.importorskip("pytest_playwright", reason=_NEEDS)
 pytest.importorskip("uvicorn")
+
+
+def _browser_installed() -> bool:
+    """Launching is the only honest check; see test_ui_flow for why it runs here."""
+    from playwright.sync_api import sync_playwright
+
+    try:
+        with sync_playwright() as p:
+            p.chromium.launch().close()
+        return True
+    except Exception:
+        return False
+
+
+if not _browser_installed():
+    pytest.skip(_NEEDS, allow_module_level=True)
 
 import uvicorn
 

--- a/src/stemmanauha/create_video.py
+++ b/src/stemmanauha/create_video.py
@@ -7,7 +7,6 @@ import subprocess
 from pathlib import Path
 import unicodedata
 from dotenv import load_dotenv
-import obsws_python as obs  # This is how you originally used it — and it works
 import logging
 
 from .upload_to_youtube import get_authenticated_service, upload_to_youtube


### PR DESCRIPTION
Closes #13

## Summary

- keep OBS optional by removing an unused eager import
- reuse pytest-playwright's session instead of nesting a second synchronous Playwright loop
- make the Virta fixture's PDF references portable across Unicode-normalizing filesystems

## Verification

- focused failure-producing order: 22 passed
- documented full suite: 246 passed

AgentDeck session: https://bazzite.taile8d16e.ts.net/sessions/codex:codex:01a03206-2712-7242-95bd-904a3d496b96
