### PR TITLE
Keep a word split by a barline as one word

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -206,6 +206,12 @@ Key test modules:
   staff+position, per-system map, part names, explicit `parts` override).
 - `test_lyric_diagnostics.py` — the structured `Mismatch` fields, measure_start
   inference, and the editor-grid → cells → blocks → import → editor-grid round trip.
+- `test_lyric_hyphenation.py` — a word split by a barline stays one word. The JSON
+  import cuts a line into per-measure chunks and writes each back out as text in
+  between, and that text could say "carries on into the next measure" but not
+  "carries on from the previous one", so every chunk starting mid-word was read as a
+  fresh word. Four of the five fail without the fix; the fifth is the guard that a
+  word inside one measure is untouched.
 - `src/clean_score/tests/scorebuilder.py` — the shared synthetic-score helper those
   two use (not a test module).
 - `test_simple1_split.py` — a **golden-file snapshot** test: it runs the split
@@ -654,9 +660,18 @@ systems. `to_dict()` puts them on the wire for the browser; the CLI wrapper prin
   no token. Rests get no token.
 - **TXT format**: `# Measure N` headers, then `staffId [syllableCount]: tok1 tok2 ...`
   Tokens are space-separated; hyphens join syllables of a word (`il-man`);
-  trailing hyphen = word continues into next measure; `_` = eligible note with
-  no lyric. Syllabic state (begin/middle/end/single) is reconstructed from
-  hyphenation on import. (Alignment is per-measure — the token counter resets at each
+  trailing hyphen = the word continues, and that holds between **any** two tokens,
+  not only across a barline; a **leading** hyphen says the same thing looking
+  backwards, so a line carried over from the previous system may be written
+  `-hil-le`. `_` = eligible note with no lyric. Syllabic state
+  (begin/middle/end/single) is reconstructed from hyphenation on import: a syllable
+  is `middle` when a word runs both into and out of it, and reading that as `end`
+  splits one word in two. It did — `lai-ne-hil-le` was stored as `lai-ne-hil` plus a
+  stray `le`, because the continuation rule was applied only to the first token of a
+  measure. The syllables still land on the right notes, so no health check, test or
+  mismatch count noticed; what showed it was the by-system editor displaying
+  `hil le` where the imported JSON said `hil-le`. See `test_lyric_hyphenation.py`.
+  (Alignment is per-measure — the token counter resets at each
   barline — so a missing slur/tie only misaligns within its own measure, not the rest
   of the line.)
 - **JSON format**: line-by-line; tokens are *distributed across measures* using

--- a/src/clean_score/lyric_txt.py
+++ b/src/clean_score/lyric_txt.py
@@ -859,43 +859,38 @@ def _tokens_to_syllables(
 ) -> List[Tuple[str, str]]:
     """
     Expand tokens (e.g. "il-man", "kuu-ta", "ja") into a list of (syllabic, text) per chord.
-    Hyphen in the middle of a token splits into begin/end syllables.
-    If first_syllabic_continuation is True (previous measure ended with begin/middle), the first
-    syllable is forced to "end" so it continues across the bar.
+
+    A syllable's state is just how it joins its neighbours: whether a word carries on
+    into it from the left, and whether it carries on out to the right. A trailing hyphen
+    says "carries on", and that applies between any two tokens -- not only at a measure
+    boundary. `first_syllabic_continuation` supplies the answer for the very first token,
+    which has no predecessor here (the previous measure ended mid-word).
+
+    Getting this wrong is not cosmetic: a syllable that continues a word but is written
+    `end` (or worse, `single`) splits one word into two, so `lai-ne-hil-le` came back as
+    `lai-ne-hil` plus a stray `le`.
     """
     out: List[Tuple[str, str]] = []
-    for idx, tok in enumerate(tokens):
+    continues_from_previous = first_syllabic_continuation
+    for tok in tokens:
         if tok == "_":
             out.append(("_", ""))
+            continues_from_previous = False
             continue
-        # Split on hyphen that joins syllables (not leading/trailing)
         raw_trailing_hyphen = tok.strip().endswith("-")
-        parts = tok.strip().rstrip("-").split("-")
-        if len(parts) == 1:
-            text = parts[0].strip()
-            if first_syllabic_continuation and idx == 0:
-                out.append(("end", text))
-            elif raw_trailing_hyphen:
-                out.append(("begin", text))  # continues to next measure
+        # strip("-") not rstrip: a leading hyphen is how a caller writes "this continues
+        # the previous line", and it must not survive into the syllable text.
+        parts = [p.strip() for p in tok.strip().strip("-").split("-") if p.strip()]
+        if not parts:
+            continue
+        for i, p in enumerate(parts):
+            joins_left = continues_from_previous if i == 0 else True
+            joins_right = (i < len(parts) - 1) or raw_trailing_hyphen
+            if joins_left:
+                out.append(("middle" if joins_right else "end", p))
             else:
-                out.append(("single", text))
-        else:
-            for i, p in enumerate(parts):
-                p = p.strip()
-                if not p:
-                    continue
-                if first_syllabic_continuation and idx == 0 and i == 0:
-                    out.append(("end", p))
-                elif i == 0:
-                    out.append(("begin", p))
-                elif i == len(parts) - 1:
-                    # Last part: "end" unless token had trailing hyphen (word continues to next measure)
-                    if raw_trailing_hyphen:
-                        out.append(("begin", p))
-                    else:
-                        out.append(("end", p))
-                else:
-                    out.append(("middle", p))
+                out.append(("begin" if joins_right else "single", p))
+        continues_from_previous = raw_trailing_hyphen
     return out
 
 
@@ -910,48 +905,21 @@ def _last_token_ends_with_hyphen(tokens: List[str]) -> bool:
 def _syllables_to_tokens(syllables: List[Tuple[str, str]]) -> List[str]:
     """
     Convert (syllabic, text) pairs back to tokens (e.g. begin+end -> "a-b", single -> "a", begin-only -> "a-").
+
+    A `middle` keeps its trailing hyphen. It is the only way this text can say the word
+    is not finished, and the JSON import cuts a line into per-measure chunks -- so a
+    chunk that begins mid-word used to come back bare and read as a fresh word.
     """
     tokens: List[str] = []
-    i = 0
-    while i < len(syllables):
-        syllabic, text = syllables[i]
+    for syllabic, text in syllables:
         if syllabic == "_":
             tokens.append("_")
-            i += 1
-        elif syllabic == "single":
-            tokens.append(text)
-            i += 1
-        elif syllabic == "begin":
-            parts = [text]
-            i += 1
-            while i < len(syllables):
-                s2, t2 = syllables[i]
-                if s2 == "middle":
-                    parts.append(t2)
-                    i += 1
-                elif s2 == "end":
-                    parts.append(t2)
-                    i += 1
-                    tokens.append("-".join(parts))
-                    break
-                elif s2 == "begin" and i + 1 == len(syllables):
-                    # Trailing-hyphen token like "il-ki-rii-vi-" ends with (begin, vi); merge as final syllable
-                    parts.append(t2)
-                    i += 1
-                    tokens.append("-".join(parts) + "-")
-                    break
-                else:
-                    break
-            else:
-                tokens.append("-".join(parts) + "-")
-        elif syllabic == "end":
-            tokens.append(text)
-            i += 1
-        elif syllabic == "middle":
-            tokens.append(text)
-            i += 1
+            continue
+        piece = text + "-" if syllabic in ("begin", "middle") else text
+        if tokens and tokens[-1] != "_" and tokens[-1].endswith("-"):
+            tokens[-1] = tokens[-1] + piece
         else:
-            i += 1
+            tokens.append(piece)
     return tokens
 
 

--- a/src/clean_score/tests/test_lyric_hyphenation.py
+++ b/src/clean_score/tests/test_lyric_hyphenation.py
@@ -1,0 +1,81 @@
+"""A word that crosses a barline must stay one word.
+
+The JSON import cuts each line into per-measure chunks and, in between, writes those
+chunks back out as plain text. That text can say "this word carries on into the next
+measure" (a trailing hyphen) but for a long time could not say "this word carries on
+FROM the previous one" -- so every chunk that began mid-word was read as a fresh word.
+
+Measured on the real songs, this hit any word split by a barline: `lai-ne-hil-le` was
+stored as `lai-ne-hil` plus a stray `le`, and the by-system editor then showed the
+singer "hil le" where the imported text said "hil-le". The syllables land on the right
+notes either way, which is why nothing else caught it.
+"""
+
+from lxml import etree
+
+from src.clean_score.lyric_txt import editor_grid, place_lyrics
+
+from .scorebuilder import build_score
+
+
+def _states(root, staff_id, measure):
+    """[(text, syllabic)] for one staff's measure, in note order."""
+    staff = [s for s in root.find(".//Score").findall("Staff")
+             if s.get("id") == str(staff_id)][0]
+    m = staff.findall("Measure")[measure - 1]
+    return [(ly.findtext("text"), ly.findtext("syllabic")) for ly in m.iter("Lyrics")]
+
+
+def test_a_word_split_by_a_barline_stays_one_word():
+    root = build_score(staff_ids=(1,), measures=2, chords=3)
+    place_lyrics(root, [{"measure_start": 1,
+                         "lyrics": [{"parts": ["P1"], "text": "lai-ne-hil-le län-ti"}]}],
+                 fmt="json", replace=True)
+    # "lai-ne-hil-le" runs out of measure 1 after three notes and finishes in measure 2.
+    assert _states(root, 1, 1) == [("lai", "begin"), ("ne", "middle"), ("hil", "middle")]
+    assert _states(root, 1, 2) == [("le", "end"), ("län", "begin"), ("ti", "end")]
+
+
+def test_a_word_carried_in_from_the_previous_block_stays_one_word():
+    """The real shape: consecutive JSON blocks, the first ending mid-word."""
+    root = build_score(staff_ids=(1,), measures=2, chords=2)
+    place_lyrics(root, [{"measure_start": 1,
+                         "lyrics": [{"parts": ["P1"], "text": "lai-ne-"}]},
+                        {"measure_start": 2,
+                         "lyrics": [{"parts": ["P1"], "text": "hil-le"}]}],
+                 fmt="json", replace=True)
+    assert _states(root, 1, 1) == [("lai", "begin"), ("ne", "middle")]
+    assert _states(root, 1, 2) == [("hil", "middle"), ("le", "end")]
+
+
+def test_a_leading_hyphen_marks_a_continuation_and_is_not_sung():
+    """Writing the carried-over line as `-hil-le` is allowed, and means the same thing."""
+    root = build_score(staff_ids=(1,), measures=2, chords=2)
+    place_lyrics(root, [{"measure_start": 1,
+                         "lyrics": [{"parts": ["P1"], "text": "lai-ne-"}]},
+                        {"measure_start": 2,
+                         "lyrics": [{"parts": ["P1"], "text": "-hil-le"}]}],
+                 fmt="json", replace=True)
+    assert _states(root, 1, 2) == [("hil", "middle"), ("le", "end")]
+
+
+def test_a_word_inside_one_measure_is_untouched():
+    """The guard: most words never cross a barline and must come through as before."""
+    root = build_score(staff_ids=(1,), measures=2, chords=2)
+    place_lyrics(root, [{"measure_start": 1,
+                         "lyrics": [{"parts": ["P1"], "text": "il-man kuu-ta"}]}],
+                 fmt="json", replace=True)
+    assert _states(root, 1, 1) == [("il", "begin"), ("man", "end")]
+    assert _states(root, 1, 2) == [("kuu", "begin"), ("ta", "end")]
+
+
+def test_the_editor_reads_back_the_words_that_were_imported():
+    """What the by-system editor shows must be the text that went in, or the two
+    ways of editing lyrics disagree about the same score."""
+    # Two notes to a measure, so the break lands mid-word with two syllables still to
+    # come -- the shape that used to read back as "hil le", two words instead of one.
+    text = "lai-ne-hil-le"
+    root = build_score(staff_ids=(1,), measures=2, chords=2)
+    place_lyrics(root, [{"measure_start": 1, "lyrics": [{"parts": ["P1"], "text": text}]}],
+                 fmt="json", replace=True)
+    assert editor_grid(root, systems=[(1, 2)]).text(0, "P1") == text


### PR DESCRIPTION
## What was wrong

The by-system lyric editor showed `hil le` for a cell whose imported text said `hil-le`. The two ways of editing lyrics were describing the same score differently.

The JSON import cuts each line into per-measure chunks and writes those chunks back out as plain text in between. That text can say *"this word carries on into the next measure"* — a trailing hyphen — but had no way to say *"this word carries on **from** the previous one"*. So every chunk beginning mid-word was read as a fresh word:

| | stored as |
|---|---|
| `lai-ne-hil-le` | `lai-ne-hil` + a stray `le` |
| `län-ti-sil-le;` | `län-ti-` + `sil` + `le;` |

The syllables land on the right notes either way, which is why nothing caught it — health checks pass, the syllable arithmetic balances, and the import reports no mismatch.

## Why it is the code, not the input

Re-importing each stored `lyrics.json` with the unmodified code reproduces its score exactly — **1760 lyrics across the three songs that have one, zero differences**. So those scores are a pure function of the submitted text, with nothing else having touched them.

The text itself is right: the word is *lainehille*, `lai-ne-hil-le`, and it crosses the measure 5/6 barline. `län-ti-sil-le;` was submitted as one well-formed token and was mangled anyway — it straddles measure 6/7.

Writing the carried-over line as `-hil-le`, with an explicit leading hyphen, produced byte-identical corruption. The leading hyphen *is* parsed correctly and then discarded by the chunker, so there was no notation that could have avoided this.

## The change

A syllable's state is only how it joins its neighbours, so it is now derived from that: does a word run into this syllable from the left, and does it run out to the right.

- `_tokens_to_syllables` applies the continuation rule between **any** two tokens, not only at the first token of a measure — and picks `middle` rather than `end` when the word carries on. A leading hyphen is accepted as "continues the previous line".
- `_syllables_to_tokens` keeps the trailing hyphen on a `middle`, so a chunk boundary stops erasing it. This also retires a lookahead loop and its `il-ki-rii-vi-` special case.

Net effect on Pois meni merehen päivä: **32 of 32 lines** now read back identically to the submitted text, where 16 did before.

## Tests

`src/clean_score/tests/test_lyric_hyphenation.py` — five tests; **four fail without the fix**, the fifth is the guard that a word inside one measure is untouched. Full suite **330 passed**, including the pinned export→import round-trip and the `il-man il-ki-rii-vi-` regressions.

## Note for existing songs

Songs keep their stored hyphenation until their lyrics are imported once more. The words and which notes they sit on are unaffected either way, so this is cosmetic for anything already recorded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)