### PR TITLE
Stop agent worktrees from blocking the deploy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,12 @@ playlists.txt
 # per-system answer cache (local testing convenience)
 .persystem_cache.json
 
+# Agent worktrees (the poller checks an issue out into .worktrees/issue-N).
+# Untracked, they made `git status --porcelain` non-empty, and the unattended
+# deploy reads that as "someone is editing the checkout" and refuses — so the
+# live app stopped deploying for as long as any agent was working here.
+.worktrees/
+
 # Working input score files dropped at the repo root (PDFs, MusicXML, MuseScore)
 /*.pdf
 /*.xml

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1011,6 +1011,16 @@ that work or ship a commit GitHub has never seen. Nothing to deploy is a no-op w
 restart, deliberately: a restart is the evidence a release waits for, so a spurious one
 would tell the board a merge had reached the host when it had not.
 
+"Dirty" has to mean *a person edited the checkout*, and one thing that is not that
+used to trip it: the poller checks each issue out into `.worktrees/issue-N` **inside
+this repo**, so `git status --porcelain` listed an untracked `.worktrees/` and the
+deploy refused for as long as any agent was working. It refused silently as far as the
+board was concerned — the timer failed every two minutes, the app kept serving old
+code, and the card that had just merged was told its production deploy had failed. This
+change gitignores `.worktrees/`. A worktree is a separate working directory, so a
+fast-forward of `main` cannot disturb one; leaving it visible bought nothing and cost
+every deploy made while a card was open.
+
 `/healthz` exists for that watcher. It returns `{"status": "ok"}` and touches nothing —
 it has to answer while a clean or a video render is occupying the worker threads.
 

--- a/src/song_app/tests/test_deploy_guard.py
+++ b/src/song_app/tests/test_deploy_guard.py
@@ -1,0 +1,33 @@
+"""What the unattended deploy is allowed to call a dirty checkout.
+
+`scripts/deploy-song-app.sh` refuses to deploy when `git status --porcelain` says
+anything, on the reasoning that someone is editing the live checkout. The poller
+checks each issue out into `.worktrees/issue-N` inside this repo, so that folder
+must be ignored or every deploy made while a card is open refuses — quietly, since
+the app keeps serving the old code and only the timer's journal says why.
+"""
+import subprocess
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[3]
+
+
+def _git(*args: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ["git", *args], cwd=REPO, capture_output=True, text=True, check=False
+    )
+
+
+def test_agent_worktrees_are_ignored():
+    result = _git("check-ignore", "-q", ".worktrees/issue-1")
+    assert result.returncode == 0, (
+        "A poller worktree under .worktrees/ shows up as an untracked file, and the "
+        "unattended deploy reads any untracked file as a dirty checkout and refuses."
+    )
+
+
+def test_the_deploy_refuses_on_a_dirty_checkout():
+    """The refusal itself is deliberate — this pins that we did not weaken it."""
+    script = (REPO / "scripts" / "deploy-song-app.sh").read_text()
+    assert 'git status --porcelain' in script
+    assert 'checkout is dirty' in script


### PR DESCRIPTION
Follow-up on #11 (`/claude check this` on the failed production deploy).

The beat marker merged in #12 is fine and is running on the host. The deploy failure was unrelated: `scripts/deploy-song-app.sh --unattended` refuses whenever `git status --porcelain` says anything, and the poller checks each issue out into `.worktrees/issue-N` **inside this repo**. That untracked folder made the timer refuse every two minutes for as long as any card was open, so the live checkout drifted behind `origin/main` while the board was told a merged card's deploy had failed.

This gitignores `.worktrees/`. A worktree is a separate working directory, so a fast-forward of `main` cannot disturb one — leaving it visible bought nothing and cost every deploy made while a card was open. The refusal itself is untouched: a real hand-edit still stops the deploy.

Verification:

- With the rule applied to the live checkout, `git status --porcelain` goes from `?? .worktrees/` to empty, so the script's dirty check passes.
- `src/song_app/tests/test_deploy_guard.py` pins both halves — the worktree path is ignored, and the dirty refusal is still in the script.
- `.venv/bin/python -m pytest src/song_app/tests/ -q -m "not browser"` — 61 passed.

I did not run the deploy itself; that is the host's timer to do after merge.

AgentDeck session: https://bazzite.taile8d16e.ts.net/sessions/claude_code:main:987ecd2a-e6c5-4ff5-b88d-bedff3065d9a

🤖 Generated with [Claude Code](https://claude.com/claude-code)
