### PR TITLE
Map songs to AgentDeck sessions

### DIFF
--- a/.env.default
+++ b/.env.default
@@ -2,3 +2,12 @@ MUSESCORE_EXPORT_PATH="/Applications/MuseScore 3.app/Contents/MacOS"
 VIDEO_EXPORT_PATH="~/Movies"
 MUSESCORE_CLI_PATH="/Applications/MuseScore 3.app/Contents/MacOS/mscore"
 YOUTUBE_CLIENT_SECRETS_PATH="client_secrets.json"
+
+# Optional: map each song workspace to a normal AgentDeck chat.
+# Browser-facing origin (what the AgentDeck button opens):
+AGENTDECK_URL=""
+# Server-facing origin; leave blank to use AGENTDECK_URL. A loopback URL is useful
+# when the browser origin is behind HTTPS/auth but both apps run on the same host.
+AGENTDECK_API_URL=""
+# Exact AgentDeck account key to use when creating a song chat.
+AGENTDECK_ACCOUNT_KEY=""

--- a/SETUP.md
+++ b/SETUP.md
@@ -71,6 +71,33 @@ The one that must be right is `MUSESCORE_CLI_PATH` — on a stock macOS install
 `YOUTUBE_CLIENT_SECRETS_PATH` matters only for uploading (below);
 `MUSESCORE_EXPORT_PATH` and `VIDEO_EXPORT_PATH` only for the screen recorder.
 
+### AgentDeck song chats (optional)
+
+The song workspace can keep one normal AgentDeck chat mapped to each song. The
+mapping is stored in that song's `.song.json`, so reopening the song reuses the
+same chat instead of creating another one.
+
+Set these in `.env` when AgentDeck is available:
+
+```dotenv
+AGENTDECK_URL="https://agentdeck.example"       # URL the browser should open
+AGENTDECK_API_URL="http://127.0.0.1:PORT"       # optional; blank = AGENTDECK_URL
+AGENTDECK_ACCOUNT_KEY="provider:account"         # exact AgentDeck account key
+```
+
+`AGENTDECK_API_URL` is useful when AgentDeck's browser URL sits behind a reverse
+proxy or access layer but Choir and AgentDeck run on the same host. It is used
+only for Choir → AgentDeck requests; the persisted link always uses
+`AGENTDECK_URL`. The account key is the value AgentDeck shows/uses for the account,
+not merely its display label.
+
+Creating a song chat uses AgentDeck's ordinary **New chat** path, with the song
+folder as its working directory. It is deliberately not an AgentDeck delegation:
+the mapped chat is a long-lived user workspace and should keep normal boss-chat
+semantics. If AgentDeck later reports that the mapped session is gone, the Choir
+header changes the action to **Recreate AgentDeck**. A temporary AgentDeck outage
+does not erase the mapping.
+
 ## 5. Check it works
 
 ```bash

--- a/src/song_app/agentdeck.py
+++ b/src/song_app/agentdeck.py
@@ -1,0 +1,284 @@
+"""Map song workspaces to ordinary AgentDeck chats.
+
+The mapping lives in ``.song.json`` because it is part of the song's working
+state: once a chat has been created, reopening the song should go back to that
+same chat instead of spawning another one.
+
+AgentDeck's human ``POST /sessions/new`` route is intentionally used for creation
+rather than ``/api/delegations``.  A song chat is a normal boss-owned working
+session, not a bounded delegated worker.  AgentDeck returns a stable
+``/sessions/starting/<token>`` URL immediately; its machine API then lets us
+resolve that token to the real session key without scraping HTML.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import time
+from typing import Dict, Optional
+from urllib.parse import quote, urlsplit
+
+import httpx
+from fastapi import APIRouter, HTTPException
+
+from . import state
+
+router = APIRouter()
+
+_START_GRACE_SECONDS = 120.0
+_REQUEST_TIMEOUT_SECONDS = 10.0
+_START_PATH = re.compile(r"^/sessions/starting/([0-9a-f]{32})$")
+
+
+def _base(value: str) -> str:
+    return (value or "").strip().rstrip("/")
+
+
+def _config(mapping: Optional[Dict] = None) -> tuple[str, str, str]:
+    """Return (browser base, server/API base, account key).
+
+    ``AGENTDECK_API_URL`` exists for the common reverse-proxy setup: the browser
+    opens AgentDeck through HTTPS while Choir talks to the same service over a
+    loopback URL.  Existing mappings retain their browser origin as a fallback,
+    so moving the songs repo does not erase the link merely because this machine
+    has not been configured yet.
+    """
+    mapping = mapping or {}
+    configured_public = _base(os.getenv("AGENTDECK_URL", ""))
+    public = configured_public or _base(str(mapping.get("base_url") or ""))
+    api = _base(os.getenv("AGENTDECK_API_URL", "")) or configured_public or public
+    account = (os.getenv("AGENTDECK_ACCOUNT_KEY", "") or "").strip()
+    return public, api, account
+
+
+async def _request(method: str, url: str, **kwargs) -> httpx.Response:
+    """Small seam for tests; never follows AgentDeck's browser redirects."""
+    async with httpx.AsyncClient(
+        timeout=_REQUEST_TIMEOUT_SECONDS, follow_redirects=False
+    ) as client:
+        return await client.request(method, url, **kwargs)
+
+
+def _url(base: str, path: str) -> Optional[str]:
+    return f"{base}{path}" if base else None
+
+
+def _starting_path(mapping: Dict) -> Optional[str]:
+    token = str(mapping.get("token") or "")
+    return f"/sessions/starting/{token}" if token else None
+
+
+def _session_path(mapping: Dict) -> Optional[str]:
+    key = str(mapping.get("session_key") or "")
+    return f"/sessions/{quote(key, safe='')}" if key else None
+
+
+def _payload(
+    status: str,
+    mapping: Optional[Dict],
+    *,
+    public: str,
+    detail: str = "",
+    prefer_starting: bool = False,
+) -> Dict:
+    mapping = mapping or {}
+    path = (
+        _starting_path(mapping)
+        if prefer_starting
+        else (_session_path(mapping) or _starting_path(mapping))
+    )
+    return {
+        "state": status,
+        "url": _url(public, path) if path else None,
+        "session_key": mapping.get("session_key"),
+        "detail": detail,
+    }
+
+
+def _age(mapping: Dict) -> float:
+    try:
+        return max(0.0, time.time() - float(mapping.get("created_at") or 0.0))
+    except (TypeError, ValueError):
+        return _START_GRACE_SECONDS + 1
+
+
+async def _known_session_status(song: state.Song, mapping: Dict, public: str, api: str) -> Dict:
+    key = str(mapping.get("session_key") or "")
+    if not key:
+        return _payload("stale", mapping, public=public, detail="Mapped session has no key.")
+    try:
+        response = await _request(
+            "GET", f"{api}/api/sessions/{quote(key, safe='')}/title"
+        )
+    except httpx.HTTPError as exc:
+        return _payload(
+            "unavailable", mapping, public=public,
+            detail=f"Could not verify AgentDeck: {exc}",
+        )
+    if response.status_code == 200:
+        return _payload("ready", mapping, public=public)
+    if response.status_code == 404:
+        # Token binding can precede the next session scan by a moment.  During
+        # the same grace window as the starting page, this is still "starting",
+        # not evidence that a just-created chat was deleted.
+        if mapping.get("token") and _age(mapping) <= _START_GRACE_SECONDS:
+            return _payload("starting", mapping, public=public, prefer_starting=True)
+        return _payload(
+            "stale", mapping, public=public,
+            detail="The mapped AgentDeck session no longer exists.",
+        )
+    return _payload(
+        "unavailable", mapping, public=public,
+        detail=f"AgentDeck returned HTTP {response.status_code} while verifying the session.",
+    )
+
+
+async def status(song: state.Song) -> Dict:
+    """Resolve and verify a song's AgentDeck mapping without guessing on failures."""
+    raw = song.data.get("agentdeck")
+    mapping = raw if isinstance(raw, dict) else None
+    public, api, _account = _config(mapping)
+
+    if mapping is None:
+        if not public:
+            return _payload(
+                "unconfigured", None, public="",
+                detail="Set AGENTDECK_URL and AGENTDECK_ACCOUNT_KEY to create song chats.",
+            )
+        return _payload("unmapped", None, public=public)
+
+    if not public:
+        return _payload(
+            "unavailable", mapping, public="",
+            detail="This song is mapped, but no AgentDeck browser URL is configured.",
+        )
+    if not api:
+        return _payload(
+            "unavailable", mapping, public=public,
+            detail="This song is mapped, but no AgentDeck API URL is configured.",
+        )
+
+    if mapping.get("session_key"):
+        return await _known_session_status(song, mapping, public, api)
+
+    token = str(mapping.get("token") or "")
+    if not token:
+        return _payload(
+            "stale", mapping, public=public,
+            detail="The stored AgentDeck mapping is incomplete.",
+        )
+
+    try:
+        response = await _request("GET", f"{api}/api/sessions/by-token/{quote(token, safe='')}")
+    except httpx.HTTPError as exc:
+        return _payload(
+            "unavailable", mapping, public=public,
+            detail=f"Could not reach AgentDeck: {exc}",
+            prefer_starting=True,
+        )
+
+    if response.status_code == 404:
+        if _age(mapping) <= _START_GRACE_SECONDS:
+            return _payload("starting", mapping, public=public, prefer_starting=True)
+        return _payload(
+            "stale", mapping, public=public,
+            detail="AgentDeck never resolved this start token; recreate the session.",
+            prefer_starting=True,
+        )
+    if response.status_code != 200:
+        return _payload(
+            "unavailable", mapping, public=public,
+            detail=f"AgentDeck returned HTTP {response.status_code} while resolving the session.",
+            prefer_starting=True,
+        )
+
+    try:
+        session_key = str(response.json().get("session_key") or "")
+    except (ValueError, AttributeError):
+        session_key = ""
+    if not session_key:
+        return _payload(
+            "unavailable", mapping, public=public,
+            detail="AgentDeck resolved the token without a session key.",
+            prefer_starting=True,
+        )
+
+    mapping["session_key"] = session_key
+    song.data["agentdeck"] = mapping
+    song.save()
+    return await _known_session_status(song, mapping, public, api)
+
+
+def _first_message(song: state.Song) -> str:
+    return (
+        f'This AgentDeck chat is mapped to the choir song "{song.name}". '
+        "Use this song directory as the working context. Do not make changes yet; "
+        "wait for the user's instructions."
+    )
+
+
+async def create(song: state.Song, *, replace: bool = False) -> Dict:
+    """Create one normal AgentDeck chat, unless this song already has a mapping."""
+    existing = song.data.get("agentdeck")
+    if isinstance(existing, dict) and not replace:
+        return await status(song)
+
+    public, api, account = _config(existing if isinstance(existing, dict) else None)
+    if not public or not api or not account:
+        raise HTTPException(
+            503,
+            "AgentDeck is not configured. Set AGENTDECK_URL and "
+            "AGENTDECK_ACCOUNT_KEY (and AGENTDECK_API_URL when its internal URL differs).",
+        )
+
+    try:
+        response = await _request(
+            "POST",
+            f"{api}/sessions/new",
+            data={
+                "account_key": account,
+                "cwd": song.dir,
+                "message": _first_message(song),
+            },
+        )
+    except httpx.HTTPError as exc:
+        raise HTTPException(502, f"Could not create AgentDeck session: {exc}") from exc
+
+    if response.status_code != 202:
+        raise HTTPException(
+            502,
+            f"AgentDeck refused session creation (HTTP {response.status_code}).",
+        )
+    redirect = response.headers.get("HX-Redirect", "")
+    match = _START_PATH.fullmatch(urlsplit(redirect).path)
+    if match is None:
+        raise HTTPException(502, "AgentDeck created a session without a usable start URL.")
+
+    mapping = {
+        "base_url": public,
+        "token": match.group(1),
+        "session_key": None,
+        "created_at": time.time(),
+    }
+    # Replace only after AgentDeck accepted the new start.  A failed recreation
+    # therefore leaves the old mapping available rather than destroying it first.
+    song.data["agentdeck"] = mapping
+    song.save()
+    return _payload("starting", mapping, public=public, prefer_starting=True)
+
+
+@router.get("/api/songs/{slug}/agentdeck")
+async def api_agentdeck_status(slug: str) -> Dict:
+    song = state.load(slug)
+    if not song:
+        raise HTTPException(404, f"No song '{slug}'")
+    return await status(song)
+
+
+@router.post("/api/songs/{slug}/agentdeck")
+async def api_agentdeck_create(slug: str, body: Optional[Dict] = None) -> Dict:
+    song = state.load(slug)
+    if not song:
+        raise HTTPException(404, f"No song '{slug}'")
+    return await create(song, replace=bool((body or {}).get("replace")))

--- a/src/song_app/server.py
+++ b/src/song_app/server.py
@@ -15,7 +15,7 @@ from fastapi import FastAPI, Form, HTTPException, UploadFile, WebSocket, WebSock
 from fastapi.responses import FileResponse, PlainTextResponse
 from fastapi.staticfiles import StaticFiles
 
-from . import health, job_state, pdf_systems, pipeline, state, verification
+from . import agentdeck, health, job_state, pdf_systems, pipeline, state, verification
 
 SCRIPT_DIR = state.SCRIPT_DIR
 STATIC_DIR = os.path.join(os.path.dirname(__file__), "static")
@@ -25,6 +25,7 @@ _env = os.path.join(SCRIPT_DIR, ".env")
 dotenv.load_dotenv(_env if os.path.exists(_env) else os.path.join(SCRIPT_DIR, ".env.default"))
 
 app = FastAPI(title="song")
+app.include_router(agentdeck.router)
 
 
 # --------------------------------------------------------------------------

--- a/src/song_app/static/index.html
+++ b/src/song_app/static/index.html
@@ -20,7 +20,12 @@
   <header>
     <a href="#/" class="brand">♪ song</a>
     <span id="crumb"></span>
+    <button id="agentdeck-action" class="new-issue-link" type="button"
+            style="display:none;margin-left:auto;background:transparent;font:inherit;cursor:pointer">
+      AgentDeck
+    </button>
     <a class="new-issue-link"
+       style="margin-left:0"
        href="https://github.com/eerovil/musescore-choir-plugins/issues/new?template=issue-for-agent-to-fix.md"
        target="_blank" rel="noopener"
        aria-label="Create musescore-choir-plugins GitHub issue"
@@ -33,6 +38,98 @@
   </header>
   <main id="app">Loading…</main>
   <script src="/app.js"></script>
+  <script>
+    (() => {
+      const action = document.getElementById("agentdeck-action");
+      let current = null;
+      let currentSlug = "";
+
+      const slugFromHash = () => {
+        const match = location.hash.match(/^#\/song\/(.+)$/);
+        return match ? decodeURIComponent(match[1]) : "";
+      };
+
+      const request = async (path, options) => {
+        const response = await fetch(path, options);
+        const body = await response.json().catch(() => ({}));
+        if (!response.ok) throw new Error(body.detail || response.statusText);
+        return body;
+      };
+
+      const draw = (status) => {
+        current = status;
+        action.disabled = false;
+        action.style.display = currentSlug ? "inline-flex" : "none";
+        if (!currentSlug) return;
+        if (status.state === "unmapped") {
+          action.textContent = "+ AgentDeck";
+          action.title = "Create an AgentDeck chat for this song";
+        } else if (status.state === "starting") {
+          action.textContent = "AgentDeck…";
+          action.title = "Open the AgentDeck chat while it starts";
+        } else if (status.state === "ready") {
+          action.textContent = "AgentDeck";
+          action.title = "Open this song's AgentDeck chat";
+        } else if (status.state === "stale") {
+          action.textContent = "Recreate AgentDeck";
+          action.title = status.detail || "The mapped AgentDeck chat no longer exists";
+        } else if (status.state === "unavailable" && status.url) {
+          action.textContent = "AgentDeck ?";
+          action.title = status.detail || "Could not verify AgentDeck; open the stored link anyway";
+        } else {
+          action.textContent = "AgentDeck";
+          action.title = status.detail || "AgentDeck is not configured";
+          action.disabled = true;
+        }
+      };
+
+      const refresh = async () => {
+        const slug = slugFromHash();
+        currentSlug = slug;
+        current = null;
+        if (!slug) {
+          action.style.display = "none";
+          return;
+        }
+        action.style.display = "inline-flex";
+        action.disabled = true;
+        action.textContent = "AgentDeck…";
+        try {
+          draw(await request(`/api/songs/${encodeURIComponent(slug)}/agentdeck`));
+        } catch (error) {
+          draw({ state: "unavailable", url: null, detail: error.message });
+        }
+      };
+
+      action.addEventListener("click", async () => {
+        if (!currentSlug || !current || action.disabled) return;
+        if (current.url && current.state !== "stale" && current.state !== "unmapped") {
+          location.href = current.url;
+          return;
+        }
+        action.disabled = true;
+        action.textContent = current.state === "stale" ? "Recreating…" : "Creating…";
+        try {
+          const result = await request(
+            `/api/songs/${encodeURIComponent(currentSlug)}/agentdeck`,
+            {
+              method: "POST",
+              headers: { "content-type": "application/json" },
+              body: JSON.stringify({ replace: current.state === "stale" }),
+            },
+          );
+          draw(result);
+          if (result.url) location.href = result.url;
+        } catch (error) {
+          alert(error.message);
+          await refresh();
+        }
+      });
+
+      window.addEventListener("hashchange", refresh);
+      window.addEventListener("DOMContentLoaded", refresh);
+    })();
+  </script>
   <script src="/rendering_state.js"></script>
   <script src="/pwa.js"></script>
 </body>

--- a/src/song_app/tests/test_agentdeck.py
+++ b/src/song_app/tests/test_agentdeck.py
@@ -1,0 +1,195 @@
+"""Song ↔ AgentDeck session mapping and recovery behavior."""
+
+import time
+
+import httpx
+import pytest
+
+from src.song_app import agentdeck, state
+
+TOKEN = "0123456789abcdef0123456789abcdef"
+TOKEN2 = "fedcba9876543210fedcba9876543210"
+SESSION = "claude_code:main:session-123"
+
+
+@pytest.fixture
+def song(tmp_path, monkeypatch):
+    songs = tmp_path / "songs"
+    songs.mkdir()
+    monkeypatch.setattr(state, "SONGS_DIR", str(songs))
+    return state.create("My Song", per_system=False)
+
+
+@pytest.fixture(autouse=True)
+def agentdeck_env(monkeypatch):
+    monkeypatch.setenv("AGENTDECK_URL", "https://deck.example")
+    monkeypatch.setenv("AGENTDECK_API_URL", "http://127.0.0.1:9090")
+    monkeypatch.setenv("AGENTDECK_ACCOUNT_KEY", "claude_code:main")
+
+
+def response(code, *, headers=None, data=None):
+    return httpx.Response(code, headers=headers or {}, json=data) if data is not None \
+        else httpx.Response(code, headers=headers or {})
+
+
+@pytest.mark.asyncio
+async def test_create_persists_start_token_and_reuses_mapping(song, monkeypatch):
+    calls = []
+
+    async def fake_request(method, url, **kwargs):
+        calls.append((method, url, kwargs))
+        if method == "POST":
+            return response(202, headers={"HX-Redirect": f"/sessions/starting/{TOKEN}"})
+        return response(404)
+
+    monkeypatch.setattr(agentdeck, "_request", fake_request)
+
+    created = await agentdeck.create(song)
+    assert created["state"] == "starting"
+    assert created["url"] == f"https://deck.example/sessions/starting/{TOKEN}"
+
+    saved = state.load(song.slug)
+    assert saved.data["agentdeck"]["token"] == TOKEN
+    assert saved.data["agentdeck"]["session_key"] is None
+    assert saved.data["agentdeck"]["base_url"] == "https://deck.example"
+    post = calls[0]
+    assert post[0:2] == ("POST", "http://127.0.0.1:9090/sessions/new")
+    assert post[2]["data"]["account_key"] == "claude_code:main"
+    assert post[2]["data"]["cwd"] == song.dir
+    assert "My Song" in post[2]["data"]["message"]
+
+    # Pressing create again is idempotent: it checks the saved start rather than
+    # creating a second AgentDeck chat.
+    again = await agentdeck.create(saved)
+    assert again["state"] == "starting"
+    assert sum(method == "POST" for method, _url, _kwargs in calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_start_token_resolves_to_session_and_is_persisted(song, monkeypatch):
+    song.data["agentdeck"] = {
+        "base_url": "https://deck.example",
+        "token": TOKEN,
+        "session_key": None,
+        "created_at": time.time(),
+    }
+    song.save()
+    calls = []
+
+    async def fake_request(method, url, **kwargs):
+        calls.append(url)
+        if "/by-token/" in url:
+            return response(200, data={"session_key": SESSION})
+        return response(200, data={"title": "My Song"})
+
+    monkeypatch.setattr(agentdeck, "_request", fake_request)
+    status = await agentdeck.status(song)
+
+    assert status == {
+        "state": "ready",
+        "url": "https://deck.example/sessions/claude_code%3Amain%3Asession-123",
+        "session_key": SESSION,
+        "detail": "",
+    }
+    assert state.load(song.slug).data["agentdeck"]["session_key"] == SESSION
+    assert calls == [
+        f"http://127.0.0.1:9090/api/sessions/by-token/{TOKEN}",
+        "http://127.0.0.1:9090/api/sessions/claude_code%3Amain%3Asession-123/title",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_deleted_session_is_stale_and_can_be_recreated(song, monkeypatch):
+    song.data["agentdeck"] = {
+        "base_url": "https://deck.example",
+        "token": TOKEN,
+        "session_key": SESSION,
+        "created_at": time.time() - 1000,
+    }
+    song.save()
+    calls = []
+
+    async def fake_request(method, url, **kwargs):
+        calls.append((method, url))
+        if method == "POST":
+            return response(202, headers={"HX-Redirect": f"/sessions/starting/{TOKEN2}"})
+        return response(404)
+
+    monkeypatch.setattr(agentdeck, "_request", fake_request)
+
+    stale = await agentdeck.status(song)
+    assert stale["state"] == "stale"
+    assert stale["url"].endswith("/sessions/claude_code%3Amain%3Asession-123")
+
+    recreated = await agentdeck.create(song, replace=True)
+    assert recreated["state"] == "starting"
+    assert recreated["url"].endswith(f"/sessions/starting/{TOKEN2}")
+    saved = state.load(song.slug).data["agentdeck"]
+    assert saved["token"] == TOKEN2
+    assert saved["session_key"] is None
+    assert [method for method, _url in calls].count("POST") == 1
+
+
+@pytest.mark.asyncio
+async def test_temporary_agentdeck_failure_does_not_destroy_mapping(song, monkeypatch):
+    mapping = {
+        "base_url": "https://deck.example",
+        "token": TOKEN,
+        "session_key": SESSION,
+        "created_at": time.time() - 1000,
+    }
+    song.data["agentdeck"] = dict(mapping)
+    song.save()
+
+    async def unavailable(*_args, **_kwargs):
+        raise httpx.ConnectError("offline")
+
+    monkeypatch.setattr(agentdeck, "_request", unavailable)
+    result = await agentdeck.status(song)
+
+    assert result["state"] == "unavailable"
+    assert result["url"].endswith("/sessions/claude_code%3Amain%3Asession-123")
+    assert state.load(song.slug).data["agentdeck"] == mapping
+
+
+@pytest.mark.asyncio
+async def test_failed_recreate_keeps_previous_mapping(song, monkeypatch):
+    mapping = {
+        "base_url": "https://deck.example",
+        "token": TOKEN,
+        "session_key": SESSION,
+        "created_at": time.time() - 1000,
+    }
+    song.data["agentdeck"] = dict(mapping)
+    song.save()
+
+    async def refused(*_args, **_kwargs):
+        return response(422)
+
+    monkeypatch.setattr(agentdeck, "_request", refused)
+    with pytest.raises(Exception) as exc:
+        await agentdeck.create(song, replace=True)
+    assert getattr(exc.value, "status_code", None) == 502
+    assert state.load(song.slug).data["agentdeck"] == mapping
+
+
+@pytest.mark.asyncio
+async def test_create_requires_configuration(song, monkeypatch):
+    monkeypatch.delenv("AGENTDECK_URL")
+    monkeypatch.delenv("AGENTDECK_API_URL")
+    monkeypatch.delenv("AGENTDECK_ACCOUNT_KEY")
+
+    status = await agentdeck.status(song)
+    assert status["state"] == "unconfigured"
+    with pytest.raises(Exception) as exc:
+        await agentdeck.create(song)
+    assert getattr(exc.value, "status_code", None) == 503
+
+
+def test_workspace_shell_contains_agentdeck_action():
+    html = (agentdeck.state.SCRIPT_DIR and __import__("pathlib").Path(
+        agentdeck.state.SCRIPT_DIR, "src", "song_app", "static", "index.html"
+    ).read_text())
+    assert 'id="agentdeck-action"' in html
+    assert "/agentdeck`" in html
+    assert "Recreate AgentDeck" in html

--- a/src/song_app/tests/test_agentdeck.py
+++ b/src/song_app/tests/test_agentdeck.py
@@ -6,8 +6,9 @@ from pathlib import Path
 
 import httpx
 import pytest
+from fastapi.testclient import TestClient
 
-from src.song_app import agentdeck, state
+from src.song_app import agentdeck, server, state
 
 TOKEN = "0123456789abcdef0123456789abcdef"
 TOKEN2 = "fedcba9876543210fedcba9876543210"
@@ -180,6 +181,12 @@ def test_create_requires_configuration(song, monkeypatch):
     with pytest.raises(Exception) as exc:
         asyncio.run(agentdeck.create(song))
     assert getattr(exc.value, "status_code", None) == 503
+
+
+def test_agentdeck_routes_are_registered_before_static_mount(song):
+    result = TestClient(server.app).get(f"/api/songs/{song.slug}/agentdeck")
+    assert result.status_code == 200
+    assert result.json()["state"] == "unmapped"
 
 
 def test_workspace_shell_contains_agentdeck_action():

--- a/src/song_app/tests/test_agentdeck.py
+++ b/src/song_app/tests/test_agentdeck.py
@@ -1,6 +1,8 @@
 """Song ↔ AgentDeck session mapping and recovery behavior."""
 
+import asyncio
 import time
+from pathlib import Path
 
 import httpx
 import pytest
@@ -32,8 +34,7 @@ def response(code, *, headers=None, data=None):
         else httpx.Response(code, headers=headers or {})
 
 
-@pytest.mark.asyncio
-async def test_create_persists_start_token_and_reuses_mapping(song, monkeypatch):
+def test_create_persists_start_token_and_reuses_mapping(song, monkeypatch):
     calls = []
 
     async def fake_request(method, url, **kwargs):
@@ -44,7 +45,7 @@ async def test_create_persists_start_token_and_reuses_mapping(song, monkeypatch)
 
     monkeypatch.setattr(agentdeck, "_request", fake_request)
 
-    created = await agentdeck.create(song)
+    created = asyncio.run(agentdeck.create(song))
     assert created["state"] == "starting"
     assert created["url"] == f"https://deck.example/sessions/starting/{TOKEN}"
 
@@ -60,13 +61,12 @@ async def test_create_persists_start_token_and_reuses_mapping(song, monkeypatch)
 
     # Pressing create again is idempotent: it checks the saved start rather than
     # creating a second AgentDeck chat.
-    again = await agentdeck.create(saved)
+    again = asyncio.run(agentdeck.create(saved))
     assert again["state"] == "starting"
     assert sum(method == "POST" for method, _url, _kwargs in calls) == 1
 
 
-@pytest.mark.asyncio
-async def test_start_token_resolves_to_session_and_is_persisted(song, monkeypatch):
+def test_start_token_resolves_to_session_and_is_persisted(song, monkeypatch):
     song.data["agentdeck"] = {
         "base_url": "https://deck.example",
         "token": TOKEN,
@@ -83,9 +83,9 @@ async def test_start_token_resolves_to_session_and_is_persisted(song, monkeypatc
         return response(200, data={"title": "My Song"})
 
     monkeypatch.setattr(agentdeck, "_request", fake_request)
-    status = await agentdeck.status(song)
+    result = asyncio.run(agentdeck.status(song))
 
-    assert status == {
+    assert result == {
         "state": "ready",
         "url": "https://deck.example/sessions/claude_code%3Amain%3Asession-123",
         "session_key": SESSION,
@@ -98,8 +98,7 @@ async def test_start_token_resolves_to_session_and_is_persisted(song, monkeypatc
     ]
 
 
-@pytest.mark.asyncio
-async def test_deleted_session_is_stale_and_can_be_recreated(song, monkeypatch):
+def test_deleted_session_is_stale_and_can_be_recreated(song, monkeypatch):
     song.data["agentdeck"] = {
         "base_url": "https://deck.example",
         "token": TOKEN,
@@ -117,11 +116,11 @@ async def test_deleted_session_is_stale_and_can_be_recreated(song, monkeypatch):
 
     monkeypatch.setattr(agentdeck, "_request", fake_request)
 
-    stale = await agentdeck.status(song)
+    stale = asyncio.run(agentdeck.status(song))
     assert stale["state"] == "stale"
     assert stale["url"].endswith("/sessions/claude_code%3Amain%3Asession-123")
 
-    recreated = await agentdeck.create(song, replace=True)
+    recreated = asyncio.run(agentdeck.create(song, replace=True))
     assert recreated["state"] == "starting"
     assert recreated["url"].endswith(f"/sessions/starting/{TOKEN2}")
     saved = state.load(song.slug).data["agentdeck"]
@@ -130,8 +129,7 @@ async def test_deleted_session_is_stale_and_can_be_recreated(song, monkeypatch):
     assert [method for method, _url in calls].count("POST") == 1
 
 
-@pytest.mark.asyncio
-async def test_temporary_agentdeck_failure_does_not_destroy_mapping(song, monkeypatch):
+def test_temporary_agentdeck_failure_does_not_destroy_mapping(song, monkeypatch):
     mapping = {
         "base_url": "https://deck.example",
         "token": TOKEN,
@@ -145,15 +143,14 @@ async def test_temporary_agentdeck_failure_does_not_destroy_mapping(song, monkey
         raise httpx.ConnectError("offline")
 
     monkeypatch.setattr(agentdeck, "_request", unavailable)
-    result = await agentdeck.status(song)
+    result = asyncio.run(agentdeck.status(song))
 
     assert result["state"] == "unavailable"
     assert result["url"].endswith("/sessions/claude_code%3Amain%3Asession-123")
     assert state.load(song.slug).data["agentdeck"] == mapping
 
 
-@pytest.mark.asyncio
-async def test_failed_recreate_keeps_previous_mapping(song, monkeypatch):
+def test_failed_recreate_keeps_previous_mapping(song, monkeypatch):
     mapping = {
         "base_url": "https://deck.example",
         "token": TOKEN,
@@ -168,28 +165,27 @@ async def test_failed_recreate_keeps_previous_mapping(song, monkeypatch):
 
     monkeypatch.setattr(agentdeck, "_request", refused)
     with pytest.raises(Exception) as exc:
-        await agentdeck.create(song, replace=True)
+        asyncio.run(agentdeck.create(song, replace=True))
     assert getattr(exc.value, "status_code", None) == 502
     assert state.load(song.slug).data["agentdeck"] == mapping
 
 
-@pytest.mark.asyncio
-async def test_create_requires_configuration(song, monkeypatch):
+def test_create_requires_configuration(song, monkeypatch):
     monkeypatch.delenv("AGENTDECK_URL")
     monkeypatch.delenv("AGENTDECK_API_URL")
     monkeypatch.delenv("AGENTDECK_ACCOUNT_KEY")
 
-    status = await agentdeck.status(song)
-    assert status["state"] == "unconfigured"
+    result = asyncio.run(agentdeck.status(song))
+    assert result["state"] == "unconfigured"
     with pytest.raises(Exception) as exc:
-        await agentdeck.create(song)
+        asyncio.run(agentdeck.create(song))
     assert getattr(exc.value, "status_code", None) == 503
 
 
 def test_workspace_shell_contains_agentdeck_action():
-    html = (agentdeck.state.SCRIPT_DIR and __import__("pathlib").Path(
-        agentdeck.state.SCRIPT_DIR, "src", "song_app", "static", "index.html"
-    ).read_text())
+    html = Path(
+        state.SCRIPT_DIR, "src", "song_app", "static", "index.html"
+    ).read_text()
     assert 'id="agentdeck-action"' in html
     assert "/agentdeck`" in html
     assert "Recreate AgentDeck" in html

--- a/src/song_app/tests/test_agentdeck_ui.py
+++ b/src/song_app/tests/test_agentdeck_ui.py
@@ -1,0 +1,53 @@
+"""Browser coverage for the song workspace's AgentDeck action."""
+
+import pytest
+
+pytest.importorskip("playwright.sync_api", reason="browser tests need Playwright")
+pytest.importorskip("pytest_playwright", reason="browser tests need pytest-playwright")
+
+from playwright.sync_api import expect
+
+from src.song_app.tests.test_ui_flow import _new_song, live_app
+
+pytestmark = pytest.mark.browser
+
+
+def test_agentdeck_action_creates_and_recreates_from_workspace(live_app, page):
+    fake = {"state": "unmapped", "posts": []}
+
+    def agentdeck_route(route, request):
+        if request.method == "POST":
+            fake["posts"].append(request.post_data_json)
+            route.fulfill(
+                status=200,
+                content_type="application/json",
+                body='{"state":"starting","url":null,"session_key":null,"detail":""}',
+            )
+            return
+        states = {
+            "unmapped": '{"state":"unmapped","url":null,"session_key":null,"detail":""}',
+            "ready": '{"state":"ready","url":null,"session_key":"session-1","detail":""}',
+            "stale": '{"state":"stale","url":null,"session_key":"session-1","detail":"gone"}',
+        }
+        route.fulfill(status=200, content_type="application/json", body=states[fake["state"]])
+
+    page.route("**/api/songs/*/agentdeck", agentdeck_route)
+    _new_song(page, live_app, "AgentDeck Song", per_system=False)
+
+    action = page.locator("#agentdeck-action")
+    expect(action).to_have_text("+ AgentDeck")
+    action.click()
+    expect(action).to_have_text("AgentDeck…")
+    assert fake["posts"] == [{"replace": False}]
+
+    fake["state"] = "ready"
+    page.reload()
+    expect(action).to_have_text("AgentDeck")
+    expect(action).to_have_attribute("title", "Open this song's AgentDeck chat")
+
+    fake["state"] = "stale"
+    page.reload()
+    expect(action).to_have_text("Recreate AgentDeck")
+    action.click()
+    expect(action).to_have_text("AgentDeck…")
+    assert fake["posts"][-1] == {"replace": True}


### PR DESCRIPTION
Closes #48.

Adds a persistent song ↔ AgentDeck chat mapping to the Choir workspace.

## Behavior
- Songs without a mapping show a `+ AgentDeck` action in the workspace header.
- Creating one starts a normal AgentDeck **New chat** in that song's directory and stores AgentDeck's stable start token in `.song.json`.
- Once AgentDeck resolves the token, Choir stores the real session key and opens that same session on future visits.
- Repeated create requests reuse the existing mapping instead of spawning duplicate chats.
- Deleted/missing sessions become `Recreate AgentDeck`; a temporary AgentDeck outage keeps the stored mapping and still offers its saved link.
- A failed recreation does not erase the previous mapping.

## Configuration
Adds optional `.env` settings:
- `AGENTDECK_URL` — browser-facing AgentDeck origin
- `AGENTDECK_API_URL` — optional server-facing/loopback origin
- `AGENTDECK_ACCOUNT_KEY` — exact account key used for new chats

## Tests
Adds coverage for creation/persistence, token resolution, reuse, stale-session recreation, temporary outages, failed recreation preservation, missing configuration, router ordering, and the workspace action.