### PR TITLE
Remember the framing a preview was asked for

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -482,8 +482,13 @@ state model are in `DESIGN.md`.
   — written into `record` when the request arrives, and falling back to what this song
   chose last before the app-wide default. They used to be written only after a render
   succeeded, so framing decided against a render that then failed was gone by the next
-  page load. Previewing still writes nothing: the preview is a look at the score, not
-  a stage of the work, so a margin nudged and only previewed is not remembered.
+  page load. **A successful preview records it too** — nudging a margin and looking at
+  the result is how the choice actually gets made, and requiring a render first lost it
+  every time. Both paths go through `_remember_margins`, which writes only a real change
+  and never while a job is running, since the state file is saved whole. A framing the
+  renderer refuses is not recorded: coming back to a margin that cannot be drawn would
+  be a trap. Nothing else about the preview writes to the song — no stage moves, no
+  video appears.
 - The Record panel already has a **silent scroll preview**, so the layout question can be
   answered before the encoding one. Whether the margins are right, whether the staff
   size reads, where the beat marker sits, whether a repeat lands on the right bar —
@@ -491,8 +496,10 @@ state model are in `DESIGN.md`.
   feedback loop for it. `GET /scroll-preview` prepares the render's own data
   (`pipeline.scroll_preview` → `src.scrollvideo.preview`) off the worker thread and
   hands it to a player in the page (`static/scroll_preview.js`, `.pvviewport` in the
-  stylesheet), with play/pause/restart/scrub. No ffmpeg, no audio, and nothing
-  written into the song's state: it is a look at the score, not a stage of the work.
+  stylesheet), with play/pause/restart/scrub. No ffmpeg, no audio, and — apart from
+  the framing it was asked for, which this pull request proposes recording (see the
+  margin note above) — nothing written into the song's state: it is a look at the
+  score, not a stage of the work.
   The prepared payload is cached beside the song under a key naming the cleaned
   score's fingerprint **and** every setting that moves the picture (size, both
   margins, the tempo the app supplies), so a score edited in MuseScore or a margin

--- a/src/song_app/server.py
+++ b/src/song_app/server.py
@@ -817,6 +817,27 @@ def _margin(value, label: str) -> float:
     return margin
 
 
+def _remember_margins(song: state.Song, top: float, bottom: float) -> None:
+    """Keep the framing this song was last shown at.
+
+    Written when a render is asked for and when a preview succeeds, so nudging a
+    margin to see what it looks like is enough to keep it — that is the moment the
+    choice is actually made. Only a real change is written, and never while a job
+    is running: the state file is saved whole, so a needless write here could land
+    on top of what a finishing render just recorded. Pass a freshly loaded song for
+    the same reason.
+    """
+    rec = song.data.get("record", {})
+    if (rec.get("top_margin"), rec.get("bottom_margin")) == (top, bottom):
+        return
+    if is_recording(song):
+        return
+    rec = song.data.setdefault("record", {})
+    rec["top_margin"] = top
+    rec["bottom_margin"] = bottom
+    song.save()
+
+
 @app.get("/api/songs/{slug}/scroll-preview")
 async def api_scroll_preview(slug: str, quality: str = "4k",
                              top_margin: float = DEFAULT_TOP_MARGIN_PERCENT,
@@ -826,8 +847,11 @@ async def api_scroll_preview(slug: str, quality: str = "4k",
 
     This is the picture without the encoding: the same engraving, viewport, clock,
     scroll curve and *pixels* `build_videos` would use, drawn by the same code at a
-    height a page can carry. It writes nothing into the song's state and does not
-    count as a render — the only files it leaves behind are its own cache.
+    height a page can carry. It does not count as a render — no stage moves and no
+    video appears; the only files it leaves behind are its own cache. The one thing
+    it does record is the framing it was asked for (`_remember_margins`), because
+    nudging a margin and looking at the result *is* how the choice gets made, and
+    having to render before it would stick lost it every time.
 
     It also fails where a render would, and that is half its value: a D.C./D.S.
     jump or margins that leave no picture come back here as an ordinary error
@@ -852,6 +876,10 @@ async def api_scroll_preview(slug: str, quality: str = "4k",
         raise
     except Exception as exc:
         raise HTTPException(400, str(exc) or exc.__class__.__name__)
+    # Only once the picture came out: a framing the renderer refuses is not one to
+    # come back to. Reloaded, because preparing can take seconds.
+    _remember_margins(_require(slug), settings["top_margin_percent"],
+                      settings["bottom_margin_percent"])
     return JSONResponse(payload, headers=dict(REVALIDATE))
 
 
@@ -1072,10 +1100,7 @@ async def api_record(slug: str, body: Dict = None) -> Dict:
                 ("top_margin", "Top", DEFAULT_TOP_MARGIN_PERCENT),
                 ("bottom_margin", "Bottom", DEFAULT_BOTTOM_MARGIN_PERCENT)):
             opts[key] = _margin(opts.get(key, remembered.get(key, default)), label)
-        rec = song.data.setdefault("record", {})
-        rec["top_margin"] = opts["top_margin"]
-        rec["bottom_margin"] = opts["bottom_margin"]
-        song.save()
+        _remember_margins(song, opts["top_margin"], opts["bottom_margin"])
     if scrolling_render and cleaned and os.path.exists(cleaned) \
             and not pipeline.has_opening_tempo(cleaned):
         try:

--- a/src/song_app/tests/test_scroll_preview.py
+++ b/src/song_app/tests/test_scroll_preview.py
@@ -149,16 +149,41 @@ def test_a_score_with_its_own_tempo_ignores_the_offered_one(client, song, prepar
     assert prepared[0]["initial_bpm"] is None
 
 
-def test_previewing_changes_nothing_about_the_song(client, song, prepared):
+def test_previewing_does_not_advance_the_song(client, song, prepared):
     """It is a look at the score, not a step in the workflow."""
-    before = open(song.path(".song.json")).read()
     client.get(f"/api/songs/{song.slug}/scroll-preview")
-    assert open(song.path(".song.json")).read() == before
 
     data = client.get(f"/api/songs/{song.slug}").json()
     assert data["stage"] == "record"
     assert not data["recording"]
     assert not data.get("record", {}).get("outputs")
+
+
+def test_the_framing_a_preview_was_asked_for_is_remembered(client, song, prepared):
+    """Nudging a margin and looking is how the choice gets made.
+
+    Everything else about the preview leaves the song alone, but a framing that
+    only stuck once you had rendered a video was lost every time.
+    """
+    client.get(f"/api/songs/{song.slug}/scroll-preview",
+               params={"top_margin": 3, "bottom_margin": 11})
+
+    rec = client.get(f"/api/songs/{song.slug}").json()["record"]
+    assert (rec["top_margin"], rec["bottom_margin"]) == (3, 11)
+
+
+def test_a_framing_the_renderer_refuses_is_not_remembered(client, song, monkeypatch):
+    """Coming back to a margin that cannot be drawn would be a trap."""
+    def refuse(*_args, **_kwargs):
+        raise ValueError("top and bottom video margins leave no visible picture")
+
+    monkeypatch.setattr("src.scrollvideo.preview.preview", refuse)
+    response = client.get(f"/api/songs/{song.slug}/scroll-preview",
+                          params={"bottom_margin": 99})
+
+    assert response.status_code == 400
+    assert "bottom_margin" not in client.get(f"/api/songs/{song.slug}").json().get(
+        "record", {})
 
 
 def test_visual_preview_does_not_prepare_any_audio(client, song, prepared, monkeypatch):


### PR DESCRIPTION
Follow-up to #75, which merged just before this commit landed on the branch.

Nudging a margin and looking at the result is how the framing choice actually gets made, so requiring a render before it stuck lost it every time. A preview that comes out now records its margins as well as a render does.

Both paths go through one helper, `_remember_margins`, which writes only a real change and never while a job is running — the state file is saved whole, so a needless write could land on top of what a finishing render just recorded. A framing the renderer refuses is deliberately *not* recorded: coming back to a margin that cannot be drawn would be a trap. Nothing else about the preview writes to the song — no stage moves, no video appears.

**Verification.** Full suite `467 passed`, browser included. Three tests: the framing a preview asked for is in the song afterwards (fails with the change reverted), a refused framing is not, and previewing still does not advance the song.

AgentDeck session: https://bazzite.taile8d16e.ts.net/sessions/claude_code:main:096ec180-aa75-49c4-b4dd-5e0a82641128

🤖 Generated with [Claude Code](https://claude.com/claude-code)
