### PR TITLE
Let a recorded fix be a sentence

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -137,6 +137,16 @@ and every kind checks what the bar reads **now** (`from`) before touching it, tu
 brackets included. A note's spelling is derived from its pitch: the first fixes to
 carry one by hand got three of four wrong.
 
+A fourth kind, `text`, is just a sentence (`{"kind": "text", "what": "..."}`), because
+most edits are none of the other three — taking one notehead off a chord and turning a
+bar-length rest into a whole-bar rest both came up on one song in one sitting, and
+neither could be written down at all. Nothing interprets it: `apply_fixes` steps over
+it and `score_fixes.free_text` hands the sentences back, so cleaning logs them as still
+outstanding and the **Fix** panel lists them (`pipeline.free_text_fixes`, read live off
+the file, so writing one shows at once and applying it stops showing). Applying one is
+a person's job, or an agent asked to do it. Refusing to clean would make the file a
+hostage; skipping in silence is the failure it exists to prevent.
+
 ```bash
 fixtures/virta-venhetta-vie/reset.sh        # drop it into songs/ at the furthest stage
 fixtures/virta-venhetta-vie/reset.sh 00     # or: just registered, ready to clean

--- a/src/clean_score/tests/test_score_fixes.py
+++ b/src/clean_score/tests/test_score_fixes.py
@@ -13,7 +13,7 @@ from lxml import etree
 
 from src.clean_score import lyric_txt
 from src.clean_score.utils.overfull_measures import _voice_len
-from src.clean_score.utils.score_fixes import FixError, apply_fixes
+from src.clean_score.utils.score_fixes import FixError, apply_fixes, free_text
 
 
 def _score(chords):
@@ -174,3 +174,38 @@ def test_a_whole_bar_rest_can_be_read_but_not_written():
     with pytest.raises(FixError):
         apply_fixes(root, [{"kind": "append", "staff": 3, "measure": 1,
                             "from": ["measure:R"], "add": ["measure:R"], "why": "x"}])
+
+
+# --------------------------------------------------------------------------- #
+# A fix that is just a sentence
+# --------------------------------------------------------------------------- #
+
+def test_a_sentence_is_recorded_but_not_carried_out():
+    """Most edits are none of the three kinds; the judgement still has to survive."""
+    root = _score([("quarter", 0, 60)])
+    said = "B1 bar 40, last eighth: drop the D, keep the C — the basses cross here."
+    lines = apply_fixes(root, [{"kind": "text", "what": said}])
+    assert lines == []                                  # nothing claims to have run
+    assert _tokens(root) == ["quarter:60"]              # and the score is untouched
+    assert free_text([{"kind": "text", "what": said}]) == [said]
+
+
+def test_a_sentence_does_not_stop_the_fixes_around_it():
+    root = _score([("quarter", 1, 60)])
+    lines = apply_fixes(root, [
+        {"kind": "text", "what": "bars 8 and 26 should be whole-bar rests"},
+        {"kind": "undot", "staff": 3, "measure": 1, "index": 0, "why": "x"},
+    ])
+    assert len(lines) == 1
+    assert _voice_len(root.find(".//voice")) == Fraction(1, 4)
+
+
+def test_a_sentence_that_says_nothing_is_an_error():
+    """An empty reminder and a repaired score look identical from here."""
+    for empty in ({"kind": "text"}, {"kind": "text", "what": "   "}):
+        with pytest.raises(FixError):
+            apply_fixes(_score([("quarter", 0, 60)]), [empty])
+
+
+def test_free_text_ignores_the_kinds_that_do_apply():
+    assert free_text([{"kind": "undot", "staff": 3, "measure": 1, "index": 0}]) == []

--- a/src/clean_score/utils/score_fixes.py
+++ b/src/clean_score/utils/score_fixes.py
@@ -37,6 +37,22 @@ own length, which a fix has no way to know, so write the rests out instead. The
 note's **spelling** (MuseScore's tpc) is derived from the pitch and is deliberately
 not part of the token: the first fixes to carry one by hand got three of four wrong,
 which puts a note on the wrong line while it still sounds right.
+
+Most edits are none of those three kinds, and the shapes that are missing are not
+exotic — taking one notehead off a chord, or turning a bar-length rest into a
+whole-bar rest, both came up on one song in one sitting. So a fix can also just be
+a **sentence**:
+
+    {"kind": "text",
+     "what": "B1 bar 40, last eighth: drop the D, keep the C. The page prints one
+              head per bass voice and the basses cross here."}
+
+Nothing here interprets it. `apply_fixes` leaves a `text` entry alone and
+`free_text` hands the sentences back, so cleaning can say out loud that the score
+is not fully repaired yet instead of either refusing to clean at all or skipping in
+silence. Applying one is a person's job — or an agent asked to do it, which is how
+the sentence came to be written in the first place. What the file guarantees is
+that the judgement survives the next rebuild.
 """
 import logging
 from fractions import Fraction
@@ -209,11 +225,38 @@ def _append_bar(measure: etree._Element, expect: List[str], add: List[str],
     return f"{dropped}added {list(add)} to the end of the bar"
 
 
+def free_text(fixes: List[Dict]) -> List[str]:
+    """The sentences among the recorded fixes, in file order.
+
+    Nothing applies these; this is what lets a caller say they are still outstanding.
+    An entry with no sentence in it raises rather than reading as nothing to do — an
+    empty reminder and a repaired score look identical from here.
+    """
+    said: List[str] = []
+    for n, fix in enumerate(fixes, start=1):
+        if not isinstance(fix, dict) or fix.get("kind") != "text":
+            continue
+        text = (fix.get("what") or fix.get("why") or "").strip()
+        if not text:
+            raise FixError(
+                f"the free-text fix at position {n} says nothing — give it a 'what', "
+                "or take it out of the file")
+        said.append(text)
+    return said
+
+
 def apply_fixes(root: etree._Element, fixes: List[Dict]) -> List[str]:
-    """Apply each recorded fix. Returns one line per fix, for the build log."""
+    """Apply each recorded fix. Returns one line per fix applied, for the build log.
+
+    Free-text fixes are not applied — they are a sentence, not an instruction anything
+    here can follow — so they are absent from the return value. `free_text` reads them.
+    """
+    free_text(fixes)  # a sentence that says nothing is a mistake worth catching early
     done: List[str] = []
     for fix in fixes:
         kind = fix.get("kind")
+        if kind == "text":
+            continue
         staff, measure = int(fix["staff"]), int(fix["measure"])
         try:
             if kind == "append":

--- a/src/song_app/pipeline.py
+++ b/src/song_app/pipeline.py
@@ -21,7 +21,7 @@ from src.clean_score.main import main as clean_main
 from src.clean_score import lyric_txt
 from src.clean_score.lyric_txt import LyricImport, import_file
 from src.clean_score.utils import per_system
-from src.clean_score.utils.score_fixes import FixError, apply_fixes
+from src.clean_score.utils.score_fixes import FixError, apply_fixes, free_text
 
 MUSESCORE_EXTS = (".mscz", ".mscx", ".musicxml", ".xml")
 Logger = Callable[[str], None]
@@ -164,25 +164,15 @@ def apply_recorded_fixes(cleaned_path: str, song_dir: str, log: Logger = _noop) 
     this raises rather than skipping it. A silently dropped fix leaves a score
     looking repaired when it is not, and the whole point of the file is that nothing
     downstream can tell the difference.
+
+    Free-text fixes are the exception, and are counted separately: nothing here can
+    carry out a sentence. They are logged as still outstanding, because the two
+    alternatives are both worse — refusing to clean would make the file a hostage,
+    and passing over them in silence is exactly the failure it exists to prevent.
     """
-    path = os.path.join(song_dir, "fixes.json")
-    if not os.path.exists(path):
-        return 0
-    try:
-        with open(path, encoding="utf-8") as f:
-            entries = json.load(f)
-    except ValueError as exc:
-        raise RuntimeError(f"fixes.json is not valid JSON: {exc}") from exc
+    entries = _recorded_fixes(song_dir)
     if not entries:
         return 0
-    # Every entry has to be applicable. Skipping the ones that are not would leave a
-    # score looking repaired when it is not — which is the failure this file exists
-    # to prevent — and an entry with a mistyped key would vanish in silence.
-    unusable = [e for e in entries if not isinstance(e, dict) or not e.get("kind")]
-    if unusable:
-        raise RuntimeError(
-            f"{len(unusable)} entry/entries in fixes.json have no 'kind' and cannot be "
-            f"applied: {unusable[:1]}. Give each one a kind, or take it out of the file.")
     tree = etree.parse(cleaned_path)
     try:
         lines = apply_fixes(tree.getroot(), entries)
@@ -191,11 +181,54 @@ def apply_recorded_fixes(cleaned_path: str, song_dir: str, log: Logger = _noop) 
             f"A recorded fix in fixes.json no longer matches the score: {exc}. "
             "Re-read the page and update (or remove) that entry before cleaning again."
         ) from exc
-    tree.write(cleaned_path, encoding="UTF-8", xml_declaration=True)
-    log(f"Re-applied {len(lines)} recorded fix(es) from fixes.json")
-    for line in lines:
-        log("  " + line[:120])
+    if lines:
+        tree.write(cleaned_path, encoding="UTF-8", xml_declaration=True)
+        log(f"Re-applied {len(lines)} recorded fix(es) from fixes.json")
+        for line in lines:
+            log("  " + line[:120])
+    outstanding = free_text(entries)
+    if outstanding:
+        log(f"{len(outstanding)} fix(es) in fixes.json are free text and were NOT applied:")
+        for said in outstanding:
+            log("  " + said[:200])
     return len(lines)
+
+
+def _recorded_fixes(song_dir: str) -> List[Dict]:
+    """The song's `fixes.json`, checked over. Empty list if there is no file."""
+    path = os.path.join(song_dir, "fixes.json")
+    if not os.path.exists(path):
+        return []
+    try:
+        with open(path, encoding="utf-8") as f:
+            entries = json.load(f)
+    except ValueError as exc:
+        raise RuntimeError(f"fixes.json is not valid JSON: {exc}") from exc
+    if not entries:
+        return []
+    # Every entry has to be applicable. Skipping the ones that are not would leave a
+    # score looking repaired when it is not — which is the failure this file exists
+    # to prevent — and an entry with a mistyped key would vanish in silence.
+    unusable = [e for e in entries if not isinstance(e, dict) or not e.get("kind")]
+    if unusable:
+        raise RuntimeError(
+            f"{len(unusable)} entry/entries in fixes.json have no 'kind' and cannot be "
+            f"applied: {unusable[:1]}. Give each one a kind, or take it out of the file.")
+    return entries
+
+
+def free_text_fixes(song_dir: str) -> List[str]:
+    """The song's outstanding free-text fixes, for showing on the Fix stage.
+
+    Read live from the file rather than remembered from the last clean, so writing a
+    sentence down shows up at once and applying it stops showing up as soon as the
+    entry goes. Unreadable is reported as nothing to do: this runs on every state
+    request, and cleaning is where a broken file gets said out loud.
+    """
+    try:
+        return free_text(_recorded_fixes(song_dir))
+    except (RuntimeError, FixError, OSError):
+        return []
 
 
 def strip_lyrics_copy(mscx_path: str) -> str:

--- a/src/song_app/server.py
+++ b/src/song_app/server.py
@@ -180,6 +180,9 @@ def _derived(song: state.Song) -> Dict:
         # the viewer show one system and the lyric editor ask per system.
         "systems": systems,
         "open_issues": [i for i in issues if i.get("status") == "open"],
+        # Recorded fixes nothing can apply on its own — a sentence waiting for a
+        # person or an agent. Read live, so it goes as soon as the entry does.
+        "pending_fixes": pipeline.free_text_fixes(song.dir),
         "recording": is_recording(song),
         "media": _media_list(song),
         "jobs": job_state.load(song.dir),

--- a/src/song_app/static/app.js
+++ b/src/song_app/static/app.js
@@ -874,6 +874,12 @@ function sysBlock(sys) {
 function panelFix(panel, song, P, refresh) {
   panel.append(el("h2", {}, "Fix"),
     el("p", { className: "sub" }, "OCR damage the auto-fixers couldn't repair. Fix in MuseScore, save, and it re-checks automatically."));
+  const pending = song.pending_fixes || [];
+  if (pending.length) {
+    panel.append(el("div", { className: "issue" },
+      el("div", { className: "top" }, el("span", {}, el("span", { className: "kind" }, "fixes.json — not applied automatically"))),
+      ...pending.map((t) => el("div", { className: "detail" }, t))));
+  }
   const issues = song.open_issues || [];
   if (!issues.length) {
     panel.append(el("p", { className: "empty" }, "✓ No issues. Ready for lyrics."));

--- a/src/song_app/static/pwa-assets.js
+++ b/src/song_app/static/pwa-assets.js
@@ -1,1 +1,1 @@
-self.SONG_PWA = Object.freeze({"cache":"song-static-df56c22fdf02","assets":["/style.css","/pwa.css","/app.js","/rendering_state.js","/pwa.js","/offline.html","/favicon.svg","/apple-touch-icon.png","/icon-192.png","/icon-512.png","/icon-maskable-512.png","/manifest.webmanifest"]});
+self.SONG_PWA = Object.freeze({"cache":"song-static-1750760854a5","assets":["/style.css","/pwa.css","/app.js","/rendering_state.js","/pwa.js","/offline.html","/favicon.svg","/apple-touch-icon.png","/icon-192.png","/icon-512.png","/icon-maskable-512.png","/manifest.webmanifest"]});

--- a/src/song_app/tests/test_fix_panel_ui.py
+++ b/src/song_app/tests/test_fix_panel_ui.py
@@ -1,0 +1,118 @@
+"""The Fix panel in a real browser: an outstanding free-text fix has to be visible.
+
+The Python tests pin that cleaning reports the sentence. The whole point of writing
+one down is that it does not get forgotten, and the log scrolls past — so this
+covers the half that only exists in the browser.
+"""
+import json
+import os
+import socket
+import threading
+import time
+
+import pytest
+
+_NEEDS = "pip install pytest-playwright && playwright install chromium"
+pytest.importorskip("playwright.sync_api", reason=_NEEDS)
+pytest.importorskip("pytest_playwright", reason=_NEEDS)
+pytest.importorskip("uvicorn")
+
+
+def _browser_installed() -> bool:
+    """Launching is the only honest check; see test_ui_flow for why it runs here."""
+    from playwright.sync_api import sync_playwright
+
+    try:
+        with sync_playwright() as p:
+            p.chromium.launch().close()
+        return True
+    except Exception:
+        return False
+
+
+if not _browser_installed():
+    pytest.skip(_NEEDS, allow_module_level=True)
+
+import uvicorn
+
+from src.song_app import server, state
+
+pytestmark = pytest.mark.browser
+
+SAID = "B1 bar 40, last eighth: drop the D, keep the C — the basses cross here."
+
+
+def _free_port():
+    with socket.socket() as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+@pytest.fixture(scope="module")
+def live(tmp_path_factory):
+    tmp = tmp_path_factory.mktemp("fixpanel")
+    songs = tmp / "songs"
+    songs.mkdir()
+    previous_dir, state.SONGS_DIR = state.SONGS_DIR, str(songs)
+    previous_cli = os.environ.get("MUSESCORE_CLI_PATH")
+    os.environ["MUSESCORE_CLI_PATH"] = str(tmp / "no-musescore-here")
+
+    song = state.create("Fix Panel Song", per_system=False)
+    with open(song.path("fixpanel_cleaned.mscx"), "w") as fh:
+        fh.write("<museScore><Score/></museScore>")
+    song.data["cleaned"] = "fixpanel_cleaned.mscx"
+    song.data["stage"] = "fix"
+    song.save()
+
+    port = _free_port()
+    srv = uvicorn.Server(uvicorn.Config(
+        server.app, host="127.0.0.1", port=port, log_level="warning"))
+    thread = threading.Thread(target=srv.run, daemon=True)
+    try:
+        thread.start()
+        deadline = time.time() + 30
+        while not srv.started and time.time() < deadline:
+            time.sleep(0.05)
+        assert srv.started, "the app did not start"
+        yield f"http://127.0.0.1:{port}", song
+    finally:
+        srv.should_exit = True
+        thread.join(timeout=10)
+        state.SONGS_DIR = previous_dir
+        if previous_cli is None:
+            os.environ.pop("MUSESCORE_CLI_PATH", None)
+        else:
+            os.environ["MUSESCORE_CLI_PATH"] = previous_cli
+
+
+def _open_fix(page, base, slug):
+    errors = []
+    page.on("pageerror", lambda e: errors.append(str(e)))
+    page.goto(f"{base}/#/song/{slug}")
+    page.wait_for_selector(".stagebar")
+    page.locator(".stagebar .step", has_text="Fix").first.click()
+    page.wait_for_selector("text=Open in MuseScore")
+    return errors
+
+
+def test_an_outstanding_sentence_is_shown_on_the_fix_stage(live, page):
+    base, song = live
+    with open(os.path.join(song.dir, "fixes.json"), "w", encoding="utf-8") as fh:
+        json.dump([{"kind": "text", "what": SAID}], fh)
+    errors = _open_fix(page, base, song.slug)
+
+    assert page.get_by_text(SAID).is_visible()
+    assert page.get_by_text("not applied automatically").is_visible()
+    assert not errors, f"the panel raised: {errors}"
+
+
+def test_nothing_is_shown_when_there_is_nothing_outstanding(live, page):
+    base, song = live
+    path = os.path.join(song.dir, "fixes.json")
+    if os.path.exists(path):
+        os.remove(path)
+    errors = _open_fix(page, base, song.slug)
+
+    assert not page.get_by_text("not applied automatically").is_visible()
+    assert page.get_by_text("No issues").is_visible()
+    assert not errors, f"the panel raised: {errors}"

--- a/src/song_app/tests/test_free_text_fixes.py
+++ b/src/song_app/tests/test_free_text_fixes.py
@@ -1,0 +1,91 @@
+"""A recorded fix that is just a sentence, seen from the app.
+
+Cleaning cannot carry one out. What it must not do is either of the two easy
+things: refuse to clean at all, or pass over it in silence — the second is the
+exact failure fixes.json exists to prevent.
+"""
+import json
+import os
+
+import pytest
+from lxml import etree
+
+from src.song_app import pipeline
+
+SAID = "B1 bar 40, last eighth: drop the D, keep the C — the basses cross here."
+
+
+@pytest.fixture
+def song(tmp_path):
+    """A song folder with a one-bar cleaned score in it."""
+    cleaned = tmp_path / "song_cleaned.mscx"
+    cleaned.write_text(
+        "<museScore><Score><Part><trackName>B1</trackName><Staff id='3'/></Part>"
+        "<Staff id='3'><Measure><voice><Chord><durationType>quarter</durationType>"
+        "<Note><pitch>60</pitch></Note></Chord></voice></Measure></Staff>"
+        "</Score></museScore>", encoding="utf-8")
+    return tmp_path, str(cleaned)
+
+
+def _write(song_dir, entries):
+    with open(os.path.join(str(song_dir), "fixes.json"), "w", encoding="utf-8") as f:
+        json.dump(entries, f)
+
+
+def test_cleaning_says_the_sentence_is_still_outstanding(song):
+    song_dir, cleaned = song
+    _write(song_dir, [{"kind": "text", "what": SAID}])
+    logged = []
+    applied = pipeline.apply_recorded_fixes(cleaned, str(song_dir), logged.append)
+
+    assert applied == 0                        # nothing claims to have run
+    assert SAID in "\n".join(logged)           # but the log says so out loud
+    assert "NOT applied" in "\n".join(logged)
+
+
+def test_the_score_is_left_exactly_as_it_was(song):
+    song_dir, cleaned = song
+    before = open(cleaned, encoding="utf-8").read()
+    _write(song_dir, [{"kind": "text", "what": SAID}])
+    pipeline.apply_recorded_fixes(cleaned, str(song_dir), lambda _m: None)
+    assert open(cleaned, encoding="utf-8").read() == before
+
+
+def test_a_sentence_does_not_stop_a_fix_that_does_apply(song):
+    song_dir, cleaned = song
+    _write(song_dir, [
+        {"kind": "text", "what": SAID},
+        {"kind": "append", "staff": 3, "measure": 1,
+         "from": ["quarter:60"], "add": ["quarter:57"], "why": "the scan lost it"},
+    ])
+    assert pipeline.apply_recorded_fixes(cleaned, str(song_dir), lambda _m: None) == 1
+    pitches = [n.findtext("pitch") for n in etree.parse(cleaned).getroot().findall(".//Note")]
+    assert pitches == ["60", "57"]
+
+
+def test_the_fix_stage_reads_the_sentences_live(song):
+    """Live off the file, so writing one shows at once and applying it stops showing."""
+    song_dir, _ = song
+    assert pipeline.free_text_fixes(str(song_dir)) == []
+    _write(song_dir, [{"kind": "text", "what": SAID},
+                      {"kind": "undot", "staff": 3, "measure": 1, "index": 0}])
+    assert pipeline.free_text_fixes(str(song_dir)) == [SAID]
+    _write(song_dir, [])
+    assert pipeline.free_text_fixes(str(song_dir)) == []
+
+
+def test_a_broken_file_is_the_cleans_problem_not_the_panels(song):
+    """Showing the Fix stage must not blow up; cleaning is where this gets said."""
+    song_dir, cleaned = song
+    with open(os.path.join(str(song_dir), "fixes.json"), "w", encoding="utf-8") as f:
+        f.write("{not json")
+    assert pipeline.free_text_fixes(str(song_dir)) == []
+    with pytest.raises(RuntimeError):
+        pipeline.apply_recorded_fixes(cleaned, str(song_dir), lambda _m: None)
+
+
+def test_a_sentence_that_says_nothing_fails_the_clean(song):
+    song_dir, cleaned = song
+    _write(song_dir, [{"kind": "text", "what": ""}])
+    with pytest.raises(RuntimeError):
+        pipeline.apply_recorded_fixes(cleaned, str(song_dir), lambda _m: None)


### PR DESCRIPTION
Closes #56.

`fixes.json` had three kinds — `undot`, `slur`, `append` — and most edits are none of them. Two came up on Pois meni mereen päivä in one sitting and neither could be recorded: taking one notehead off a chord (`drop` only takes rests), and turning a bar-length rest into a whole-bar rest (`measure:R` cannot be written). Both had to be hand-edited into the cleaned score, where the next clean would throw them away.

A fix can now be a sentence:

```json
{"kind": "text", "what": "B1 bar 40, last eighth: drop the D, keep the C — the basses cross here."}
```

- `apply_fixes` steps over it; `score_fixes.free_text` hands the sentences back.
- Cleaning logs them as **NOT applied**, and `pipeline.free_text_fixes` puts them on the Fix panel — read live off the file, so writing one shows at once and applying it stops showing.
- A `text` entry with nothing in it fails the clean. An empty reminder and a repaired score look identical from here.
- The other three kinds are untouched.

Applying one stays a person's job, or an agent asked to do it — which is how the sentence gets written in the first place.

## Testing

`353 passed` (full suite, with poppler, Playwright and the MuseScore CLI). New:

- `src/clean_score/tests/test_score_fixes.py` — a sentence is recorded but not carried out, does not stop the fixes around it, and one that says nothing raises.
- `src/song_app/tests/test_free_text_fixes.py` — cleaning says it is outstanding, leaves the score byte-identical, still applies the real fixes beside it, reads the panel's list live, and a broken file is the clean's problem rather than the panel's.
- `src/song_app/tests/test_fix_panel_ui.py` — the sentence is actually visible on the Fix stage in a real browser. Verified by sabotage: blanking the panel's list fails it.

`pwa-assets.js` is regenerated because `app.js` changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)