### PR TITLE
Keep Choir PWA distinct on non-default ports

### DIFF
--- a/docs/PWA.md
+++ b/docs/PWA.md
@@ -4,6 +4,23 @@ The song app is installable as a standalone mobile web app. Its approach follows
 the live-dashboard boundary used by AgentDeck: installability and a resilient
 static shell, **not** offline song data.
 
+## App identity and ports
+
+Choir uses its own manifest identity, `./choir-pwa`, instead of the generic root
+identity `/`. Its `id`, `start_url`, `scope`, and icon paths are relative to the
+manifest URL. Browsers therefore resolve them against the exact origin that served
+the manifest — including a non-default port.
+
+This matters when several PWAs live on the same machine or Tailscale hostname. For
+example, AgentDeck may occupy `https://host` while Choir is served from
+`https://host:PORT`; Choir must remain a separate installed app and launch the port
+from which it was installed.
+
+The first PWA release used `id: "/"`. Because changing a manifest ID intentionally
+creates a different installed-app identity, remove an already-installed Choir icon
+from that release and install it once again after this change. Future updates keep
+the stable `choir-pwa` identity.
+
 ## Cache boundary
 
 `src/song_app/static/sw.js` handles only:

--- a/src/song_app/static/manifest.webmanifest
+++ b/src/song_app/static/manifest.webmanifest
@@ -3,28 +3,28 @@
   "short_name": "Choir",
   "description": "Prepare, render, and review choir practice tracks from MuseScore.",
   "lang": "en",
-  "id": "/",
-  "start_url": "/#/",
-  "scope": "/",
+  "id": "./choir-pwa",
+  "start_url": "./#/",
+  "scope": "./",
   "display": "standalone",
   "background_color": "#14151a",
   "theme_color": "#14151a",
   "categories": ["music", "productivity"],
   "icons": [
     {
-      "src": "/icon-192.png",
+      "src": "./icon-192.png",
       "sizes": "192x192",
       "type": "image/png",
       "purpose": "any"
     },
     {
-      "src": "/icon-512.png",
+      "src": "./icon-512.png",
       "sizes": "512x512",
       "type": "image/png",
       "purpose": "any"
     },
     {
-      "src": "/icon-maskable-512.png",
+      "src": "./icon-maskable-512.png",
       "sizes": "512x512",
       "type": "image/png",
       "purpose": "maskable"

--- a/src/song_app/static/pwa-assets.js
+++ b/src/song_app/static/pwa-assets.js
@@ -1,1 +1,1 @@
-self.SONG_PWA = Object.freeze({"cache":"song-static-2ed587400bdc","assets":["/style.css","/pwa.css","/app.js","/rendering_state.js","/pwa.js","/offline.html","/favicon.svg","/apple-touch-icon.png","/icon-192.png","/icon-512.png","/icon-maskable-512.png","/manifest.webmanifest"]});
+self.SONG_PWA = Object.freeze({"cache":"song-static-b72f38d8f1f2","assets":["/style.css","/pwa.css","/app.js","/rendering_state.js","/pwa.js","/offline.html","/favicon.svg","/apple-touch-icon.png","/icon-192.png","/icon-512.png","/icon-maskable-512.png","/manifest.webmanifest"]});

--- a/src/song_app/tests/test_pwa.py
+++ b/src/song_app/tests/test_pwa.py
@@ -8,6 +8,7 @@ import subprocess
 import sys
 from io import BytesIO
 from pathlib import Path
+from urllib.parse import urljoin
 
 import pytest
 
@@ -42,9 +43,9 @@ def test_manifest_is_standalone_and_has_regular_and_maskable_icons(client):
     assert response.status_code == 200
     assert response.headers["content-type"].startswith("application/manifest+json")
     manifest = response.json()
-    assert manifest["id"] == "/"
-    assert manifest["start_url"] == "/#/"
-    assert manifest["scope"] == "/"
+    assert manifest["id"] == "./choir-pwa"
+    assert manifest["start_url"] == "./#/"
+    assert manifest["scope"] == "./"
     assert manifest["display"] == "standalone"
     assert manifest["theme_color"] == "#14151a"
     assert {(icon["sizes"], icon["purpose"]) for icon in manifest["icons"]} == {
@@ -60,6 +61,26 @@ def test_manifest_is_standalone_and_has_regular_and_maskable_icons(client):
         with Image.open(BytesIO(image_response.content)) as image:
             side = int(icon["sizes"].split("x", 1)[0])
             assert image.size == (side, side)
+
+
+def test_manifest_identity_and_launch_preserve_non_default_port(tmp_path, monkeypatch):
+    monkeypatch.setattr(state, "SONGS_DIR", str(tmp_path))
+    origin = "https://bazzite.taile8d16e.ts.net:8443"
+    with TestClient(server.app, base_url=origin) as port_client:
+        response = port_client.get("/manifest.webmanifest")
+
+    manifest = response.json()
+    base = str(response.url)
+    assert urljoin(base, manifest["id"]) == origin + "/choir-pwa"
+    assert urljoin(base, manifest["start_url"]) == origin + "/#/"
+    assert urljoin(base, manifest["scope"]) == origin + "/"
+    assert {
+        urljoin(base, icon["src"]) for icon in manifest["icons"]
+    } == {
+        origin + "/icon-192.png",
+        origin + "/icon-512.png",
+        origin + "/icon-maskable-512.png",
+    }
 
 
 def test_service_worker_is_root_scoped_javascript_and_never_caches_live_data(client):

--- a/src/song_app/tests/test_pwa_ui.py
+++ b/src/song_app/tests/test_pwa_ui.py
@@ -91,44 +91,54 @@ def _warm_pwa(page, base: str) -> None:
     )
 
 
-def test_chromium_computes_a_distinct_port_qualified_app_identity(live_app, page):
-    _warm_pwa(page, live_app)
+def test_chromium_computes_a_distinct_port_qualified_app_identity(live_app, browser_type):
+    # CDP documents Page.getAppId as returning values only while Chromium's
+    # WebAppEnableManifestId feature is enabled. Launch this focused regression with
+    # that feature explicitly on so an empty response cannot masquerade as a PWA-ID
+    # failure in headless CI.
+    browser = browser_type.launch(args=["--enable-features=WebAppEnableManifestId"])
+    context = browser.new_context()
+    page = context.new_page()
+    try:
+        _warm_pwa(page, live_app)
 
-    manifest = page.evaluate("""async () => {
-        const link = document.querySelector('link[rel="manifest"]');
-        const response = await fetch(link.href);
-        const data = await response.json();
-        return {
-          href: link.href,
-          data,
-          resolved: {
-            id: new URL(data.id, link.href).href,
-            start: new URL(data.start_url, link.href).href,
-            scope: new URL(data.scope, link.href).href,
-          },
-        };
-    }""")
-    assert manifest["href"] == live_app + "/manifest.webmanifest"
-    assert manifest["data"]["display"] == "standalone"
-    assert manifest["data"]["id"] == "./choir-pwa"
-    assert manifest["resolved"] == {
-        "id": live_app + "/choir-pwa",
-        "start": live_app + "/#/",
-        "scope": live_app + "/",
-    }
-    assert {icon["sizes"] for icon in manifest["data"]["icons"]} >= {"192x192", "512x512"}
+        manifest = page.evaluate("""async () => {
+            const link = document.querySelector('link[rel="manifest"]');
+            const response = await fetch(link.href);
+            const data = await response.json();
+            return {
+              href: link.href,
+              data,
+              resolved: {
+                id: new URL(data.id, link.href).href,
+                start: new URL(data.start_url, link.href).href,
+                scope: new URL(data.scope, link.href).href,
+              },
+            };
+        }""")
+        assert manifest["href"] == live_app + "/manifest.webmanifest"
+        assert manifest["data"]["display"] == "standalone"
+        assert manifest["data"]["id"] == "./choir-pwa"
+        assert manifest["resolved"] == {
+            "id": live_app + "/choir-pwa",
+            "start": live_app + "/#/",
+            "scope": live_app + "/",
+        }
+        assert {icon["sizes"] for icon in manifest["data"]["icons"]} >= {"192x192", "512x512"}
 
-    cdp = page.context.new_cdp_session(page)
-    parsed = cdp.send("Page.getAppManifest")
-    assert parsed["url"] == live_app + "/manifest.webmanifest"
-    assert parsed.get("errors", []) == []
-    assert parsed.get("parsed", {}).get("scope") == live_app + "/"
+        cdp = context.new_cdp_session(page)
+        parsed = cdp.send("Page.getAppManifest")
+        assert parsed["url"] == live_app + "/manifest.webmanifest"
+        assert parsed.get("errors", []) == []
+        assert parsed.get("parsed", {}).get("scope") == live_app + "/"
 
-    # This is Chromium's computed PWA identity, not our own URL resolution. A random
-    # non-default port is part of it, and the Choir-specific path prevents a root PWA
-    # such as AgentDeck from being mistaken for this app on the same hostname.
-    app_id = cdp.send("Page.getAppId")
-    assert app_id["appId"] == live_app + "/choir-pwa"
+        # This is Chromium's computed PWA identity, not our own URL resolution. A
+        # random non-default port is part of it, and the Choir-specific path prevents
+        # a root PWA such as AgentDeck from being mistaken for this app on the same host.
+        app_id = cdp.send("Page.getAppId")
+        assert app_id["appId"] == live_app + "/choir-pwa"
+    finally:
+        browser.close()
 
 
 def test_offline_reload_shows_reconnecting_shell_then_returns_to_live_app(live_app, page):

--- a/src/song_app/tests/test_pwa_ui.py
+++ b/src/song_app/tests/test_pwa_ui.py
@@ -91,54 +91,44 @@ def _warm_pwa(page, base: str) -> None:
     )
 
 
-def test_chromium_computes_a_distinct_port_qualified_app_identity(live_app, browser_type):
-    # CDP documents Page.getAppId as returning values only while Chromium's
-    # WebAppEnableManifestId feature is enabled. Launch this focused regression with
-    # that feature explicitly on so an empty response cannot masquerade as a PWA-ID
-    # failure in headless CI.
-    browser = browser_type.launch(args=["--enable-features=WebAppEnableManifestId"])
-    context = browser.new_context()
-    page = context.new_page()
-    try:
-        _warm_pwa(page, live_app)
+def test_chromium_computes_a_distinct_port_qualified_app_identity(live_app, page):
+    _warm_pwa(page, live_app)
 
-        manifest = page.evaluate("""async () => {
-            const link = document.querySelector('link[rel="manifest"]');
-            const response = await fetch(link.href);
-            const data = await response.json();
-            return {
-              href: link.href,
-              data,
-              resolved: {
-                id: new URL(data.id, link.href).href,
-                start: new URL(data.start_url, link.href).href,
-                scope: new URL(data.scope, link.href).href,
-              },
-            };
-        }""")
-        assert manifest["href"] == live_app + "/manifest.webmanifest"
-        assert manifest["data"]["display"] == "standalone"
-        assert manifest["data"]["id"] == "./choir-pwa"
-        assert manifest["resolved"] == {
-            "id": live_app + "/choir-pwa",
-            "start": live_app + "/#/",
-            "scope": live_app + "/",
-        }
-        assert {icon["sizes"] for icon in manifest["data"]["icons"]} >= {"192x192", "512x512"}
+    manifest = page.evaluate("""async () => {
+        const link = document.querySelector('link[rel="manifest"]');
+        const response = await fetch(link.href);
+        const data = await response.json();
+        return {
+          href: link.href,
+          data,
+          resolved: {
+            id: new URL(data.id, link.href).href,
+            start: new URL(data.start_url, link.href).href,
+            scope: new URL(data.scope, link.href).href,
+          },
+        };
+    }""")
+    assert manifest["href"] == live_app + "/manifest.webmanifest"
+    assert manifest["data"]["display"] == "standalone"
+    assert manifest["data"]["id"] == "./choir-pwa"
+    assert manifest["resolved"] == {
+        "id": live_app + "/choir-pwa",
+        "start": live_app + "/#/",
+        "scope": live_app + "/",
+    }
+    assert {icon["sizes"] for icon in manifest["data"]["icons"]} >= {"192x192", "512x512"}
 
-        cdp = context.new_cdp_session(page)
-        parsed = cdp.send("Page.getAppManifest")
-        assert parsed["url"] == live_app + "/manifest.webmanifest"
-        assert parsed.get("errors", []) == []
-        assert parsed.get("parsed", {}).get("scope") == live_app + "/"
-
-        # This is Chromium's computed PWA identity, not our own URL resolution. A
-        # random non-default port is part of it, and the Choir-specific path prevents
-        # a root PWA such as AgentDeck from being mistaken for this app on the same host.
-        app_id = cdp.send("Page.getAppId")
-        assert app_id["appId"] == live_app + "/choir-pwa"
-    finally:
-        browser.close()
+    # Page.getAppManifest returns Chromium's processed WebAppManifest. These values
+    # have already been resolved by Chromium itself, so they directly verify that a
+    # random non-default port is part of the installed-app identity and launch URL.
+    cdp = page.context.new_cdp_session(page)
+    parsed = cdp.send("Page.getAppManifest")
+    assert parsed["url"] == live_app + "/manifest.webmanifest"
+    assert parsed.get("errors", []) == []
+    processed = parsed["manifest"]
+    assert processed["id"] == live_app + "/choir-pwa"
+    assert processed["startUrl"] == live_app + "/#/"
+    assert processed["scope"] == live_app + "/"
 
 
 def test_offline_reload_shows_reconnecting_shell_then_returns_to_live_app(live_app, page):

--- a/src/song_app/tests/test_pwa_ui.py
+++ b/src/song_app/tests/test_pwa_ui.py
@@ -91,23 +91,44 @@ def _warm_pwa(page, base: str) -> None:
     )
 
 
-def test_chromium_parses_the_manifest_and_activates_a_root_worker(live_app, page):
+def test_chromium_computes_a_distinct_port_qualified_app_identity(live_app, page):
     _warm_pwa(page, live_app)
 
     manifest = page.evaluate("""async () => {
         const link = document.querySelector('link[rel="manifest"]');
         const response = await fetch(link.href);
-        return { href: link.href, data: await response.json() };
+        const data = await response.json();
+        return {
+          href: link.href,
+          data,
+          resolved: {
+            id: new URL(data.id, link.href).href,
+            start: new URL(data.start_url, link.href).href,
+            scope: new URL(data.scope, link.href).href,
+          },
+        };
     }""")
     assert manifest["href"] == live_app + "/manifest.webmanifest"
     assert manifest["data"]["display"] == "standalone"
-    assert manifest["data"]["scope"] == "/"
+    assert manifest["data"]["id"] == "./choir-pwa"
+    assert manifest["resolved"] == {
+        "id": live_app + "/choir-pwa",
+        "start": live_app + "/#/",
+        "scope": live_app + "/",
+    }
     assert {icon["sizes"] for icon in manifest["data"]["icons"]} >= {"192x192", "512x512"}
 
     cdp = page.context.new_cdp_session(page)
     parsed = cdp.send("Page.getAppManifest")
     assert parsed["url"] == live_app + "/manifest.webmanifest"
     assert parsed.get("errors", []) == []
+    assert parsed.get("parsed", {}).get("scope") == live_app + "/"
+
+    # This is Chromium's computed PWA identity, not our own URL resolution. A random
+    # non-default port is part of it, and the Choir-specific path prevents a root PWA
+    # such as AgentDeck from being mistaken for this app on the same hostname.
+    app_id = cdp.send("Page.getAppId")
+    assert app_id["appId"] == live_app + "/choir-pwa"
 
 
 def test_offline_reload_shows_reconnecting_shell_then_returns_to_live_app(live_app, page):


### PR DESCRIPTION
## Summary

- give Choir its own manifest identity (`./choir-pwa`) instead of sharing AgentDeck's generic root ID
- make manifest ID, launch URL, scope, and icons relative to the manifest so they resolve against the exact origin/port from which Choir was installed
- refresh the static-shell cache generation
- add an HTTPS non-default-port regression test
- extend the real Chromium test to assert Chromium's processed Web App Manifest resolves `id`, `startUrl`, and `scope` with the actual non-default test port
- document the one-time reinstall required for copies installed from the original `id: "/"` manifest

Closes #42

## Verification

Verified by GitHub Actions at PR head `8d42a028467f6acee527efecb2e3eab93988ca06`:

- **Python and integration tests:** 297 passed, 5 expected browser-module skips
- **Browser tests:** 28 passed, 86 non-browser tests deselected
- Both independent CI jobs passed.