### PR TITLE
Keep empty lyric slots in the by-system editor

### DIFF
--- a/src/clean_score/lyric_txt.py
+++ b/src/clean_score/lyric_txt.py
@@ -251,14 +251,23 @@ def _token_from_lyric(syllabic: str, text: str) -> str:
 
 
 def _merge_tokens(tokens: List[str]) -> str:
-    """Merge hyphenated syllables and join with space."""
+    """Merge hyphenated syllables and join with space.
+
+    An `_` is a note with no syllable, never part of a word: a trailing hyphen
+    says the word carries on to the next *syllable*, and the empty slot is not
+    one. Absorbing it produced `kär-_ si-net`, which reads back as a syllable
+    literally spelled "_" and loses the slot it was standing for.
+    """
     if not tokens:
         return ""
     result: List[str] = []
     cur = tokens[0]
     for i in range(1, len(tokens)):
         nxt = tokens[i]
-        if cur.endswith("-"):
+        if cur == "_" or nxt == "_":
+            result.append(cur)
+            cur = nxt
+        elif cur.endswith("-"):
             cur = cur.rstrip("-") + "-" + nxt.lstrip("-").strip()
         elif nxt.startswith("-"):
             cur = cur.rstrip() + "-" + nxt.lstrip("-").strip()
@@ -1375,7 +1384,15 @@ def editor_grid(
             )
             tokens: List[str] = []
             for mi in range(system.start - 1, system.end):
-                tokens += [t for t in by_measure.get(mi, {}).get(part.id, []) if t != "_"]
+                tokens += by_measure.get(mi, {}).get(part.id, [])
+            # Trailing slots are kept as well as inner ones: a note at the end of
+            # the line with no word under it is worth seeing, and dropping it left
+            # the cell short of its own capacity, so re-saving an untouched system
+            # reported `too_few` out of nowhere. But a cell of *nothing but* empty
+            # slots is a part that does not sing in this system, and that is an
+            # empty cell, not a row of underscores.
+            if not any(t != "_" for t in tokens):
+                continue
             text = _merge_tokens(tokens).strip()
             if text:
                 cells.setdefault(system.index, {})[part.name] = text

--- a/src/clean_score/tests/test_lyric_diagnostics.py
+++ b/src/clean_score/tests/test_lyric_diagnostics.py
@@ -178,7 +178,18 @@ def test_editor_cells_round_trip_through_import_and_back():
         {"measure_start": 3, "lyrics": [{"parts": ["S"], "text": "toi-nen ri"}]},
     ]
     place_lyrics(root, blocks, replace=True)
-    assert editor_grid(root).cells == typed
+    # Each system holds 6 slots and each line fills 3, so the editor comes back
+    # saying which notes were left bare rather than quietly rounding down. Saving
+    # that reads identically -- an `_` places nothing, same as no token at all.
+    assert editor_grid(root).cells == {
+        0: {"S": "en-sim mäi _ _ _", "A": "al-to yk _ _ _"},
+        1: {"S": "toi-nen ri _ _ _"},
+    }
+    assert blocks_from_cells(editor_grid(root), editor_grid(root).cells) == [
+        {"measure_start": 1, "lyrics": [{"parts": ["S"], "text": "en-sim mäi _ _ _"},
+                                        {"parts": ["A"], "text": "al-to yk _ _ _"}]},
+        {"measure_start": 3, "lyrics": [{"parts": ["S"], "text": "toi-nen ri _ _ _"}]},
+    ]
 
 
 def test_blank_editor_cells_are_left_out_rather_than_clearing_a_part():
@@ -226,3 +237,54 @@ def test_slot_counts_are_what_a_mismatch_is_measured_against():
     # Eligibility matches the export: a continuation note takes no syllable, so
     # the totals cannot exceed the notes present.
     assert all(n >= 0 for per in counts.values() for n in per.values())
+
+
+def test_editor_keeps_an_empty_slot_so_a_melisma_survives_a_round_trip():
+    """A note that carries no syllable is `_`, and the editor must show it.
+
+    Dropping it from the cell looks harmless -- the words read the same -- but the
+    editor is also what the next save is built from, so an invisible slot is a
+    deleted one: every syllable after it slides one note earlier and the counts
+    still add up, so nothing is reported. On Herää Suomi one round trip through
+    the grid moved syllables in 22 measures without a single warning.
+    """
+    root = build_score(staff_ids=(1,), measures=2, chords=3, names={1: "S"},
+                       line_breaks=(1,))
+    typed = {0: {"S": "_ yk-si"}, 1: {"S": "kak- _ si"}}
+
+    grid = editor_grid(root)
+    place_lyrics(root, blocks_from_cells(grid, typed), replace=True)
+    assert editor_grid(root).cells == typed
+
+
+def test_a_trailing_empty_slot_is_shown_so_a_no_op_save_reports_nothing():
+    """A note at the end of the line with no word under it is worth seeing.
+
+    Hiding it also left the cell one token short of its own capacity, so saving a
+    system nobody had touched reported `too_few`. A warning raised by a no-op is
+    worse than an underscore on screen.
+    """
+    root = build_score(staff_ids=(1,), measures=1, chords=3, names={1: "S"})
+    typed = {0: {"S": "yk-si _"}}
+
+    place_lyrics(root, blocks_from_cells(editor_grid(root), typed), replace=True)
+    grid = editor_grid(root)
+    assert grid.cells == typed
+    assert grid.capacities[0]["S"] == 3
+    assert place_lyrics(root, blocks_from_cells(grid, grid.cells),
+                        replace=True).mismatches == []
+
+
+def test_a_part_that_sings_nothing_gets_an_empty_cell_not_a_row_of_underscores():
+    root = build_score(staff_ids=(1, 2), measures=1, chords=3, names={1: "S", 2: "A"})
+    place_lyrics(root, blocks_from_cells(editor_grid(root), {0: {"S": "yk-si kak"}}),
+                 replace=True)
+    assert editor_grid(root).cells == {0: {"S": "yk-si kak"}}   # no "A" key at all
+
+
+def test_an_empty_slot_is_never_glued_onto_the_syllable_before_it():
+    """`kär- _ si-net` is three things; `kär-_ si-net` is a word with an underscore in it."""
+    from src.clean_score.lyric_txt import _merge_tokens, _tokenize_line
+
+    assert _merge_tokens(["kär-", "_", "si-", "net"]) == "kär- _ si-net"
+    assert _tokenize_line("kär- _ si-net") == ["kär-", "_", "si-net"]

--- a/src/song_app/tests/test_ui_flow.py
+++ b/src/song_app/tests/test_ui_flow.py
@@ -177,8 +177,12 @@ def test_per_system_answers_clean_the_score_and_lyrics_land_on_their_cell(live_a
     other = page.locator(".lyrow", has=page.locator('textarea[data-part="T2"]')).first
     expect(other.locator(".lyerr")).to_have_count(0)
 
-    # What was typed survives the re-render, read back out of the score.
-    expect(page.locator('textarea[data-sys="0"][data-part="T1"]')).to_have_value("yk")
+    # What was typed survives the re-render, and every remaining lyric slot is
+    # represented explicitly as a bare-note marker.
+    rendered_cell = page.locator('textarea[data-sys="0"][data-part="T1"]')
+    label = rendered_cell.locator("xpath=preceding-sibling::label").inner_text()
+    capacity = int(re.search(r"(\d+) lyric slots", label).group(1))
+    assert rendered_cell.input_value().split() == ["yk"] + ["_"] * (capacity - 1)
     if evidence := os.getenv("ISSUE_17_EVIDENCE_DIR"):
         page.locator(".stagebar .step", has_text="Review").click()
         expect(page.locator(".verify")).to_contain_text("Health: Current score checked")


### PR DESCRIPTION
An `_` is a note that carries no syllable. The by-system lyric editor threw it away when reading the score back into a cell — and since the editor is also what the next save is built from, an invisible slot is a deleted one.

Saving a system **nobody had touched** moved every syllable after the gap one note earlier. The counts still added up, so no warning was raised. On Herää Suomi one round trip through the grid shifted syllables in 22 measures silently; that is how it was found.

## Two places dropped it

- `editor_grid` filtered `_` out of the tokens outright.
- `_merge_tokens` glued it onto a preceding hyphenated syllable, so `kär- _ si-net` came back as `kär-_ si-net` — a word with an underscore inside it, rather than a syllable, a gap and a syllable. A trailing hyphen says the word carries on to the next *syllable*, and an empty slot is not one.

## Trailing slots are kept too

Dropping them places identical lyrics, but leaves the cell short of its own capacity, so re-saving an untouched system reported `too_few` out of nowhere — three times on this song. A note at the end of a line with no word under it is also worth seeing.

A cell of *nothing but* empty slots is a different thing: that is a part which does not sing in this system, and it stays an empty cell rather than a row of underscores.

## Behaviour change

`test_editor_cells_round_trip_through_import_and_back` now expects the cell to come back naming the notes it left bare (`"toi-nen ri _ _ _"` for a 6-slot system given 3 syllables) instead of quietly rounding down. Saving that reads identically — an `_` places nothing, same as no token at all.

## Verified

Targeted suite green (`src/clean_score/tests/` + `test_clean_flow.py`, 129 passed). Against the real song, a full editor round trip over all 24 systems now changes **0** lines of placed lyrics and raises **0** warnings; before this it changed 22 measures.

Not in scope: recording a genuinely missing slur, which is the better repair when the score itself is wrong — #88.

🤖 Generated with [Claude Code](https://claude.com/claude-code)