### PR TITLE
Add GitHub Actions CI for pull requests

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,12 +1,11 @@
-# To get started with Dependabot version updates, you'll need to specify which
-# package ecosystems to update and where the package manifests are located.
-# Please see the documentation for more information:
-# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
-# https://containers.dev/guide/dependabot
-
 version: 2
 updates:
- - package-ecosystem: "devcontainers"
-   directory: "/"
-   schedule:
-     interval: weekly
+  - package-ecosystem: "devcontainers"
+    directory: "/"
+    schedule:
+      interval: weekly
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: weekly

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,9 +23,6 @@ jobs:
     name: Python and integration tests
     runs-on: ubuntu-24.04
     timeout-minutes: 30
-    env:
-      MUSESCORE_CLI_PATH: /usr/bin/musescore3
-      QT_QPA_PLATFORM: offscreen
 
     steps:
       - name: Check out repository
@@ -45,9 +42,27 @@ jobs:
           sudo apt-get update
           sudo apt-get install --yes \
             ffmpeg \
-            musescore3 \
             poppler-utils \
             xvfb
+
+      - name: Install MuseScore 3.6.2
+        env:
+          MUSESCORE_APPIMAGE_URL: https://github.com/musescore/MuseScore/releases/download/v3.6.2/MuseScore-3.6.2.548021370-x86_64.AppImage
+        run: |
+          appimage="$RUNNER_TEMP/MuseScore-3.6.2.AppImage"
+          install_dir="$RUNNER_TEMP/musescore-3.6.2"
+
+          curl --fail --location --retry 3 \
+            "$MUSESCORE_APPIMAGE_URL" \
+            --output "$appimage"
+          chmod +x "$appimage"
+
+          (
+            cd "$RUNNER_TEMP"
+            "$appimage" --appimage-extract >/dev/null
+          )
+          mv "$RUNNER_TEMP/squashfs-root" "$install_dir"
+          echo "MUSESCORE_CLI_PATH=$install_dir/AppRun" >> "$GITHUB_ENV"
 
       - name: Install Python dependencies
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,123 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+env:
+  PIP_DISABLE_PIP_VERSION_CHECK: "1"
+  PYTHONUNBUFFERED: "1"
+
+jobs:
+  tests:
+    name: Python and integration tests
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    env:
+      MUSESCORE_CLI_PATH: /usr/bin/musescore3
+      QT_QPA_PLATFORM: offscreen
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@v7
+        with:
+          python-version: "3.13"
+          cache: pip
+          cache-dependency-path: pip-requirements.txt
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install --yes \
+            ffmpeg \
+            musescore3 \
+            poppler-utils \
+            xvfb
+
+      - name: Install Python dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -r pip-requirements.txt
+          python -m pip check
+
+      - name: Show tool versions
+        run: |
+          python --version
+          xvfb-run -a "$MUSESCORE_CLI_PATH" --version
+          ffmpeg -version | head -n 1
+          pdftoppm -v 2>&1 | head -n 1
+
+      - name: Run Python and integration tests
+        run: |
+          xvfb-run -a python -m pytest \
+            src/clean_score/tests \
+            src/song_app/tests \
+            src/scrollvideo/tests \
+            -m "not browser" \
+            --strict-markers \
+            --durations=10 \
+            -ra
+
+  browser-tests:
+    name: Browser tests
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@v7
+        with:
+          python-version: "3.13"
+          cache: pip
+          cache-dependency-path: pip-requirements.txt
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install --yes poppler-utils xvfb
+
+      - name: Install Python and browser dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -r pip-requirements.txt pytest-playwright
+          python -m pip check
+          python -m playwright install --with-deps chromium
+
+      - name: Verify Chromium starts
+        run: |
+          python - <<'PY'
+          from playwright.sync_api import sync_playwright
+
+          with sync_playwright() as playwright:
+              browser = playwright.chromium.launch()
+              browser.close()
+          PY
+
+      - name: Run browser tests
+        run: |
+          xvfb-run -a python -m pytest \
+            src/song_app/tests \
+            -m browser \
+            --strict-markers \
+            --durations=10 \
+            -ra

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install --yes \
             ffmpeg \
+            libegl1 \
             poppler-utils \
             xvfb
 
@@ -56,6 +57,7 @@ jobs:
             "$MUSESCORE_APPIMAGE_URL" \
             --output "$appimage"
           chmod +x "$appimage"
+          sha256sum "$appimage"
 
           (
             cd "$RUNNER_TEMP"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,12 +26,12 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           persist-credentials: false
 
       - name: Set up Python
-        uses: actions/setup-python@v7
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
         with:
           python-version: "3.13"
           cache: pip
@@ -49,6 +49,7 @@ jobs:
       - name: Install MuseScore 3.6.2
         env:
           MUSESCORE_APPIMAGE_URL: https://github.com/musescore/MuseScore/releases/download/v3.6.2/MuseScore-3.6.2.548021370-x86_64.AppImage
+          MUSESCORE_APPIMAGE_SHA256: c59a41ee88bc7c565a939b9c73498ac0451bbd86574e95cb6e359302c1465290
         run: |
           appimage="$RUNNER_TEMP/MuseScore-3.6.2.AppImage"
           install_dir="$RUNNER_TEMP/musescore-3.6.2"
@@ -56,8 +57,8 @@ jobs:
           curl --fail --location --retry 3 \
             "$MUSESCORE_APPIMAGE_URL" \
             --output "$appimage"
+          echo "$MUSESCORE_APPIMAGE_SHA256  $appimage" | sha256sum --check --strict
           chmod +x "$appimage"
-          sha256sum "$appimage"
 
           (
             cd "$RUNNER_TEMP"
@@ -97,12 +98,12 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           persist-credentials: false
 
       - name: Set up Python
-        uses: actions/setup-python@v7
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
         with:
           python-version: "3.13"
           cache: pip

--- a/docs/CI.md
+++ b/docs/CI.md
@@ -1,0 +1,82 @@
+# Pull-request CI
+
+The repository's CI is ordinary **GitHub Actions** defined in
+[`.github/workflows/ci.yml`](../.github/workflows/ci.yml). It is intended to be
+usable from **ChatGPT Chat through the GitHub connector**. It does not depend on
+Codex, a Codex comment, an agent label, a GitHub App, or a repository secret.
+
+## When it runs
+
+The workflow starts automatically when a pull request is opened or updated,
+when a commit reaches `main`, and when a person starts it with
+`workflow_dispatch`. A newer run for the same pull request cancels the older
+one, so the result attached to the current PR head is the result that matters.
+
+## Checks
+
+A pull request gets two independent checks on Ubuntu 24.04 with Python 3.13:
+
+### Python and integration tests
+
+This job installs the normal Python requirements plus FFmpeg, Poppler, Xvfb,
+and the project's MuseScore 3.6.2 AppImage. The AppImage is pinned by version
+and verified against its SHA-256 digest before execution. It runs:
+
+```bash
+python -m pytest \
+  src/clean_score/tests \
+  src/song_app/tests \
+  src/scrollvideo/tests \
+  -m "not browser" \
+  --strict-markers \
+  --durations=10 \
+  -ra
+```
+
+That includes tests which otherwise skip when MuseScore, FFmpeg, or Poppler is
+missing.
+
+### Browser tests
+
+This job installs `pytest-playwright` and Playwright's Chromium build, proves
+that Chromium can start, and runs:
+
+```bash
+python -m pytest \
+  src/song_app/tests \
+  -m browser \
+  --strict-markers \
+  --durations=10 \
+  -ra
+```
+
+Keeping browser tests separate makes browser setup failures distinguishable
+from Python or music-rendering failures.
+
+## Procedure for ChatGPT Chat
+
+When verifying a code change in a pull request:
+
+1. Push the proposed commit to the PR branch. The `pull_request` `synchronize`
+   event starts CI automatically.
+2. Read the workflow run associated with the PR's **current head SHA**. A green
+   run for an older commit is not evidence for a newer one.
+3. Require both `Python and integration tests` and `Browser tests` to finish
+   successfully.
+4. On failure, inspect the failed job log. Fix a code or test failure and push a
+   new commit. Re-run only the failed job when the failure is clearly transient
+   infrastructure, such as a download outage.
+5. Report the exact tested SHA, both job conclusions, test counts, and any
+   skips. Browser modules skipped by the non-browser job are expected only when
+   they are selected and passed by the browser job.
+
+The GitHub connector available to ChatGPT Chat can inspect PRs, workflow runs,
+job steps and logs, and can re-run failed jobs. No Codex execution environment
+is involved.
+
+## Security and maintenance
+
+The workflow grants the GitHub token only read access to repository contents,
+does not persist checkout credentials, pins third-party actions to commit
+SHAs, and verifies the downloaded MuseScore binary. Dependabot is configured
+to propose updates to the pinned GitHub Actions revisions.


### PR DESCRIPTION
## Summary

- add a GitHub Actions workflow for pull requests, pushes to `main`, and manual runs
- run the Python, MuseScore, FFmpeg, and Poppler-backed test suite on Ubuntu 24.04 with Python 3.13
- pin the integration environment to the repository-compatible MuseScore 3.6.2 release and verify its AppImage checksum
- run the Playwright Chromium tests as a separate check
- cancel superseded runs for the same PR
- give the workflow read-only repository permissions, disable persisted checkout credentials, and pin GitHub Actions to tested commit SHAs
- enable weekly Dependabot updates for GitHub Actions
- document the ChatGPT Chat operating procedure in `docs/CI.md`; no Codex app, comment, label, token, or execution environment is involved

## Checks

### Python and integration tests

Installs FFmpeg, Poppler, Xvfb, EGL, and the official MuseScore 3.6.2 AppImage, then runs the non-browser suite with strict pytest marker validation.

Verified on GitHub Actions at PR head `c5afc49f1caf8c571240bf03eaddfad83dd7b3ef`:

- **287 passed**
- **3 skipped** browser modules, all exercised by the separate browser job
- MuseScore-backed timing/synchronization tests ran successfully rather than skipping

### Browser tests

Installs Playwright and Chromium, verifies that Chromium launches, then runs the `browser` marker suite.

Verified on the same PR head:

- **24 passed**
- **77 deselected** non-browser tests

Both independent checks are green: **311 passing test executions in total**.