### PR TITLE
Clarify lyric hyphen guidance

### DIFF
--- a/lyric_json_prompt.txt
+++ b/lyric_json_prompt.txt
@@ -33,9 +33,13 @@ Notes:
 - Give each line's text by "staff_number" (top staff = 1) and, for a staff shared by
   two divisi voices that sing different words, a "position" ("above"/"below"). If the
   two voices on a staff sing the SAME words, give one line and omit "position".
-- Split each word into syllables with hyphens, e.g. "ly-ric". Give the syllables as
-  they are actually sung; don't worry about matching the exact note count
-  (melismas/slurs are handled separately) and don't add padding or melisma markers.
+- Split each word into syllables with hyphens, e.g. "ly-ric". Be meticulous: put a
+  hyphen between every pair of sung syllables that belong to the same word, using
+  the lyric's language and the PDF spelling. A missing hyphen makes the score show
+  a new word, so re-check every multi-syllable word before returning the JSON.
+  Give the syllables as they are actually sung; don't worry about matching the exact
+  note count (melismas/slurs are handled separately) and don't add padding or melisma
+  markers.
 - A word that continues onto the next line ends with a trailing hyphen (e.g. "Su-ku-")
   and the next line starts with the rest of it ("pol-vis-ta …").
 - Only verse 1 is imported. Skip later verses and editorial/ossia notes.

--- a/lyrics_txt_prompt.txt
+++ b/lyrics_txt_prompt.txt
@@ -4,7 +4,10 @@ Keep same formatting, new lines, etc.
 Treat underscore as an empty syllable.
 Each line has the form: staffNum [syllable_count]: tokens
 The number in brackets is the required syllable count for that voice in that measure. You must keep exactly that many syllables (tokens) when fixing the text; do not change the bracket number.
-Syllables are separated by space or dash (hyphen joins multi-syllable words).
+Syllables are separated by space or dash. Be meticulous: put a hyphen between every
+pair of sung syllables that belong to the same word, using the lyric's language and
+the PDF spelling. A missing hyphen makes the score show a new word, so re-check every
+multi-syllable word before returning the file.
 
 Give result as .txt file. Do not use pandoc or any formatting conversion.
 Write the .txt file only. Save as "lyrics_fixed.txt". remember new lines

--- a/src/song_app/tests/test_lyric_prompts.py
+++ b/src/song_app/tests/test_lyric_prompts.py
@@ -1,0 +1,15 @@
+"""The AI handoff must explain that lyric hyphens control score word joins."""
+
+from pathlib import Path
+
+
+ROOT = Path(__file__).parents[3]
+
+
+def test_ai_prompts_warn_that_missing_hyphens_create_new_words():
+    for name in ("lyric_json_prompt.txt", "lyrics_txt_prompt.txt"):
+        prompt = (ROOT / name).read_text(encoding="utf-8")
+        prompt = " ".join(prompt.split())
+
+        assert "hyphen between every pair of sung syllables" in prompt
+        assert "A missing hyphen makes the score show a new word" in prompt


### PR DESCRIPTION
Closes #31

Summary:
- tell lyric-producing AI to join every sung syllable within a word with hyphens
- explain that a missing hyphen becomes a visible word break in MuseScore
- preserve the existing trailing-hyphen guidance for words spanning systems
- test both AI prompt files for the warning

Verification:
- `.venv/bin/python -m pytest src/song_app/tests/test_lyric_prompts.py src/clean_score/tests/test_lyric_txt_spanner.py -q` (15 passed)
- `.venv/bin/python -m pytest src/clean_score/tests/ src/song_app/tests/ src/scrollvideo/tests/ -q` (307 passed)

AgentDeck session link unavailable: this read-only worker could not access the local session API.
