### PR TITLE
Improve rendering refresh, audio progress, and reload state

### DIFF
--- a/src/scrollvideo/build.py
+++ b/src/scrollvideo/build.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 import os
 import shutil
 import tempfile
-from concurrent.futures import ThreadPoolExecutor
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from bisect import bisect_left
 from typing import Callable, List, Optional, Sequence
 
@@ -57,6 +57,27 @@ def _noop(_msg: str) -> None:
 def video_encoder(hardware_encoding: bool, width: int, height: int) -> str:
     """Select automatic hardware encoding unless the caller explicitly disabled it."""
     return preferred_encoder(width, height) if hardware_encoding else SOFTWARE_ENCODER
+
+
+def _collect_audio_results(futures: dict, progress: Logger) -> dict:
+    """Collect concurrent audio renders while reporting each completed mix.
+
+    MuseScore audio export is often the longest quiet phase before frame rendering.
+    Reporting completions rather than starts makes the number durable and truthful
+    even though mixes finish out of order on the worker pool.
+    """
+    total = len(futures)
+    if not total:
+        return {}
+    progress(f"Creating audio mixes: 0/{total} (0%)")
+    names = {future: name for name, future in futures.items()}
+    results = {}
+    for completed, future in enumerate(as_completed(names), 1):
+        name = names[future]
+        results[name] = future.result()
+        percent = round(completed * 100 / total)
+        progress(f"Creating audio mixes: {completed}/{total} ({percent}%) — {name}")
+    return results
 
 
 def unsupported_repeats(root: etree._Element) -> List[str]:
@@ -229,7 +250,7 @@ def build_videos(mscx_path: str, out_dir: str, *, parts: Optional[Sequence[str]]
                     futures = {name: pool.submit(audio_mod.render_mix_cached, source, focus,
                                                  audio_cache_dir)
                                for name, focus in mixes}
-                    results = {name: future.result() for name, future in futures.items()}
+                    results = _collect_audio_results(futures, progress)
                     tracks = {name: result[0] for name, result in results.items()}
                     reused = sum(result[1] for result in results.values())
                     if reused:
@@ -239,7 +260,7 @@ def build_videos(mscx_path: str, out_dir: str, *, parts: Optional[Sequence[str]]
                     futures = {name: pool.submit(audio_mod.render_mix, source, focus,
                                                  os.path.join(tmp, f"{name}.wav"))
                                for name, focus in mixes}
-                    tracks = {name: future.result() for name, future in futures.items()}
+                    tracks = _collect_audio_results(futures, progress)
 
         encoder = video_encoder(hardware_encoding, width, height)
         if encoder == NVIDIA_ENCODER:

--- a/src/scrollvideo/tests/test_audio_progress.py
+++ b/src/scrollvideo/tests/test_audio_progress.py
@@ -1,0 +1,26 @@
+"""Progress emitted while MuseScore creates the per-part audio mixes."""
+
+from concurrent.futures import Future
+
+from src.scrollvideo.build import _collect_audio_results
+
+
+def test_each_completed_audio_mix_advances_visible_progress():
+    soprano = Future()
+    alto = Future()
+    soprano.set_result(("soprano.wav", False))
+    alto.set_result(("alto.wav", True))
+    lines = []
+
+    results = _collect_audio_results({"S1": soprano, "A1": alto}, lines.append)
+
+    assert results == {
+        "S1": ("soprano.wav", False),
+        "A1": ("alto.wav", True),
+    } or results == {
+        "A1": ("alto.wav", True),
+        "S1": ("soprano.wav", False),
+    }
+    assert lines[0] == "Creating audio mixes: 0/2 (0%)"
+    assert lines[-1].startswith("Creating audio mixes: 2/2 (100%)")
+    assert {line.rsplit(" — ", 1)[-1] for line in lines[1:]} == {"S1", "A1"}

--- a/src/song_app/static/index.html
+++ b/src/song_app/static/index.html
@@ -23,5 +23,6 @@
   </header>
   <main id="app">Loading…</main>
   <script src="/app.js"></script>
+  <script src="/rendering_state.js"></script>
 </body>
 </html>

--- a/src/song_app/static/rendering_state.js
+++ b/src/song_app/static/rendering_state.js
@@ -1,0 +1,259 @@
+"use strict";
+
+// Workspace state that must survive a browser reload, plus a polling safety net for
+// long renders. The main app normally refreshes from its WebSocket; phones can suspend
+// or drop that socket while a render runs, so this small companion also watches the
+// durable job state. It only reloads the page when the existing panel cannot be
+// updated in place, and the remembered tabs make that reload land where the user was.
+(() => {
+  const STORAGE_PREFIX = "songWorkspace:";
+  const MOBILE_PANES = ["stages", "panel", "viewer"];
+  const appRoot = document.getElementById("app");
+
+  let restoreQueued = false;
+  let pollTimer = null;
+  let observedSlug = null;
+  let snapshot = null;
+
+  function currentSlug() {
+    const match = location.hash.match(/^#\/song\/(.+)$/);
+    if (!match) return null;
+    try { return decodeURIComponent(match[1]); }
+    catch { return match[1]; }
+  }
+
+  function storageKey(slug) {
+    return STORAGE_PREFIX + slug;
+  }
+
+  function loadWorkspace(slug) {
+    try {
+      const value = JSON.parse(localStorage.getItem(storageKey(slug)) || "{}");
+      return value && typeof value === "object" ? value : {};
+    } catch {
+      return {};
+    }
+  }
+
+  function saveWorkspace(patch) {
+    const slug = currentSlug();
+    if (!slug) return;
+    try {
+      localStorage.setItem(storageKey(slug), JSON.stringify({ ...loadWorkspace(slug), ...patch }));
+    } catch {
+      // Storage can be disabled in private browsing. The app still works; only the
+      // convenience of returning to the same tab is unavailable in that browser.
+    }
+  }
+
+  // Remember deliberate navigation. Capture phase records it before app.js redraws
+  // the panel and replaces the clicked node.
+  document.addEventListener("click", (event) => {
+    const target = event.target instanceof Element ? event.target : null;
+    if (!target) return;
+
+    const stage = target.closest(".stagebar .step");
+    if (stage) saveWorkspace({ stage: stage.textContent.trim() });
+
+    const mobile = target.closest(".mobilebar .mtab");
+    if (mobile) {
+      const buttons = [...mobile.closest(".mobilebar").querySelectorAll(".mtab")];
+      const index = buttons.indexOf(mobile);
+      if (index >= 0) saveWorkspace({ mobilePane: MOBILE_PANES[index] });
+    }
+
+    const viewerTab = target.closest(".viewtabs .vtab:not(.split):not(.close)");
+    if (viewerTab) {
+      const slot = viewerTab.closest(".vslot");
+      const slots = [...document.querySelectorAll(".viewer .vslot")];
+      const index = slots.indexOf(slot);
+      if (index >= 0) {
+        const saved = loadWorkspace(currentSlug());
+        const viewerTabs = Array.isArray(saved.viewerTabs) ? [...saved.viewerTabs] : [];
+        viewerTabs[index] = viewerTab.textContent.trim();
+        saveWorkspace({ viewerTabs });
+      }
+    }
+  }, true);
+
+  function queueRestore() {
+    if (restoreQueued) return;
+    restoreQueued = true;
+    requestAnimationFrame(() => {
+      restoreQueued = false;
+      restoreWorkspace();
+    });
+  }
+
+  function restoreWorkspace() {
+    const slug = currentSlug();
+    if (!slug) return;
+    const saved = loadWorkspace(slug);
+
+    // Restore the workflow stage first. Its click redraws the panel and intentionally
+    // brings the panel pane forward, so restore the mobile/viewer tabs on the next pass.
+    if (saved.stage) {
+      const steps = [...document.querySelectorAll(".stagebar .step")];
+      const wanted = steps.find((step) => step.textContent.trim() === saved.stage);
+      if (wanted && !wanted.classList.contains("active")) {
+        wanted.click();
+        queueRestore();
+        return;
+      }
+    }
+
+    if (Array.isArray(saved.viewerTabs)) {
+      const slots = [...document.querySelectorAll(".viewer .vslot")];
+      saved.viewerTabs.forEach((label, index) => {
+        if (!label || !slots[index]) return;
+        const tabs = [...slots[index].querySelectorAll(".viewtabs .vtab:not(.split):not(.close)")];
+        const wanted = tabs.find((tab) => tab.textContent.trim() === label);
+        if (wanted && !wanted.classList.contains("active")) wanted.click();
+      });
+    }
+
+    const paneIndex = MOBILE_PANES.indexOf(saved.mobilePane);
+    const mobileButtons = [...document.querySelectorAll(".mobilebar .mtab")];
+    if (paneIndex >= 0 && mobileButtons[paneIndex]
+        && !mobileButtons[paneIndex].classList.contains("active")) {
+      mobileButtons[paneIndex].click();
+    }
+  }
+
+  const observer = new MutationObserver(queueRestore);
+  if (appRoot) observer.observe(appRoot, { childList: true, subtree: true });
+
+  function renderedMedia(data) {
+    const media = Array.isArray(data.media) ? data.media : [];
+    const merged = media.filter((item) => item.merged);
+    return merged.length ? merged : media;
+  }
+
+  function completionToken(data) {
+    const job = data.jobs?.render || {};
+    return job.finished_at || data.record?.rendered_against || "";
+  }
+
+  function mediaUrl(url, token) {
+    const parsed = new URL(url, location.href);
+    // The server already versions media by mtime and size. The durable job token is
+    // an extra guarantee for a same-name, same-size render completed within one mtime
+    // tick, and lets an already-mounted <video> unequivocally load the new take.
+    if (token) parsed.searchParams.set("completed", String(token));
+    return parsed.pathname + parsed.search;
+  }
+
+  function mediaSignature(data) {
+    const token = completionToken(data);
+    return renderedMedia(data).map((item) => `${item.label}:${mediaUrl(item.url, token)}`).join("|");
+  }
+
+  function syncProgress(data) {
+    const logs = data.jobs?.render?.logs || [];
+    const latest = [...logs].reverse().find((entry) => entry.type === "progress");
+    if (!latest) return;
+    const log = document.querySelector(".panel .log");
+    if (!log) return;
+    let row = log.querySelector(".progress:last-of-type");
+    if (!row) {
+      row = document.createElement("div");
+      row.className = "progress";
+      log.append(row);
+    }
+    row.textContent = latest.line;
+    log.scrollTop = log.scrollHeight;
+  }
+
+  function refreshVideosInPlace(data) {
+    const expected = renderedMedia(data);
+    if (!expected.length) return true;
+    const rows = [...document.querySelectorAll(".panel .result")];
+    if (rows.length !== expected.length) return false;
+
+    for (let index = 0; index < expected.length; index += 1) {
+      const label = rows[index].querySelector(".rlabel")?.textContent.trim();
+      const video = rows[index].querySelector("video");
+      if (!video || label !== expected[index].label) return false;
+    }
+
+    const token = completionToken(data);
+    rows.forEach((row, index) => {
+      const video = row.querySelector("video");
+      const wanted = mediaUrl(expected[index].url, token);
+      const shown = video.getAttribute("src") || "";
+      if (shown !== wanted) {
+        video.src = wanted;
+        video.load();
+      }
+    });
+    return true;
+  }
+
+  function renderRunning(data) {
+    return !!data.recording || data.jobs?.render?.status === "running";
+  }
+
+  function schedulePoll(delay) {
+    if (pollTimer) clearTimeout(pollTimer);
+    pollTimer = setTimeout(poll, delay);
+  }
+
+  async function poll() {
+    pollTimer = null;
+    const slug = currentSlug();
+    if (!slug) {
+      observedSlug = null;
+      snapshot = null;
+      schedulePoll(3000);
+      return;
+    }
+    if (slug !== observedSlug) {
+      observedSlug = slug;
+      snapshot = null;
+      queueRestore();
+    }
+
+    let delay = 2500;
+    try {
+      const response = await fetch(`/api/songs/${encodeURIComponent(slug)}`, { cache: "no-store" });
+      if (!response.ok) throw new Error(response.statusText);
+      const data = await response.json();
+      syncProgress(data);
+
+      const current = {
+        running: renderRunning(data),
+        signature: mediaSignature(data),
+      };
+      const completed = snapshot?.running && !current.running;
+      const outputsChanged = !!snapshot && snapshot.signature !== current.signature
+        && renderedMedia(data).length > 0;
+      const updated = refreshVideosInPlace(data);
+
+      // Healthy WebSockets redraw the Record panel before this branch is reached.
+      // When a phone lost its socket, the old panel has no result rows to update;
+      // reload once, then the saved workflow/viewer tabs restore the exact context.
+      if ((completed || outputsChanged) && !updated) {
+        location.reload();
+        return;
+      }
+
+      snapshot = current;
+      delay = current.running ? 1000 : 4000;
+    } catch {
+      // A transient request failure must not affect the render. Keep trying quietly.
+      delay = 2000;
+    }
+    schedulePoll(delay);
+  }
+
+  window.addEventListener("hashchange", () => {
+    observedSlug = null;
+    snapshot = null;
+    queueRestore();
+    schedulePoll(0);
+  });
+  window.addEventListener("DOMContentLoaded", () => {
+    queueRestore();
+    schedulePoll(0);
+  });
+})();

--- a/src/song_app/static/rendering_state.js
+++ b/src/song_app/static/rendering_state.js
@@ -3,14 +3,15 @@
 // Workspace state that must survive a browser reload, plus a polling safety net for
 // long renders. The main app normally refreshes from its WebSocket; phones can suspend
 // or drop that socket while a render runs, so this small companion also watches the
-// durable job state. It only reloads the page when the existing panel cannot be
-// updated in place, and the remembered tabs make that reload land where the user was.
+// durable job state. An observed render completion reloads once, and the remembered
+// tabs make that reload land exactly where the user was.
 (() => {
   const STORAGE_PREFIX = "songWorkspace:";
   const MOBILE_PANES = ["stages", "panel", "viewer"];
   const appRoot = document.getElementById("app");
 
   let restoreQueued = false;
+  let restoring = false;
   let pollTimer = null;
   let observedSlug = null;
   let snapshot = null;
@@ -46,14 +47,23 @@
     }
   }
 
+  function clickForRestore(element) {
+    restoring = true;
+    try { element.click(); }
+    finally { restoring = false; }
+  }
+
   // Remember deliberate navigation. Capture phase records it before app.js redraws
-  // the panel and replaces the clicked node.
+  // the panel and replaces the clicked node. A stage choice deliberately brings the
+  // panel forward on phones, so that resulting pane — not the old Stages pane — is
+  // what should survive the next reload.
   document.addEventListener("click", (event) => {
+    if (restoring) return;
     const target = event.target instanceof Element ? event.target : null;
     if (!target) return;
 
     const stage = target.closest(".stagebar .step");
-    if (stage) saveWorkspace({ stage: stage.textContent.trim() });
+    if (stage) saveWorkspace({ stage: stage.textContent.trim(), mobilePane: "panel" });
 
     const mobile = target.closest(".mobilebar .mtab");
     if (mobile) {
@@ -90,13 +100,14 @@
     if (!slug) return;
     const saved = loadWorkspace(slug);
 
-    // Restore the workflow stage first. Its click redraws the panel and intentionally
-    // brings the panel pane forward, so restore the mobile/viewer tabs on the next pass.
+    // Restore the workflow stage first. Its click redraws the panel, so restore the
+    // mobile/viewer tabs on the next pass. Synthetic restore clicks are not allowed
+    // to overwrite what the person actually chose before reloading.
     if (saved.stage) {
       const steps = [...document.querySelectorAll(".stagebar .step")];
       const wanted = steps.find((step) => step.textContent.trim() === saved.stage);
       if (wanted && !wanted.classList.contains("active")) {
-        wanted.click();
+        clickForRestore(wanted);
         queueRestore();
         return;
       }
@@ -108,7 +119,7 @@
         if (!label || !slots[index]) return;
         const tabs = [...slots[index].querySelectorAll(".viewtabs .vtab:not(.split):not(.close)")];
         const wanted = tabs.find((tab) => tab.textContent.trim() === label);
-        if (wanted && !wanted.classList.contains("active")) wanted.click();
+        if (wanted && !wanted.classList.contains("active")) clickForRestore(wanted);
       });
     }
 
@@ -116,7 +127,7 @@
     const mobileButtons = [...document.querySelectorAll(".mobilebar .mtab")];
     if (paneIndex >= 0 && mobileButtons[paneIndex]
         && !mobileButtons[paneIndex].classList.contains("active")) {
-      mobileButtons[paneIndex].click();
+      clickForRestore(mobileButtons[paneIndex]);
     }
   }
 
@@ -154,7 +165,8 @@
     if (!latest) return;
     const log = document.querySelector(".panel .log");
     if (!log) return;
-    let row = log.querySelector(".progress:last-of-type");
+    const rows = log.querySelectorAll(".progress");
+    let row = rows[rows.length - 1];
     if (!row) {
       row = document.createElement("div");
       row.className = "progress";
@@ -229,10 +241,17 @@
         && renderedMedia(data).length > 0;
       const updated = refreshVideosInPlace(data);
 
-      // Healthy WebSockets redraw the Record panel before this branch is reached.
-      // When a phone lost its socket, the old panel has no result rows to update;
-      // reload once, then the saved workflow/viewer tabs restore the exact context.
-      if ((completed || outputsChanged) && !updated) {
+      // A complete refresh clears the old running banner, re-enables the controls,
+      // and mounts the final output set. It happens once because the next page starts
+      // with an idle snapshot; the saved workspace state restores the exact tab/pane.
+      if (completed) {
+        location.reload();
+        return;
+      }
+      // Also recover if outputs changed without this page ever observing the running
+      // state (for example, a phone resumed after the whole render) and its old panel
+      // cannot be updated safely in place.
+      if (outputsChanged && !updated) {
         location.reload();
         return;
       }

--- a/src/song_app/tests/test_mp3_progress.py
+++ b/src/song_app/tests/test_mp3_progress.py
@@ -36,7 +36,7 @@ def test_recording_pipeline_forwards_progress_to_mp3_export(tmp_path, monkeypatc
 
     assert seen["song_dir"] == str(song)
     assert seen["redo"] is True
-    assert seen["progress"] is progress_lines.append
+    assert callable(seen["progress"])
     assert progress_lines == ["Creating MP3 audio: 1/2"]
 
 

--- a/src/song_app/tests/test_mp3_progress.py
+++ b/src/song_app/tests/test_mp3_progress.py
@@ -1,0 +1,75 @@
+"""The screen-recording renderer reports its otherwise quiet MP3 export phase."""
+
+import os
+from pathlib import Path
+
+# create_video validates these at import time. Tests replace all external programs,
+# so harmless temporary defaults are enough here.
+os.environ.setdefault("MUSESCORE_EXPORT_PATH", "/tmp")
+os.environ.setdefault("VIDEO_EXPORT_PATH", "/tmp")
+
+from src.stemmanauha import create_video
+
+
+def test_recording_pipeline_forwards_progress_to_mp3_export(tmp_path, monkeypatch):
+    song = tmp_path / "demo"
+    song.mkdir()
+    media = song / "media"
+    media.mkdir()
+    mp3 = media / "demo ALL.mp3"
+    mp3.write_bytes(b"audio")
+    seen = {}
+    progress_lines = []
+
+    def fake_export(song_dir, redo=False, log=None, progress=None):
+        seen.update(song_dir=song_dir, redo=redo, log=log, progress=progress)
+        progress("Creating MP3 audio: 1/2")
+        return mp3
+
+    monkeypatch.setattr(create_video, "export_mp3_from_musescore", fake_export)
+    monkeypatch.setattr(create_video, "record_video", lambda *args, **kwargs: None)
+    monkeypatch.setattr(create_video, "merge_mp3_to_video", lambda *args, **kwargs: [])
+
+    create_video.run(
+        song_dir=str(song), redo_mp3=True,
+        log=lambda _message: None, progress=progress_lines.append)
+
+    assert seen["song_dir"] == str(song)
+    assert seen["redo"] is True
+    assert seen["progress"] is progress_lines.append
+    assert progress_lines == ["Creating MP3 audio: 1/2"]
+
+
+def test_mp3_export_reports_start_wait_and_completion(tmp_path, monkeypatch):
+    song = tmp_path / "demo"
+    song.mkdir()
+    exported = tmp_path / "exports"
+    exported.mkdir()
+    all_mp3 = exported / "demo ALL.mp3"
+    all_mp3.write_bytes(b"audio")
+    lines = []
+    logs = []
+
+    monkeypatch.setattr(create_video, "MUSESCORE_EXPORT_PATH", str(exported))
+    monkeypatch.setattr(create_video, "export_path", exported)
+    monkeypatch.setattr(create_video.subprocess, "run", lambda *args, **kwargs: None)
+    monkeypatch.setattr(create_video.time, "sleep", lambda _seconds: None)
+
+    def fake_wait(export_dir, timeout=120, check_interval=1, progress=None):
+        assert Path(export_dir) == exported
+        progress("Creating MP3 audio: waiting 4s")
+        return all_mp3
+
+    monkeypatch.setattr(create_video, "wait_for_all_mp3", fake_wait)
+    monkeypatch.setattr(create_video, "get_filtered_mp3_files", lambda _base: [all_mp3])
+
+    result = create_video.export_mp3_from_musescore(
+        str(song), redo=True, log=logs.append, progress=lines.append)
+
+    assert Path(result) == song / "media" / "demo ALL.mp3"
+    assert logs == ["Creating MP3 audio in MuseScore…", "MP3 audio ready."]
+    assert lines == [
+        "Creating MP3 audio: starting MuseScore export",
+        "Creating MP3 audio: waiting 4s",
+        "Creating MP3 audio: 100%",
+    ]

--- a/src/song_app/tests/test_rendering_improvements_ui.py
+++ b/src/song_app/tests/test_rendering_improvements_ui.py
@@ -32,6 +32,7 @@ import uvicorn
 from src.song_app import job_state, server, state
 
 pytestmark = pytest.mark.browser
+PHONE = {"width": 390, "height": 844}
 
 
 def _free_port():
@@ -78,22 +79,31 @@ def live(tmp_path_factory):
             os.environ["MUSESCORE_CLI_PATH"] = previous_cli
 
 
+def _choose_stage(page, label):
+    stages = page.locator(".mobilebar").get_by_role("button", name="Stages")
+    if stages.is_visible():
+        stages.click()
+    page.locator(".stagebar .step", has_text=label).click()
+
+
 def _open_record(page, live):
     base, slug = live
     page.goto(f"{base}/#/song/{slug}")
     page.wait_for_selector(".stagebar")
     # Make this a deliberate selection so the companion script stores it.
-    page.locator(".stagebar .step", has_text="Review").click()
-    page.locator(".stagebar .step", has_text="Record").click()
+    _choose_stage(page, "Review")
+    _choose_stage(page, "Record")
     page.wait_for_selector("text=How to make the videos")
     return slug
 
 
-def test_workflow_and_viewer_tabs_survive_a_reload(live, page):
+def test_workflow_mobile_pane_and_viewer_tab_survive_a_reload(live, page):
     errors = []
     page.on("pageerror", lambda error: errors.append(str(error)))
+    page.set_viewport_size(PHONE)
     slug = _open_record(page, live)
 
+    page.locator(".mobilebar").get_by_role("button", name="Score").click()
     cleaned_tab = page.locator(".viewtabs .vtab", has_text="Cleaned MSCX").first
     cleaned_tab.click()
     assert cleaned_tab.evaluate("node => node.classList.contains('active')")
@@ -103,7 +113,6 @@ def test_workflow_and_viewer_tabs_survive_a_reload(live, page):
     song.save()
     try:
         page.reload()
-        page.wait_for_selector("text=How to make the videos")
         page.wait_for_function("""
             () => [...document.querySelectorAll('.stagebar .step')]
               .some(step => step.classList.contains('active') && step.textContent.trim() === 'Record')
@@ -111,6 +120,10 @@ def test_workflow_and_viewer_tabs_survive_a_reload(live, page):
         page.wait_for_function("""
             () => [...document.querySelectorAll('.viewtabs .vtab.active')]
               .some(tab => tab.textContent.trim() === 'Cleaned MSCX')
+        """)
+        page.wait_for_function("""
+            () => [...document.querySelectorAll('.mobilebar .mtab')]
+              .some(tab => tab.classList.contains('active') && tab.textContent.trim() === 'Score')
         """)
         assert not errors, f"the reloaded workspace raised: {errors}"
     finally:
@@ -123,6 +136,23 @@ def test_finished_render_appears_without_a_websocket_state_message(live, page):
     """The polling fallback must notice completion on a suspended/disconnected phone."""
     errors = []
     page.on("pageerror", lambda error: errors.append(str(error)))
+    # app.js only assigns onmessage and closes the socket. This inert substitute makes
+    # the browser genuinely miss every file-watcher state message while keeping the
+    # rest of the workspace identical to a temporarily disconnected phone.
+    page.add_init_script("""
+        (() => {
+          class SilentWebSocket {
+            constructor(url) { this.url = url; this.readyState = 1; this.onmessage = null; }
+            close() { this.readyState = 3; }
+            send() {}
+          }
+          SilentWebSocket.CONNECTING = 0;
+          SilentWebSocket.OPEN = 1;
+          SilentWebSocket.CLOSING = 2;
+          SilentWebSocket.CLOSED = 3;
+          window.WebSocket = SilentWebSocket;
+        })();
+    """)
     slug = _open_record(page, live)
     song = state.load(slug)
     lock = server._lock_path(song)
@@ -151,12 +181,11 @@ def test_finished_render_appears_without_a_websocket_state_message(live, page):
         song.save()
         job_state.finish(song.dir, "render")
         os.remove(lock)
-        # Deliberately do not call server.hub.emit(..., {"type": "state"}).
+        # Deliberately do not emit a WebSocket state message. The fake socket also
+        # prevents the server's file watcher from updating this page behind our back.
 
-        page.wait_for_selector(".result video", timeout=10000)
+        page.wait_for_selector(".result video[src*='completed=']", timeout=10000)
         assert page.locator(".result .rlabel").first.inner_text() == "S1"
-        source = page.locator(".result video").first.get_attribute("src")
-        assert "completed=" in source, source
         active = page.locator(".stagebar .step.active").inner_text()
         assert active == "Record"
         assert not errors, f"the completion refresh raised: {errors}"

--- a/src/song_app/tests/test_rendering_improvements_ui.py
+++ b/src/song_app/tests/test_rendering_improvements_ui.py
@@ -1,0 +1,173 @@
+"""Reload behavior for the workspace and completed renders in a real browser."""
+
+import os
+import socket
+import threading
+import time
+
+import pytest
+
+_NEEDS = "pip install pytest-playwright && playwright install chromium"
+pytest.importorskip("playwright.sync_api", reason=_NEEDS)
+pytest.importorskip("pytest_playwright", reason=_NEEDS)
+pytest.importorskip("uvicorn")
+
+
+def _browser_installed() -> bool:
+    from playwright.sync_api import sync_playwright
+
+    try:
+        with sync_playwright() as playwright:
+            playwright.chromium.launch().close()
+        return True
+    except Exception:
+        return False
+
+
+if not _browser_installed():
+    pytest.skip(_NEEDS, allow_module_level=True)
+
+import uvicorn
+
+from src.song_app import job_state, server, state
+
+pytestmark = pytest.mark.browser
+
+
+def _free_port():
+    with socket.socket() as sock:
+        sock.bind(("127.0.0.1", 0))
+        return sock.getsockname()[1]
+
+
+@pytest.fixture(scope="module")
+def live(tmp_path_factory):
+    tmp = tmp_path_factory.mktemp("rendering-improvements")
+    songs = tmp / "songs"
+    songs.mkdir()
+    previous_dir, state.SONGS_DIR = state.SONGS_DIR, str(songs)
+    previous_cli = os.environ.get("MUSESCORE_CLI_PATH")
+    os.environ["MUSESCORE_CLI_PATH"] = str(tmp / "no-musescore-here")
+
+    song = state.create("Reload Song", per_system=False)
+    cleaned = song.path("reload_cleaned.mscx")
+    with open(cleaned, "w") as handle:
+        handle.write("<museScore><Score/></museScore>")
+    song.data["cleaned"] = os.path.basename(cleaned)
+    song.data["stage"] = "record"
+    song.save()
+
+    port = _free_port()
+    running = uvicorn.Server(uvicorn.Config(
+        server.app, host="127.0.0.1", port=port, log_level="warning"))
+    thread = threading.Thread(target=running.run, daemon=True)
+    try:
+        thread.start()
+        deadline = time.time() + 30
+        while not running.started and time.time() < deadline:
+            time.sleep(0.05)
+        assert running.started, "the app did not start"
+        yield f"http://127.0.0.1:{port}", song.slug
+    finally:
+        running.should_exit = True
+        thread.join(timeout=10)
+        state.SONGS_DIR = previous_dir
+        if previous_cli is None:
+            os.environ.pop("MUSESCORE_CLI_PATH", None)
+        else:
+            os.environ["MUSESCORE_CLI_PATH"] = previous_cli
+
+
+def _open_record(page, live):
+    base, slug = live
+    page.goto(f"{base}/#/song/{slug}")
+    page.wait_for_selector(".stagebar")
+    # Make this a deliberate selection so the companion script stores it.
+    page.locator(".stagebar .step", has_text="Review").click()
+    page.locator(".stagebar .step", has_text="Record").click()
+    page.wait_for_selector("text=How to make the videos")
+    return slug
+
+
+def test_workflow_and_viewer_tabs_survive_a_reload(live, page):
+    errors = []
+    page.on("pageerror", lambda error: errors.append(str(error)))
+    slug = _open_record(page, live)
+
+    cleaned_tab = page.locator(".viewtabs .vtab", has_text="Cleaned MSCX").first
+    cleaned_tab.click()
+    assert cleaned_tab.evaluate("node => node.classList.contains('active')")
+
+    song = state.load(slug)
+    song.data["stage"] = "upload"
+    song.save()
+    try:
+        page.reload()
+        page.wait_for_selector("text=How to make the videos")
+        page.wait_for_function("""
+            () => [...document.querySelectorAll('.stagebar .step')]
+              .some(step => step.classList.contains('active') && step.textContent.trim() === 'Record')
+        """)
+        page.wait_for_function("""
+            () => [...document.querySelectorAll('.viewtabs .vtab.active')]
+              .some(tab => tab.textContent.trim() === 'Cleaned MSCX')
+        """)
+        assert not errors, f"the reloaded workspace raised: {errors}"
+    finally:
+        song = state.load(slug)
+        song.data["stage"] = "record"
+        song.save()
+
+
+def test_finished_render_appears_without_a_websocket_state_message(live, page):
+    """The polling fallback must notice completion on a suspended/disconnected phone."""
+    errors = []
+    page.on("pageerror", lambda error: errors.append(str(error)))
+    slug = _open_record(page, live)
+    song = state.load(slug)
+    lock = server._lock_path(song)
+    video = song.path("media", "video", f"{slug} S1.mp4")
+
+    try:
+        job_state.start(song.dir, "render", state.file_fingerprint(song.cleaned_path()))
+        with open(lock, "w") as handle:
+            handle.write(str(os.getpid()))
+
+        page.reload()
+        page.wait_for_selector("text=Rendering… leave this running.")
+        # Let rendering_state.js observe the running baseline before completing it.
+        page.wait_for_timeout(1200)
+
+        os.makedirs(os.path.dirname(video), exist_ok=True)
+        with open(video, "wb") as handle:
+            handle.write(b"new take")
+        song = state.load(slug)
+        song.data["record"] = {
+            "renderer": "scroll",
+            "outputs": [os.path.basename(video)],
+            "rendered_against": state.file_fingerprint(song.cleaned_path()),
+        }
+        song.data["stage"] = "upload"
+        song.save()
+        job_state.finish(song.dir, "render")
+        os.remove(lock)
+        # Deliberately do not call server.hub.emit(..., {"type": "state"}).
+
+        page.wait_for_selector(".result video", timeout=10000)
+        assert page.locator(".result .rlabel").first.inner_text() == "S1"
+        source = page.locator(".result video").first.get_attribute("src")
+        assert "completed=" in source, source
+        active = page.locator(".stagebar .step.active").inner_text()
+        assert active == "Record"
+        assert not errors, f"the completion refresh raised: {errors}"
+    finally:
+        if os.path.exists(lock):
+            os.remove(lock)
+        if os.path.exists(video):
+            os.remove(video)
+        song = state.load(slug)
+        song.data["record"] = {}
+        song.data["stage"] = "record"
+        song.save()
+        if job_state.is_running(song.dir, "render"):
+            job_state.finish(song.dir, "render", error="test cleanup")

--- a/src/song_app/tests/test_rendering_improvements_ui.py
+++ b/src/song_app/tests/test_rendering_improvements_ui.py
@@ -89,7 +89,7 @@ def _choose_stage(page, label):
 def _open_record(page, live):
     base, slug = live
     page.goto(f"{base}/#/song/{slug}")
-    page.wait_for_selector(".stagebar")
+    page.wait_for_selector(".stagebar", state="attached")
     # Make this a deliberate selection so the companion script stores it.
     _choose_stage(page, "Review")
     _choose_stage(page, "Record")

--- a/src/stemmanauha/create_video.py
+++ b/src/stemmanauha/create_video.py
@@ -275,11 +275,12 @@ def merge_mp3_to_video(song_dir, audio_delay_ms=1300, force=False):
     return results
 
 
-def wait_for_all_mp3(export_dir, timeout=120, check_interval=1):
+def wait_for_all_mp3(export_dir, timeout=120, check_interval=1, progress=None):
     """
     Wait for a file ending in ALL.mp3 to be created or updated and fully written in export_dir.
-    Logs any new or replaced files.
+    Logs any new or replaced files and reports durable progress to the song app.
     """
+    progress = progress or (lambda _message: None)
     export_dir = Path(export_dir)
     seen_files = {}
 
@@ -294,6 +295,7 @@ def wait_for_all_mp3(export_dir, timeout=120, check_interval=1):
     elapsed = 0
 
     print(f"Watching for '*ALL.mp3' in: {export_dir.resolve()}")
+    progress("Creating MP3 audio: waiting for MuseScore export")
 
     while elapsed < timeout:
         for f in export_dir.glob("*.mp3"):
@@ -304,6 +306,7 @@ def wait_for_all_mp3(export_dir, timeout=120, check_interval=1):
 
             if f not in seen_files or seen_files[f] != mtime:
                 print(f"New or updated file detected: {f.name}")
+                progress(f"Creating MP3 audio: received {f.name}")
                 seen_files[f] = mtime
                 elapsed = 0  # reset timeout on new activity
 
@@ -327,21 +330,24 @@ def wait_for_all_mp3(export_dir, timeout=120, check_interval=1):
                     stable_seconds = 0
                     last_size = -1
 
+                progress(f"Finalising MP3 audio: {stable_seconds}/3 stable seconds")
                 time.sleep(1)
 
             print(f"{target_file.name} has finished writing.")
             return target_file
 
+        progress(f"Creating MP3 audio: waiting {int(elapsed)}s")
         time.sleep(check_interval)
         elapsed += check_interval
 
     raise TimeoutError("Timed out waiting for '*ALL.mp3' to appear or finish writing.")
 
 
-def export_mp3_from_musescore(song_dir, redo=False):
-    """
-    Export MP3 files from MuseScore using AppleScript.
-    """
+def export_mp3_from_musescore(song_dir, redo=False, log=None, progress=None):
+    """Export MP3 files from MuseScore using AppleScript, with visible progress."""
+    log = log or (lambda message: logging.info(message))
+    progress = progress or (lambda _message: None)
+
     # If mp3 already exists in song_dir/mp3, skip export
     if song_dir:
         media_dir = Path(song_dir) / "media"
@@ -351,6 +357,8 @@ def export_mp3_from_musescore(song_dir, redo=False):
                 mp3.unlink()
         if media_dir.exists() and any(media_dir.glob("*.mp3")):
             logging.info(f"MP3 files already exist in {media_dir}, skipping export.")
+            log("Reusing existing MP3 audio.")
+            progress("Creating MP3 audio: 100% (reused)")
             one_mp3 = next(media_dir.glob("*.mp3"))
             return one_mp3
 
@@ -358,9 +366,13 @@ def export_mp3_from_musescore(song_dir, redo=False):
     if not script_path.exists():
         raise FileNotFoundError(f"Script {script_path} does not exist.")
 
+    log("Creating MP3 audio in MuseScore…")
+    progress("Creating MP3 audio: starting MuseScore export")
     subprocess.run(["osascript", str(script_path)], check=True)
     time.sleep(5)
-    all_mp3 = wait_for_all_mp3(export_dir=MUSESCORE_EXPORT_PATH, timeout=120, check_interval=1)
+    all_mp3 = wait_for_all_mp3(
+        export_dir=MUSESCORE_EXPORT_PATH, timeout=120, check_interval=1,
+        progress=progress)
     logging.info("MP3 export from MuseScore completed.")
 
     if song_dir:
@@ -375,7 +387,9 @@ def export_mp3_from_musescore(song_dir, redo=False):
             mp3.rename(target_path)
             all_mp3 = target_path
         logging.info(f"All MP3 files moved to {target_dir}")
-    
+
+    progress("Creating MP3 audio: 100%")
+    log("MP3 audio ready.")
     return all_mp3
 
 
@@ -428,6 +442,7 @@ def run(song_dir=None, youtube=False, extra_playlist_id=None,
         raise ValueError("A valid song_dir must be provided.")
 
     log = log or (lambda m: logging.info(m))
+    progress = progress or log
 
     if youtube:
         get_authenticated_service()
@@ -443,7 +458,8 @@ def run(song_dir=None, youtube=False, extra_playlist_id=None,
         logging.info("Re-merged with offset %sms: %s", audio_delay_ms,
                      ", ".join(str(r) for r in results))
     else:
-        mp3 = export_mp3_from_musescore(song_dir, redo=redo_mp3)
+        mp3 = export_mp3_from_musescore(
+            song_dir, redo=redo_mp3, log=log, progress=progress)
         logging.info("MP3 files exported from MuseScore.")
 
         record_video(song_dir, mp3, redo=redo_video)


### PR DESCRIPTION
## Summary

- preserve the selected workflow stage, mobile pane, and score-viewer tab across page reloads
- poll durable render state as a fallback when a phone suspends or loses its WebSocket, then refresh completed video sources and reload once on observed completion while restoring the user’s exact context
- add a render-completion cache token so a newly finished same-name video is reloaded unambiguously
- report per-mix progress while the scrolling renderer creates audio
- report start, wait, finalisation, reuse, and completion progress for screen-recorder MP3 export
- add focused unit and real-browser coverage, including completion without a WebSocket state message

Closes #38

## Verification

Verified by GitHub Actions at PR head `a0bd0f61f273dcf803960525d43b69c23c716dbb`:

- **Python and integration tests:** 290 passed, 4 expected browser-module skips
- **Browser tests:** 26 passed, 79 non-browser tests deselected
- Both independent CI jobs passed.