### PR TITLE
Document the choir.taile8d16e.ts.net address for the live app

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1010,10 +1010,25 @@ stage when its output exists; the web app exposes the redo flags instead.
 ## This host: the live app, the deploy, the board
 
 The app is not something someone starts when they want it. It runs as a systemd **user**
-service from this very checkout, `song-app.service` on 127.0.0.1:8123 (reached from the
-phone over Tailscale). The units are committed under `systemd/` — the live copies live in
-`~/.config/systemd/user/`, so an edit here is not live until it is copied over and
-`systemctl --user daemon-reload` has run.
+service from this very checkout, `song-app.service` on 127.0.0.1:8123. The units are
+committed under `systemd/` — the live copies live in `~/.config/systemd/user/`, so an
+edit here is not live until it is copied over and `systemctl --user daemon-reload` has
+run.
+
+The phone reaches it over Tailscale at **https://choir.taile8d16e.ts.net/**, a Tailscale
+*service* (`svc:choir`) whose 443 handler proxies to `http://127.0.0.1:8123`. The older
+`https://bazzite.taile8d16e.ts.net:8123` still works and points at the same app. That
+config lives in tailscaled, not in this repo:
+
+```bash
+tailscale serve --service=svc:choir --https=443 --set-path=/ http://127.0.0.1:8123
+```
+
+Port 8000 is **not** available on this host — a podman container (`sos`, the Outdoor dev
+server) has it, and `song.py` silently falls back to the next free port rather than
+failing, so an app "started on 8000" ends up somewhere like 8002 with nothing pointing at
+it. The two addresses are different **origins**, so an installed PWA does not follow a
+move from one to the other; it has to be installed again (see the PWA identity notes).
 
 A merge deploys itself. `song-app-deploy.timer` runs `scripts/deploy-song-app.sh
 --unattended` every two minutes: it fast-forwards `main` to `origin/main`, installs


### PR DESCRIPTION
The phone now reaches the song app at **https://choir.taile8d16e.ts.net/** — a Tailscale service (`svc:choir`) proxying to the same `127.0.0.1:8123` the systemd unit already serves. The old `bazzite.taile8d16e.ts.net:8123` still works.

CLAUDE.md only said "reached from the phone over Tailscale", which doesn't say which address, or that the config lives in tailscaled rather than in this repo. This adds both, plus the command that sets it.

It also records two things that cost time today:

- **Port 8000 is not free on this host.** The `sos` podman container has it, and `song.py` falls back to the next free port rather than failing — so pointing the unit at 8000 puts the app on 8002 with nothing proxying to it, and the service still reports `active`.
- The two hostnames are **different origins**, so an installed PWA does not follow a move between them; it has to be installed again.

Docs only — no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)