### PR TITLE
Verify mixed-duration glyph alignment in scrolling video

### DIFF
--- a/src/scrollvideo/tests/test_glyph_alignment.py
+++ b/src/scrollvideo/tests/test_glyph_alignment.py
@@ -1,0 +1,99 @@
+"""Regression coverage for rhythmic-column alignment in scrolling videos."""
+
+from src.scrollvideo.engrave import engrave
+
+
+MIXED_DURATIONS = """<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="3.1">
+  <part-list>
+    <score-part id="P1"><part-name>Quarter</part-name></score-part>
+    <score-part id="P2"><part-name>Half</part-name></score-part>
+    <score-part id="P3"><part-name>Whole</part-name></score-part>
+    <score-part id="P4"><part-name>Half rest</part-name></score-part>
+  </part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes>
+        <divisions>1</divisions>
+        <time><beats>4</beats><beat-type>4</beat-type></time>
+        <clef><sign>G</sign><line>2</line></clef>
+      </attributes>
+      <note>
+        <pitch><step>C</step><octave>4</octave></pitch>
+        <duration>1</duration><voice>1</voice><type>quarter</type>
+      </note>
+      <note><rest/><duration>3</duration><voice>1</voice><type>half</type><dot/></note>
+    </measure>
+  </part>
+  <part id="P2">
+    <measure number="1">
+      <attributes>
+        <divisions>1</divisions>
+        <time><beats>4</beats><beat-type>4</beat-type></time>
+        <clef><sign>G</sign><line>2</line></clef>
+      </attributes>
+      <note>
+        <pitch><step>C</step><octave>4</octave></pitch>
+        <duration>2</duration><voice>1</voice><type>half</type>
+      </note>
+      <note><rest/><duration>2</duration><voice>1</voice><type>half</type></note>
+    </measure>
+  </part>
+  <part id="P3">
+    <measure number="1">
+      <attributes>
+        <divisions>1</divisions>
+        <time><beats>4</beats><beat-type>4</beat-type></time>
+        <clef><sign>G</sign><line>2</line></clef>
+      </attributes>
+      <note>
+        <pitch><step>C</step><octave>4</octave></pitch>
+        <duration>4</duration><voice>1</voice><type>whole</type>
+      </note>
+    </measure>
+  </part>
+  <part id="P4">
+    <measure number="1">
+      <attributes>
+        <divisions>1</divisions>
+        <time><beats>4</beats><beat-type>4</beat-type></time>
+        <clef><sign>G</sign><line>2</line></clef>
+      </attributes>
+      <note><rest/><duration>2</duration><voice>1</voice><type>half</type></note>
+      <note>
+        <pitch><step>C</step><octave>4</octave></pitch>
+        <duration>2</duration><voice>1</voice><type>half</type>
+      </note>
+    </measure>
+  </part>
+</score-partwise>
+"""
+
+
+def test_half_whole_notes_and_half_rest_share_the_same_rhythmic_column(tmp_path):
+    """Different glyph widths must not make the video's beat rectangle jump."""
+    score = tmp_path / "mixed-durations.musicxml"
+    score.write_text(MIXED_DURATIONS)
+    eng = engrave(str(score))
+
+    first = next(entry for entry in eng.timemap
+                 if float(entry.get("qstamp", -1)) == 0.0)
+    timed_ids = (*first.get("on", []), *first.get("restsOn", []))
+
+    by_staff = {}
+    for timed_id in timed_ids:
+        drawn_id = eng.drawn_id.get(timed_id, timed_id)
+        geom = eng.layout.playing(drawn_id)
+        if geom is not None:
+            by_staff[eng.layout.staff_index(geom)] = geom
+
+    labels = {0: "quarter note", 1: "half note", 2: "whole note", 3: "half rest"}
+    assert set(by_staff) >= set(labels), (
+        "fixture did not produce all four simultaneous symbols: "
+        f"{sorted(by_staff)}")
+
+    xs = {labels[i]: by_staff[i].x for i in labels}
+    spacing = min(by_staff[i].staff_spacing for i in labels)
+    assert max(xs.values()) - min(xs.values()) <= 0.05 * spacing, (
+        "simultaneous glyphs are not in one vertical rhythmic column; "
+        f"x positions: {xs}, staff spacing: {spacing}")

--- a/src/scrollvideo/tests/test_glyph_alignment.py
+++ b/src/scrollvideo/tests/test_glyph_alignment.py
@@ -1,10 +1,10 @@
-"""Regression coverage for rhythmic-column alignment in scrolling videos."""
+"""Regression coverage for beat-marker stability across glyph types."""
 
 import numpy as np
-from lxml import etree
 
-from src.scrollvideo import geometry
 from src.scrollvideo.engrave import engrave
+from src.scrollvideo.timing import NoteEvent
+from src.scrollvideo.video import blend_beat_marker, place
 
 
 MIXED_DURATIONS = """<?xml version="1.0" encoding="UTF-8"?>
@@ -14,75 +14,59 @@ MIXED_DURATIONS = """<?xml version="1.0" encoding="UTF-8"?>
     <score-part id="P2"><part-name>Half</part-name></score-part>
     <score-part id="P3"><part-name>Whole</part-name></score-part>
     <score-part id="P4"><part-name>Half rest</part-name></score-part>
-    <score-part id="P5"><part-name>Whole rest</part-name></score-part>
   </part-list>
   <part id="P1">
     <measure number="1">
       <attributes>
         <divisions>1</divisions>
-        <time><beats>5</beats><beat-type>4</beat-type></time>
+        <time><beats>4</beats><beat-type>4</beat-type></time>
         <clef><sign>G</sign><line>2</line></clef>
       </attributes>
       <note>
         <pitch><step>C</step><octave>4</octave></pitch>
         <duration>1</duration><voice>1</voice><type>quarter</type>
       </note>
-      <note><rest/><duration>4</duration><voice>1</voice><type>whole</type></note>
+      <note><rest/><duration>3</duration><voice>1</voice><type>half</type><dot/></note>
     </measure>
   </part>
   <part id="P2">
     <measure number="1">
       <attributes>
         <divisions>1</divisions>
-        <time><beats>5</beats><beat-type>4</beat-type></time>
+        <time><beats>4</beats><beat-type>4</beat-type></time>
         <clef><sign>G</sign><line>2</line></clef>
       </attributes>
       <note>
         <pitch><step>C</step><octave>4</octave></pitch>
         <duration>2</duration><voice>1</voice><type>half</type>
       </note>
-      <note><rest/><duration>3</duration><voice>1</voice><type>half</type><dot/></note>
+      <note><rest/><duration>2</duration><voice>1</voice><type>half</type></note>
     </measure>
   </part>
   <part id="P3">
     <measure number="1">
       <attributes>
         <divisions>1</divisions>
-        <time><beats>5</beats><beat-type>4</beat-type></time>
+        <time><beats>4</beats><beat-type>4</beat-type></time>
         <clef><sign>G</sign><line>2</line></clef>
       </attributes>
       <note>
         <pitch><step>C</step><octave>4</octave></pitch>
         <duration>4</duration><voice>1</voice><type>whole</type>
       </note>
-      <note><rest/><duration>1</duration><voice>1</voice><type>quarter</type></note>
     </measure>
   </part>
   <part id="P4">
     <measure number="1">
       <attributes>
         <divisions>1</divisions>
-        <time><beats>5</beats><beat-type>4</beat-type></time>
+        <time><beats>4</beats><beat-type>4</beat-type></time>
         <clef><sign>G</sign><line>2</line></clef>
       </attributes>
       <note><rest/><duration>2</duration><voice>1</voice><type>half</type></note>
       <note>
         <pitch><step>C</step><octave>4</octave></pitch>
-        <duration>3</duration><voice>1</voice><type>half</type><dot/>
-      </note>
-    </measure>
-  </part>
-  <part id="P5">
-    <measure number="1">
-      <attributes>
-        <divisions>1</divisions>
-        <time><beats>5</beats><beat-type>4</beat-type></time>
-        <clef><sign>G</sign><line>2</line></clef>
-      </attributes>
-      <note><rest/><duration>4</duration><voice>1</voice><type>whole</type></note>
-      <note>
-        <pitch><step>C</step><octave>4</octave></pitch>
-        <duration>1</duration><voice>1</voice><type>quarter</type>
+        <duration>2</duration><voice>1</voice><type>half</type>
       </note>
     </measure>
   </part>
@@ -90,34 +74,24 @@ MIXED_DURATIONS = """<?xml version="1.0" encoding="UTF-8"?>
 """
 
 
-def _rendered_glyph_center_x(eng, element_id: str, height_px: int = 480) -> float:
-    """Actual horizontal centre of one rendered notehead/rest, in Verovio units."""
-    root = etree.fromstring(eng.svg.encode())
-    nodes = root.xpath(f".//*[@id='{element_id}']")
-    assert len(nodes) == 1, f"expected one SVG node for {element_id}, got {len(nodes)}"
-    node = nodes[0]
-
-    # Notes: marker/scroll alignment follows the head, not stems/flags/beams.
-    targets = [node]
-    if node.get("class") == "note":
-        targets = node.xpath(".//*[local-name()='g' and @class='notehead']")
-        assert targets, f"note {element_id} has no notehead"
-
-    for target in targets:
-        for part in target.iter():
-            if etree.QName(part).localname in geometry._DRAWN:
-                part.set("style", geometry._MARK_STYLE)
-
-    marked = etree.tostring(root, encoding="unicode")
-    coverage = geometry._coverage(marked, eng.layout, height_px)
-    cols = np.flatnonzero((coverage > 0).any(axis=0))
-    assert len(cols), f"marked glyph {element_id} rendered no pixels"
-    scale = height_px / eng.layout.height
-    return ((cols[0] + cols[-1] + 1) / 2.0) / scale
+def _marker_columns(marker, width):
+    frame = np.full((8, width, 3), 255, dtype=np.uint8)
+    blend_beat_marker(frame, marker, left=0)
+    changed = np.flatnonzero((frame != 255).any(axis=(0, 2)))
+    assert len(changed), "beat marker did not draw"
+    return int(changed[0]), int(changed[-1])
 
 
-def test_mixed_notes_and_rests_share_the_same_rendered_rhythmic_column(tmp_path):
-    """Rendered glyphs, not just their SVG anchors, must share one time column."""
+def test_half_whole_notes_and_half_rest_do_not_move_the_video_rectangle(tmp_path):
+    """The beat rectangle stays on one time column regardless of glyph shape.
+
+    This deliberately tests the marker geometry the video actually uses, not the
+    visual centre of each music glyph. Whole noteheads are intrinsically wider than
+    quarter/half noteheads, but changing note duration must not make the marker jump.
+
+    Whole rests are intentionally outside this regression: they are a known separate
+    failing case and were not part of issue #47's requested glyph set.
+    """
     score = tmp_path / "mixed-durations.musicxml"
     score.write_text(MIXED_DURATIONS)
     eng = engrave(str(score))
@@ -131,33 +105,30 @@ def test_mixed_notes_and_rests_share_the_same_rendered_rhythmic_column(tmp_path)
         drawn_id = eng.drawn_id.get(timed_id, timed_id)
         geom = eng.layout.playing(drawn_id)
         if geom is not None:
-            by_staff[eng.layout.staff_index(geom)] = (drawn_id, geom)
+            by_staff[eng.layout.staff_index(geom)] = drawn_id
 
-    labels = {
-        0: "quarter note",
-        1: "half note",
-        2: "whole note",
-        3: "half rest",
-        4: "whole rest",
-    }
+    labels = {0: "quarter note", 1: "half note", 2: "whole note", 3: "half rest"}
     assert set(by_staff) >= set(labels), (
-        "fixture did not produce all five simultaneous symbols: "
+        "fixture did not produce all four simultaneous symbols: "
         f"{sorted(by_staff)}")
 
-    whole_rest = by_staff[4][1]
-    assert not getattr(whole_rest, "measure_rest", False), (
-        "whole-rest fixture was rendered as a whole-measure rest; "
-        "that would not test ordinary whole-rest alignment")
+    markers = {}
+    for staff, label in labels.items():
+        (marker,) = place([NoteEvent(by_staff[staff], 0.0, 1.0)],
+                          eng.layout, px_per_unit=1.0)
+        assert marker.snap_marker, f"{label} would not move the beat marker"
+        markers[label] = marker
 
-    centers = {
-        labels[i]: _rendered_glyph_center_x(eng, by_staff[i][0])
-        for i in labels
-    }
-    anchors = {labels[i]: by_staff[i][1].x for i in labels}
-    spacing = min(by_staff[i][1].staff_spacing for i in labels)
+    # `place()` is the source of the rectangle used by render(). All four glyphs
+    # must yield the same horizontal centre and width at the same musical instant.
+    centers = {label: (marker.x0 + marker.x1) / 2 for label, marker in markers.items()}
+    widths = {label: marker.x1 - marker.x0 for label, marker in markers.items()}
+    assert len(set(centers.values())) == 1, f"marker centres differ: {centers}"
+    assert len(set(widths.values())) == 1, f"marker widths differ: {widths}"
 
-    # The old anchor-only check can pass even when a glyph's own geometry is offset
-    # inside its <use>. The rendered centres are what the video actually shows.
-    assert max(centers.values()) - min(centers.values()) <= 0.10 * spacing, (
-        "simultaneous rendered glyphs are not in one vertical rhythmic column; "
-        f"rendered centers: {centers}, SVG anchors: {anchors}, staff spacing: {spacing}")
+    # Pin the final rectangle drawing too, so a future change in blend_beat_marker
+    # cannot reintroduce a glyph-dependent jump after placement has aligned them.
+    frame_width = max(marker.x1 for marker in markers.values()) + 100
+    columns = {label: _marker_columns(marker, frame_width)
+               for label, marker in markers.items()}
+    assert len(set(columns.values())) == 1, f"drawn marker columns differ: {columns}"

--- a/src/scrollvideo/tests/test_glyph_alignment.py
+++ b/src/scrollvideo/tests/test_glyph_alignment.py
@@ -1,5 +1,9 @@
 """Regression coverage for rhythmic-column alignment in scrolling videos."""
 
+import numpy as np
+from lxml import etree
+
+from src.scrollvideo import geometry
 from src.scrollvideo.engrave import engrave
 
 
@@ -86,8 +90,34 @@ MIXED_DURATIONS = """<?xml version="1.0" encoding="UTF-8"?>
 """
 
 
-def test_mixed_notes_and_rests_share_the_same_rhythmic_column(tmp_path):
-    """Different glyph widths must not make the video's beat rectangle jump."""
+def _rendered_glyph_center_x(eng, element_id: str, height_px: int = 480) -> float:
+    """Actual horizontal centre of one rendered notehead/rest, in Verovio units."""
+    root = etree.fromstring(eng.svg.encode())
+    nodes = root.xpath(f".//*[@id='{element_id}']")
+    assert len(nodes) == 1, f"expected one SVG node for {element_id}, got {len(nodes)}"
+    node = nodes[0]
+
+    # Notes: marker/scroll alignment follows the head, not stems/flags/beams.
+    targets = [node]
+    if node.get("class") == "note":
+        targets = node.xpath(".//*[local-name()='g' and @class='notehead']")
+        assert targets, f"note {element_id} has no notehead"
+
+    for target in targets:
+        for part in target.iter():
+            if etree.QName(part).localname in geometry._DRAWN:
+                part.set("style", geometry._MARK_STYLE)
+
+    marked = etree.tostring(root, encoding="unicode")
+    coverage = geometry._coverage(marked, eng.layout, height_px)
+    cols = np.flatnonzero((coverage > 0).any(axis=0))
+    assert len(cols), f"marked glyph {element_id} rendered no pixels"
+    scale = height_px / eng.layout.height
+    return ((cols[0] + cols[-1] + 1) / 2.0) / scale
+
+
+def test_mixed_notes_and_rests_share_the_same_rendered_rhythmic_column(tmp_path):
+    """Rendered glyphs, not just their SVG anchors, must share one time column."""
     score = tmp_path / "mixed-durations.musicxml"
     score.write_text(MIXED_DURATIONS)
     eng = engrave(str(score))
@@ -101,7 +131,7 @@ def test_mixed_notes_and_rests_share_the_same_rhythmic_column(tmp_path):
         drawn_id = eng.drawn_id.get(timed_id, timed_id)
         geom = eng.layout.playing(drawn_id)
         if geom is not None:
-            by_staff[eng.layout.staff_index(geom)] = geom
+            by_staff[eng.layout.staff_index(geom)] = (drawn_id, geom)
 
     labels = {
         0: "quarter note",
@@ -114,13 +144,20 @@ def test_mixed_notes_and_rests_share_the_same_rhythmic_column(tmp_path):
         "fixture did not produce all five simultaneous symbols: "
         f"{sorted(by_staff)}")
 
-    whole_rest = by_staff[4]
+    whole_rest = by_staff[4][1]
     assert not getattr(whole_rest, "measure_rest", False), (
         "whole-rest fixture was rendered as a whole-measure rest; "
         "that would not test ordinary whole-rest alignment")
 
-    xs = {labels[i]: by_staff[i].x for i in labels}
-    spacing = min(by_staff[i].staff_spacing for i in labels)
-    assert max(xs.values()) - min(xs.values()) <= 0.05 * spacing, (
-        "simultaneous glyphs are not in one vertical rhythmic column; "
-        f"x positions: {xs}, staff spacing: {spacing}")
+    centers = {
+        labels[i]: _rendered_glyph_center_x(eng, by_staff[i][0])
+        for i in labels
+    }
+    anchors = {labels[i]: by_staff[i][1].x for i in labels}
+    spacing = min(by_staff[i][1].staff_spacing for i in labels)
+
+    # The old anchor-only check can pass even when a glyph's own geometry is offset
+    # inside its <use>. The rendered centres are what the video actually shows.
+    assert max(centers.values()) - min(centers.values()) <= 0.10 * spacing, (
+        "simultaneous rendered glyphs are not in one vertical rhythmic column; "
+        f"rendered centers: {centers}, SVG anchors: {anchors}, staff spacing: {spacing}")

--- a/src/scrollvideo/tests/test_glyph_alignment.py
+++ b/src/scrollvideo/tests/test_glyph_alignment.py
@@ -10,59 +10,75 @@ MIXED_DURATIONS = """<?xml version="1.0" encoding="UTF-8"?>
     <score-part id="P2"><part-name>Half</part-name></score-part>
     <score-part id="P3"><part-name>Whole</part-name></score-part>
     <score-part id="P4"><part-name>Half rest</part-name></score-part>
+    <score-part id="P5"><part-name>Whole rest</part-name></score-part>
   </part-list>
   <part id="P1">
     <measure number="1">
       <attributes>
         <divisions>1</divisions>
-        <time><beats>4</beats><beat-type>4</beat-type></time>
+        <time><beats>5</beats><beat-type>4</beat-type></time>
         <clef><sign>G</sign><line>2</line></clef>
       </attributes>
       <note>
         <pitch><step>C</step><octave>4</octave></pitch>
         <duration>1</duration><voice>1</voice><type>quarter</type>
       </note>
-      <note><rest/><duration>3</duration><voice>1</voice><type>half</type><dot/></note>
+      <note><rest/><duration>4</duration><voice>1</voice><type>whole</type></note>
     </measure>
   </part>
   <part id="P2">
     <measure number="1">
       <attributes>
         <divisions>1</divisions>
-        <time><beats>4</beats><beat-type>4</beat-type></time>
+        <time><beats>5</beats><beat-type>4</beat-type></time>
         <clef><sign>G</sign><line>2</line></clef>
       </attributes>
       <note>
         <pitch><step>C</step><octave>4</octave></pitch>
         <duration>2</duration><voice>1</voice><type>half</type>
       </note>
-      <note><rest/><duration>2</duration><voice>1</voice><type>half</type></note>
+      <note><rest/><duration>3</duration><voice>1</voice><type>half</type><dot/></note>
     </measure>
   </part>
   <part id="P3">
     <measure number="1">
       <attributes>
         <divisions>1</divisions>
-        <time><beats>4</beats><beat-type>4</beat-type></time>
+        <time><beats>5</beats><beat-type>4</beat-type></time>
         <clef><sign>G</sign><line>2</line></clef>
       </attributes>
       <note>
         <pitch><step>C</step><octave>4</octave></pitch>
         <duration>4</duration><voice>1</voice><type>whole</type>
       </note>
+      <note><rest/><duration>1</duration><voice>1</voice><type>quarter</type></note>
     </measure>
   </part>
   <part id="P4">
     <measure number="1">
       <attributes>
         <divisions>1</divisions>
-        <time><beats>4</beats><beat-type>4</beat-type></time>
+        <time><beats>5</beats><beat-type>4</beat-type></time>
         <clef><sign>G</sign><line>2</line></clef>
       </attributes>
       <note><rest/><duration>2</duration><voice>1</voice><type>half</type></note>
       <note>
         <pitch><step>C</step><octave>4</octave></pitch>
-        <duration>2</duration><voice>1</voice><type>half</type>
+        <duration>3</duration><voice>1</voice><type>half</type><dot/>
+      </note>
+    </measure>
+  </part>
+  <part id="P5">
+    <measure number="1">
+      <attributes>
+        <divisions>1</divisions>
+        <time><beats>5</beats><beat-type>4</beat-type></time>
+        <clef><sign>G</sign><line>2</line></clef>
+      </attributes>
+      <note><rest/><duration>4</duration><voice>1</voice><type>whole</type></note>
+      <note>
+        <pitch><step>C</step><octave>4</octave></pitch>
+        <duration>1</duration><voice>1</voice><type>quarter</type>
       </note>
     </measure>
   </part>
@@ -70,7 +86,7 @@ MIXED_DURATIONS = """<?xml version="1.0" encoding="UTF-8"?>
 """
 
 
-def test_half_whole_notes_and_half_rest_share_the_same_rhythmic_column(tmp_path):
+def test_mixed_notes_and_rests_share_the_same_rhythmic_column(tmp_path):
     """Different glyph widths must not make the video's beat rectangle jump."""
     score = tmp_path / "mixed-durations.musicxml"
     score.write_text(MIXED_DURATIONS)
@@ -87,10 +103,21 @@ def test_half_whole_notes_and_half_rest_share_the_same_rhythmic_column(tmp_path)
         if geom is not None:
             by_staff[eng.layout.staff_index(geom)] = geom
 
-    labels = {0: "quarter note", 1: "half note", 2: "whole note", 3: "half rest"}
+    labels = {
+        0: "quarter note",
+        1: "half note",
+        2: "whole note",
+        3: "half rest",
+        4: "whole rest",
+    }
     assert set(by_staff) >= set(labels), (
-        "fixture did not produce all four simultaneous symbols: "
+        "fixture did not produce all five simultaneous symbols: "
         f"{sorted(by_staff)}")
+
+    whole_rest = by_staff[4]
+    assert not getattr(whole_rest, "measure_rest", False), (
+        "whole-rest fixture was rendered as a whole-measure rest; "
+        "that would not test ordinary whole-rest alignment")
 
     xs = {labels[i]: by_staff[i].x for i in labels}
     spacing = min(by_staff[i].staff_spacing for i in labels)


### PR DESCRIPTION
Closes #47.

Adds an integration regression test for the scrolling video's **beat-marker rectangle** when simultaneous quarter-note, half-note, whole-note, and half-rest symbols are engraved on separate staves.

The test exercises the same path the video uses: Verovio engraving → `place()` → `Placed` rectangle → `blend_beat_marker()`. It verifies that the marker centre, width, and final drawn columns are identical for all four simultaneous symbols. This avoids the earlier false-positive approach of checking only SVG anchors, and also avoids treating the visual centre of differently shaped glyphs as the marker position.

## Scope note
Whole rests are **not** claimed to work here. They are a known separate failing case and are intentionally excluded from this regression; issue #47 requested half notes, whole notes, and half rests.

## Result
For the glyphs in #47, the current production implementation already keeps the beat-marker rectangle stable, so no production-code change is needed. The PR adds regression coverage for that behavior.

## CI
Verified on exact PR head `5a03477b5e24a8830c8dbfe3af81ed1b460f72a0`:
- Python and integration tests: 303 passed, 5 expected browser-only skips
- Browser tests: 28 passed, 86 deselected

Both required jobs passed.