### PR TITLE
Fix Verovio recording in background workers

### DIFF
--- a/src/scrollvideo/engrave.py
+++ b/src/scrollvideo/engrave.py
@@ -8,6 +8,7 @@ same ids. This module owns that pairing; nothing else touches verovio.
 from __future__ import annotations
 
 from dataclasses import dataclass
+from importlib.resources import files
 from typing import Dict, List
 
 import verovio
@@ -37,6 +38,11 @@ OPTIONS = {
     "xmlIdSeed": XML_ID_SEED,
 }
 
+# The native library does not carry the package's default resource path into the
+# executor thread used by the song app. Give each toolkit its bundled fonts
+# explicitly wherever engraving runs.
+RESOURCE_PATH = str(files("verovio") / "data")
+
 
 @dataclass(frozen=True)
 class Engraving:
@@ -52,7 +58,9 @@ class Engraving:
 
 def engrave(musicxml_path: str, options: Dict | None = None) -> Engraving:
     """Render `musicxml_path` as one system and return SVG + geometry + timemap."""
-    tk = verovio.toolkit()
+    tk = verovio.toolkit(False)
+    if not tk.setResourcePath(RESOURCE_PATH):
+        raise RuntimeError(f"Verovio could not load its resources from {RESOURCE_PATH}")
     tk.setOptions({**OPTIONS, **(options or {})})
     if not tk.loadFile(musicxml_path):
         raise RuntimeError(f"Verovio could not load {musicxml_path}")

--- a/src/scrollvideo/tests/test_geometry.py
+++ b/src/scrollvideo/tests/test_geometry.py
@@ -1,5 +1,7 @@
 """Reading a verovio SVG: where the notes are, and turning the page into pixels."""
 
+from concurrent.futures import ThreadPoolExecutor
+
 import numpy as np
 import pytest
 from lxml import etree
@@ -47,6 +49,13 @@ def test_layout_uses_the_definition_scale_viewbox_not_the_root_size():
 def test_parse_layout_rejects_a_non_verovio_svg():
     with pytest.raises(ValueError):
         parse_layout('<svg xmlns="http://www.w3.org/2000/svg"><g/></svg>')
+
+
+def test_engrave_loads_fonts_in_a_worker_thread(fermata_musicxml):
+    """The song app engraves in an executor, outside Verovio's importing thread."""
+    with ThreadPoolExecutor(max_workers=1) as executor:
+        rendered = executor.submit(engrave, fermata_musicxml).result()
+    assert rendered.notes
 
 
 def test_every_engraved_note_that_sounds_has_a_position(fermata_musicxml):


### PR DESCRIPTION
Fixes #20

## Summary

- initialize each Verovio toolkit with its bundled font resources inside recording worker threads
- keep score-load failures hard failures; no unspaced fallback
- cover executor-thread engraving with a regression test

## Verification

- `266 passed` in the documented full repository suite
- the real `Pois meni mereen päivä` spaced MusicXML engraves in a worker thread (503 notes, 189 timing events)

AgentDeck session: https://bazzite.taile8d16e.ts.net/sessions/codex:codex:01a032f1-5ab5-76b3-b1a5-23de473d0a7e
