### PR TITLE
Cut system crops by the score they came from, not just the band

### DIFF
--- a/src/song_app/pdf_systems.py
+++ b/src/song_app/pdf_systems.py
@@ -222,6 +222,21 @@ def rendered_system_bands(
     return bands
 
 
+def _file_version(path: str) -> str:
+    """What the file holds, cheaply: its size and modification time.
+
+    Content would be exact, but these crops are cut from a render that is itself
+    rebuilt whenever the score is newer, so a rewrite always moves the mtime. A
+    rebuild that happens to be byte-identical costs one wasted crop, which is the
+    right way round to be wrong.
+    """
+    try:
+        st = os.stat(path)
+    except OSError:
+        return ""
+    return f"{st.st_size}:{st.st_mtime_ns}"
+
+
 def crop_systems(
     pdf_path: str,
     bounds: List[SystemBounds],
@@ -233,14 +248,21 @@ def crop_systems(
     Only the band is rasterised, not the page it sits on. A full A4 at 400 dpi
     takes seconds; a system is a fifth of that, and this is on the path where
     someone clicks a lyric cell and waits to see the music.
+
+    The cache name carries the source as well as the band. The scan never changes,
+    but the compare view cuts its bands out of a render of the *cleaned* score,
+    which changes whenever the score does -- and a name made of the band alone kept
+    serving bar 8 as it looked before a slur was recorded, hours after the slur was
+    in the file and in the render. The page said the fix had not applied.
     """
     os.makedirs(out_dir, exist_ok=True)
     width, height = _page_size_px(pdf_path, dpi)
+    source = _file_version(pdf_path)
     images = []
     for b in bounds:
         top = max(0, min(height - 1, int(height * b.top)))
         band = max(1, min(height - top, int(height * b.bottom) - top))
-        geometry = f"{b.page}:{b.top:.9f}:{b.bottom:.9f}".encode()
+        geometry = f"{source}:{b.page}:{b.top:.9f}:{b.bottom:.9f}".encode()
         version = hashlib.sha1(geometry).hexdigest()[:10]
         path = os.path.join(out_dir, f"system-{b.index:02d}@{dpi}-{version}.png")
         if not os.path.exists(path):

--- a/src/song_app/tests/test_pdf_systems.py
+++ b/src/song_app/tests/test_pdf_systems.py
@@ -8,6 +8,7 @@ resolution, and is never labelled with a measure range that does not fit.
 import json
 import os
 import shutil
+import subprocess
 
 import pytest
 
@@ -133,3 +134,23 @@ def test_the_grid_overlay_is_the_page_with_a_scale_on_it(tmp_path):
     assert gridded != plain
     reds = [px for px in b.convert("RGB").getdata() if px[0] > 200 and px[1] < 100]
     assert reds, "no scale was drawn"
+
+
+def test_a_crop_follows_the_score_it_was_cut_from(bounds, tmp_path):
+    """The same band of a *different* PDF is a different crop.
+
+    The compare view cuts its bands out of a render of the cleaned score, and that
+    render changes whenever the score does. Keying the cache on the band alone
+    served bar 8 as it looked before a slur was recorded, hours after the slur was
+    in the file and in the render -- so the page said the fix had not applied.
+    """
+    one = [bounds[0]]
+    first = pdf_systems.crop_systems(PDF, one, out_dir=str(tmp_path), dpi=100)[0]
+
+    # A different score of the same shape: page 2 of the fixture, alone.
+    other = str(tmp_path / "other.pdf")
+    subprocess.run(["pdfseparate", "-f", "2", "-l", "2", PDF, other], check=True)
+    second = pdf_systems.crop_systems(other, one, out_dir=str(tmp_path), dpi=100)[0]
+
+    assert second.path != first.path
+    assert Image.open(second.path).tobytes() != Image.open(first.path).tobytes()


### PR DESCRIPTION
The Compare tab kept showing bar 8 without the slur, hours after the slur was recorded in `fixes.json`, replayed by a re-clean, present in the `.mscx` and drawn in the rebuilt render.

`crop_systems` named its cache after the band alone — page, top, bottom — so once a PNG existed for a band it was never cut again. The compare view slices its bands out of a render of the **cleaned** score, and that render is rebuilt whenever the score changes, so the cache had no way to notice. On this song `.pages/cleaned/system-03@300-*.png` was two and a half hours older than the score it claimed to show.

It reads as "the fix did not apply", which is the worst possible way to be wrong: the Fix panel had recorded the slur correctly and the page said it hadn't.

## Change

The cache name now carries the source file's size and mtime as well as the band.

Content hashing would be exact, but these crops come from a render that is itself rebuilt whenever the score is newer, so a rewrite always moves the mtime. A byte-identical rebuild costs one wasted crop — the right way round to be wrong.

The scan's own crops go through the same call. In practice the source PDF never changes, so nothing moves for them; they are now equally safe if it is replaced.

## Test

`test_a_crop_follows_the_score_it_was_cut_from` — the same band of a different PDF is a different crop, and different pixels. It fails on the old code with both paths identical.

Verified on the real song: clearing the stale directory and re-fetching `/cleaned-system/3` returns bar 8 with the slur drawn and `sor – ran –` under it.

19 passed in `test_pdf_systems.py` + `test_bounds_api.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)