### PR TITLE
Give homr a venv of its own and one call into it

### DIFF
--- a/.env.default
+++ b/.env.default
@@ -3,6 +3,11 @@ VIDEO_EXPORT_PATH="~/Movies"
 MUSESCORE_CLI_PATH="/Applications/MuseScore 3.app/Contents/MacOS/mscore"
 YOUTUBE_CLIENT_SECRETS_PATH="client_secrets.json"
 
+# Optional: homr (optical music recognition), installed by scripts/install-homr.sh.
+# Leave blank unless the venv is somewhere other than the script's default,
+# ~/.local/share/musescore-choir-plugins/homr-venv.
+HOMR_BIN=""
+
 # Optional: map each song workspace to a normal AgentDeck chat.
 # Browser-facing origin (what the AgentDeck button opens):
 AGENTDECK_URL=""

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -292,8 +292,11 @@ Key test modules:
   litter does not follow it, that `--gpu no` is actually on the command line, that
   both streams reach the log, and that each way of failing says something — a bad
   exit, a clean exit with no file, a wedged run, a PDF handed in by mistake, homr not
-  installed. The last test is the card's own acceptance and the only one that runs the
-  real thing: a page of the scanned fixture rasterised at 300 dpi goes in and parseable
+  installed. It also pins the heavy slot: a page is read under one, held across the
+  run rather than asked for and dropped; the label names the page; `queue=False`
+  genuinely does not ask; and losing the lease mid-page stops the page *and* takes
+  homr with it. The last test is the card's own acceptance and the only one that runs
+  the real thing: a page of the scanned fixture rasterised at 300 dpi goes in and parseable
   MusicXML with parts, measures and notes comes out (~50s). It skips without homr or
   poppler, the same way the MuseScore-CLI and Playwright tests skip.
 - `src/song_app/tests/test_clean_flow.py` — the song-app path: grid answers →
@@ -717,6 +720,22 @@ state model are in `DESIGN.md`.
   that kills the process group, not `wait(timeout=...)`, because reading the pipe is
   what blocks. Not installed is its own error (`HomrMissing`) naming the install
   script.
+  **A page is read under one of this host's heavy slots**, through the same
+  `heavy_slot` client the scrolling render uses — not a second slot client. A page is
+  ~30s of every core on a four-core host shared with the deck's own suites and a song
+  rendering, which is exactly what that queue is for. Its two backwards-looking rules
+  carry over unchanged and are not re-argued here: **failing** to get a slot is
+  fail-open (the scan runs unqueued with a line in the log), **losing** one is not (a
+  heartbeat answering 404 means the cores may already be somebody else's, so the page
+  stops with `SlotLost`). homr's own output lines are the checkpoints `Slot.guard`
+  needs, and abandoning the read loop kills homr's process group — otherwise it would
+  keep running on cores that have been handed away.
+  **One slot per page, not one per song.** The page is the unit `read_page` owns and
+  each page writes its own MusicXML, so releasing between pages lets a render or a
+  suite in, and an interruption costs the page in flight rather than the song — the
+  pages already read are on disk. A caller that would rather hold one lease across a
+  whole song passes `queue=False` and wraps the loop itself, so the two never nest
+  (nesting would deadlock a one-slot pool).
   Deliberately **not** here yet, because they belong to other cards on #92's map:
   nothing calls `read_page` (the stage machine and UI are #98), pages are not stitched
   into one score (#97), the deploy and `/healthz` do not know homr exists, and whether

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,6 +37,7 @@ src/song_app/            Local web app tying the workflow together (see DESIGN.m
   state.py               Song state machine (.song.json), slug, stages
   health.py              Health check (malformed-tick / extra-voice scan; no mutation)
   pdf_systems.py         Crop the source PDF into one image per printed system
+  omr.py                 Run homr on a page image -> MusicXML (its own venv; see below)
   pipeline.py            Glue: convert + clean (clean_score) + lyric import (lyric_txt)
   server.py              FastAPI routes, WebSocket progress, file-watch re-check
   static/                Vanilla-JS SPA (library + 3-pane workspace, PDF viewer)
@@ -285,6 +286,16 @@ Key test modules:
   tuplet survival, line breaks, lyric map/metaTags, carried-forward answers, answer
   persistence) and pins both assignment adapters — the CLI prompt and grid answers —
   to the same rebuild.
+- `src/song_app/tests/test_omr.py` — added by this pull request. Most of it drives a
+  stub standing in for homr, because what `omr.py` owns is the boundary: where the
+  binary is found, that the MusicXML lands where the caller asked and the teaser
+  litter does not follow it, that `--gpu no` is actually on the command line, that
+  both streams reach the log, and that each way of failing says something — a bad
+  exit, a clean exit with no file, a wedged run, a PDF handed in by mistake, homr not
+  installed. The last test is the card's own acceptance and the only one that runs the
+  real thing: a page of the scanned fixture rasterised at 300 dpi goes in and parseable
+  MusicXML with parts, measures and notes comes out (~50s). It skips without homr or
+  poppler, the same way the MuseScore-CLI and Playwright tests skip.
 - `src/song_app/tests/test_clean_flow.py` — the song-app path: grid answers →
   `save_system_answers` → headless `run_clean` → rebuilt parts + lyric routing.
 - `src/song_app/tests/test_ui_flow.py` — the **SPA itself**, in a real browser: it
@@ -660,6 +671,56 @@ state model are in `DESIGN.md`.
   one syllable too long. The cleaned system crop is shown alongside where one is
   available (`/compare` + `/cleaned-system/{index}`); it needs a MuseScore render, so
   not having it costs a picture rather than the feature.
+- `omr.py` is added by this pull request: **one call that turns a page image into a
+  MusicXML path**, `read_page(image, out_dir=..., log=...)`. It runs homr (optical
+  music recognition, adopted in #86), which is the first thing the app depends on that
+  cannot live in the app's environment — so where it lives is the decision this module
+  carries, and the reasoning is worth keeping.
+  homr **is not a pip requirement and must not become one.** It is ~660 MB of
+  onnxruntime and opencv wheels, plus ~150 MB of model weights it stores *inside its
+  own site-packages*, and `scripts/deploy-song-app.sh --unattended` reinstalls
+  `pip-requirements.txt` on every merge — so putting it there would re-download the
+  weights on a whim and let a resolution failure in an ML stack take the live app
+  down. It also is not the `omr` **distrobox** container it was benchmarked in: that
+  container is hand-built host state nothing in this repo describes, which is the cost
+  CLAUDE.md's "Working in a worktree" section exists to complain about. And it is not
+  a container image either — a build system to hold one venv is not worth the second
+  thing to keep working.
+  So: a `uv`-managed python 3.12 venv outside the checkout, built by
+  **`scripts/install-homr.sh`** (idempotent; `HOMR_VENV` moves it), called as a
+  subprocess. A fresh clone runs one script.
+  **Where homr comes from is one variable in that script, `HOMR_SOURCE`, and it is
+  expected to stop being a PyPI pin.** #97 decided to fork homr and build the
+  multi-page joining, the staff-grouping fix and PDF input *inside the fork*, because
+  the app only ever sees homr's output and by then the staves are gone; #104 stands
+  that fork up. So `homr==0.7.0` today becomes a `git+https://...` URL then, changed in
+  one line, and nothing in `omr.py` or in the rest of the script moves with it. Do not
+  be surprised to find a git URL where a version pin is written here.
+  Two things the earlier notes got wrong
+  and this pins: homr 0.7.0 declares `>=3.11,<3.16` and installs on 3.14 too, so the
+  version is a choice and not a wall — 3.12 because every benchmark number in #93 and
+  #95 came off 3.12; and there is **no `[cpu]` extra** on 0.7.0, so upstream's
+  `uvx --from 'homr[cpu]' homr` recipe silently ignores it. Plain `homr==0.7.0` pulls
+  the CPU onnxruntime, which is all this host can use anyway.
+  What the module absorbs is the CLI's shape. homr takes one image, writes
+  `<image>.musicxml` **beside it**, has no `--output`, and drops a `_teaser.png` next
+  to the input, so the run happens on a copy in a scratch dir and only the answer is
+  moved to where the caller asked. `--gpu` is passed **`no`** every time and never
+  left at `auto`: auto asks whether the CUDA provider is *registered*, not whether it
+  can run, and this host's GTX 970 is sm_52 against onnxruntime's sm_60 floor, so auto
+  would pick CUDA and die on the first segnet node without falling back (#93). Note
+  the value is `no`, not `off`. Output is streamed line by line to a `log` callback —
+  a page is ~30s and a song 2–5 minutes, so that is the progress channel #93 asked
+  for — and every failure raises `HomrError` carrying the tail of what homr said.
+  Including the quiet one: homr **deletes its own MusicXML when parsing raises**, so a
+  zero exit with no file is a failure and is reported as one. The deadline is a timer
+  that kills the process group, not `wait(timeout=...)`, because reading the pipe is
+  what blocks. Not installed is its own error (`HomrMissing`) naming the install
+  script.
+  Deliberately **not** here yet, because they belong to other cards on #92's map:
+  nothing calls `read_page` (the stage machine and UI are #98), pages are not stitched
+  into one score (#97), the deploy and `/healthz` do not know homr exists, and whether
+  the unit of work is a page or a printed system is #103.
 - **Hazards guarded:** re-cleaning warns it discards manual edits (the Clean
   button label changes once a cleaned file exists); lyric import uses `--replace`.
   No automatic LLM (users have no API key) — the lyrics stage supports either a
@@ -1500,6 +1561,14 @@ its own API calls, and `load_dotenv` does not override a variable that is alread
 so `./song.py` run from such a chat persists the loopback origin into the song's
 `.song.json`. The service has no such variable; clear them (`env -u AGENTDECK_URL`)
 before reading anything into a conclusion.
+
+**homr lives at `~/.local/share/musescore-choir-plugins/homr-venv` on this host**, put
+there by `scripts/install-homr.sh` and pointed at by nothing in `.env` because that is
+the script's own default. It is host state, like `.venv` — but unlike the `omr`
+distrobox container it replaces, a second host reproduces it by running one committed
+script. The deploy does not touch it, on purpose: it is not in `pip-requirements.txt`,
+so a merge cannot churn 150 MB of model weights, and `/healthz` does not know it
+exists.
 
 Issues are worked from a GitHub Project board by the AgentDeck poller (instance
 `musescore`, unit `agentdeck-poller@musescore.timer`). Its manifest is **not** in this

--- a/SETUP.md
+++ b/SETUP.md
@@ -45,7 +45,29 @@ brew install ffmpeg poppler
 | **MuseScore 3** | everything (`.mscz`/MusicXML conversion, audio, MIDI) | nothing works; MuseScore 4 is a different CLI and is not supported |
 | `ffmpeg` / `ffprobe` | both video renderers | no video |
 | poppler (`pdftoppm`, `pdfinfo`) | PDF system crops | Systems tab and the lyric editor's score crops are unavailable; their tests skip |
+| homr (below) | reading a scanned page into MusicXML | scanned scores have to be brought in as MusicXML by hand; its tests skip |
 | QuickRecorder | the screen recorder only | use the scrolling renderer, which is the default anyway |
+
+### homr, for reading scanned scores (optional)
+
+homr turns a page image into MusicXML. It is **not** a pip package of this
+project and does not go into `.venv`: it is ~660 MB of onnxruntime and opencv
+wheels plus ~150 MB of model weights it keeps inside its own site-packages, and
+the unattended deploy reinstalls this project's requirements on every merge.
+So it gets a venv of its own, outside the checkout, built by a script:
+
+```bash
+scripts/install-homr.sh          # needs uv; ~10 minutes, ~660 MB on disk
+```
+
+That creates `~/.local/share/musescore-choir-plugins/homr-venv` on python 3.12
+and downloads the model weights, so the first scan is not the slow one.
+Re-running it is safe. Set `HOMR_VENV` to put it elsewhere, and then `HOMR_BIN`
+in `.env` so the app can find it. `HOMR_SOURCE` is where homr is installed
+from — a PyPI pin now, our own fork's git URL once
+[#104](https://github.com/eerovil/musescore-choir-plugins/issues/104) lands.
+Without homr, `src/song_app/omr.py` raises a message saying so and its tests
+skip; nothing else in the app is affected.
 
 Install the QML plugins separately by copying or symlinking `plugins/` into
 `~/Documents/MuseScore3/Plugins` — MuseScore loads them from there, not from this

--- a/scripts/install-homr.sh
+++ b/scripts/install-homr.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# Install homr (optical music recognition) into a venv the song app can call.
+#
+# homr does not go into the app's own .venv on purpose. The unattended deploy
+# reinstalls pip-requirements.txt on every merge, and homr is ~660 MB of
+# onnxruntime/opencv wheels plus ~150 MB of model weights that it stores inside
+# its own site-packages — so a reinstall there would churn the weights and a
+# resolution failure would take the live app down. It lives in its own venv,
+# outside the checkout, so a fresh clone or a deploy never touches it.
+#
+# Idempotent: re-running upgrades the pin in place and re-downloads only
+# whatever weights are missing.
+#
+#   scripts/install-homr.sh                 # default location
+#   HOMR_VENV=/somewhere/else scripts/install-homr.sh
+#
+# Afterwards, point the app at it if you used a non-default location:
+#   HOMR_BIN=/somewhere/else/bin/homr   in .env
+
+set -euo pipefail
+
+# Where homr comes from. ONE PLACE, deliberately: issue #97 decided to fork
+# homr and fix multi-page joining, staff grouping and PDF input inside the
+# fork, because by the time the app sees homr's output the staves are gone. So
+# this line becomes a git URL once #104 stands the fork up —
+#   "git+https://github.com/<owner>/homr@<ref>"
+# — and nothing else in this script or in src/song_app/omr.py changes with it.
+HOMR_SOURCE="${HOMR_SOURCE:-homr==0.7.0}"
+
+# homr 0.7.0 declares >=3.11,<3.16, but every benchmark number recorded for this
+# project came off 3.12. uv fetches the interpreter, so this costs nothing.
+HOMR_PYTHON="${HOMR_PYTHON:-3.12}"
+HOMR_VENV="${HOMR_VENV:-$HOME/.local/share/musescore-choir-plugins/homr-venv}"
+
+if ! command -v uv >/dev/null 2>&1; then
+    echo "uv is not installed. See https://docs.astral.sh/uv/getting-started/" >&2
+    exit 1
+fi
+
+echo "Creating $HOMR_VENV (python $HOMR_PYTHON)"
+mkdir -p "$(dirname "$HOMR_VENV")"
+# --allow-existing rather than --clear: re-running this to move HOMR_SOURCE on
+# to the fork must not throw away the 150 MB of weights already downloaded.
+uv venv --allow-existing --python "$HOMR_PYTHON" "$HOMR_VENV"
+
+# There is no [cpu] extra on 0.7.0 despite what upstream's README suggests —
+# uv warns and ignores it. Plain homr pulls the CPU onnxruntime, which is all
+# this host can use anyway (see issue #93: the GTX 970 is sm_52, below
+# onnxruntime's sm_60 floor).
+echo "Installing $HOMR_SOURCE"
+VIRTUAL_ENV="$HOMR_VENV" uv pip install "$HOMR_SOURCE"
+
+# Pull the model weights now rather than on the first parse a person is waiting
+# for. ~150 MB, into the homr package directory inside the venv.
+echo "Downloading model weights (once; ~150 MB)"
+"$HOMR_VENV/bin/homr" --init
+
+echo
+echo "homr installed: $HOMR_VENV/bin/homr"
+if [ "$HOMR_VENV" != "$HOME/.local/share/musescore-choir-plugins/homr-venv" ]; then
+    echo "Non-default location — add to .env:"
+    echo "  HOMR_BIN=$HOMR_VENV/bin/homr"
+fi

--- a/src/song_app/omr.py
+++ b/src/song_app/omr.py
@@ -1,0 +1,200 @@
+"""Run homr (optical music recognition) on a page image.
+
+One public call: give it a page image, get a MusicXML path back. Everything
+about *how* homr is reached lives here — where its interpreter is, that the
+picture and the answer land in the same folder, that a hundred lines of
+progress on stderr are a progress channel rather than noise, and that a
+failure has to say what went wrong rather than return a number.
+
+**homr is not in the app's environment and cannot be.** It is ~660 MB of
+onnxruntime and opencv wheels plus ~150 MB of model weights it keeps inside
+its own site-packages, and the unattended deploy reinstalls the app's
+requirements every two minutes on merge. So it lives in a venv of its own,
+built by ``scripts/install-homr.sh`` outside the checkout, and is called as a
+subprocess. A page is ~30 seconds, so the cost of a process is not a number
+worth thinking about.
+
+Two things about the CLI that this module exists to absorb:
+
+* It takes one image, writes ``<image>.musicxml`` beside it, and has no
+  ``--output``. It also drops a ``_teaser.png`` and, in debug mode, more. So
+  the run happens on a copy in a scratch directory and only the MusicXML is
+  kept.
+* ``--gpu`` defaults to ``auto``, which asks whether the CUDA provider is
+  *registered* and not whether it can run. This host's card is below
+  onnxruntime's floor (issue #93), so auto would pick CUDA and die on the
+  first segnet node without falling back. Every call passes ``no``.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import signal
+import subprocess
+import tempfile
+import threading
+from typing import Callable, List, Optional
+
+Logger = Callable[[str], None]
+
+#: Where ``scripts/install-homr.sh`` puts the venv when nobody says otherwise.
+DEFAULT_VENV = os.path.join(
+    os.path.expanduser("~"), ".local", "share", "musescore-choir-plugins", "homr-venv"
+)
+
+#: A page is ~30s (issue #93). This is a wedged-process guard, not a budget.
+DEFAULT_TIMEOUT = 600
+
+IMAGE_EXTS = (".png", ".jpg", ".jpeg")
+
+#: How much of homr's output an error carries. Its stderr is chatty and the
+#: line that explains the failure is at the end.
+_ERROR_TAIL_LINES = 20
+
+
+class HomrError(RuntimeError):
+    """homr could not read the image, or could not be run at all."""
+
+
+class HomrMissing(HomrError):
+    """homr is not installed on this host."""
+
+
+def _noop(_msg: str) -> None:
+    pass
+
+
+def homr_binary() -> str:
+    """The homr executable: ``HOMR_BIN``, else the default venv, else PATH."""
+    configured = os.getenv("HOMR_BIN")
+    if configured:
+        return configured
+    default = os.path.join(DEFAULT_VENV, "bin", "homr")
+    if os.path.exists(default):
+        return default
+    return "homr"
+
+
+def homr_available() -> bool:
+    """Whether :func:`read_page` can run at all on this host."""
+    binary = homr_binary()
+    if os.path.sep in binary:
+        return os.access(binary, os.X_OK)
+    return shutil.which(binary) is not None
+
+
+def read_page(
+    image_path: str,
+    out_dir: Optional[str] = None,
+    log: Logger = _noop,
+    timeout: int = DEFAULT_TIMEOUT,
+) -> str:
+    """Read one page image and return the path of the MusicXML written for it.
+
+    The file is named after the image and lands in ``out_dir`` (the image's own
+    directory by default). An existing file there is overwritten, so re-reading
+    a page replaces its answer rather than accumulating.
+
+    ``log`` is called with each line homr prints — that is the only progress
+    this takes minutes to produce, so a caller with a person waiting should
+    pass one.
+    """
+    if not os.path.exists(image_path):
+        raise HomrError(f"No such image: {image_path}")
+    if not image_path.lower().endswith(IMAGE_EXTS):
+        raise HomrError(
+            f"homr reads {', '.join(IMAGE_EXTS)}, not {os.path.splitext(image_path)[1]}: "
+            f"{image_path}"
+        )
+
+    binary = homr_binary()
+    if not homr_available():
+        raise HomrMissing(
+            f"homr is not installed ({binary}). Run scripts/install-homr.sh, "
+            "or set HOMR_BIN if it lives somewhere else."
+        )
+
+    base = os.path.splitext(os.path.basename(image_path))[0]
+    destination = os.path.join(out_dir or os.path.dirname(os.path.abspath(image_path)),
+                               base + ".musicxml")
+
+    # homr writes beside its input and litters a teaser image next to it, so it
+    # is given a copy in a directory of its own and only the answer is kept.
+    with tempfile.TemporaryDirectory(prefix="homr-") as scratch:
+        scratch_image = os.path.join(scratch, os.path.basename(image_path))
+        shutil.copy2(image_path, scratch_image)
+        produced = os.path.join(scratch, base + ".musicxml")
+
+        log(f"Reading {os.path.basename(image_path)} with homr")
+        output = _run([binary, "--gpu", "no", scratch_image], log, timeout)
+
+        if not os.path.exists(produced):
+            # homr deletes its own output when parsing fails, so a zero exit
+            # with no file is still a failure and has to be reported as one.
+            raise HomrError(
+                f"homr produced no MusicXML for {os.path.basename(image_path)}.\n"
+                + _tail(output)
+            )
+
+        os.makedirs(os.path.dirname(destination), exist_ok=True)
+        shutil.move(produced, destination)
+
+    return destination
+
+
+def _run(command: List[str], log: Logger, timeout: int) -> List[str]:
+    """Run homr, streaming its output to ``log``, and return the lines.
+
+    The deadline is a timer that kills the process, not ``wait(timeout=...)``:
+    reading the pipe is what blocks, and a wedged homr holding it open would
+    never reach the wait at all.
+    """
+    try:
+        process = subprocess.Popen(
+            command,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+            bufsize=1,
+            # Its own process group, so a deadline can take any child with it.
+            start_new_session=True,
+        )
+    except OSError as exc:
+        raise HomrMissing(f"Could not run {command[0]}: {exc}") from exc
+
+    expired = threading.Event()
+
+    def give_up() -> None:
+        expired.set()
+        try:
+            os.killpg(process.pid, signal.SIGKILL)
+        except (ProcessLookupError, PermissionError):
+            process.kill()
+
+    deadline = threading.Timer(timeout, give_up)
+    deadline.start()
+
+    lines: List[str] = []
+    try:
+        assert process.stdout is not None
+        for line in process.stdout:
+            line = line.rstrip("\n")
+            if line:
+                lines.append(line)
+                log(line)
+        returncode = process.wait()
+    finally:
+        deadline.cancel()
+        if process.stdout is not None:
+            process.stdout.close()
+
+    if expired.is_set():
+        raise HomrError(f"homr did not finish within {timeout}s.\n" + _tail(lines))
+    if returncode != 0:
+        raise HomrError(f"homr exited {returncode}.\n" + _tail(lines))
+    return lines
+
+
+def _tail(lines: List[str]) -> str:
+    return "\n".join(lines[-_ERROR_TAIL_LINES:])

--- a/src/song_app/omr.py
+++ b/src/song_app/omr.py
@@ -24,6 +24,21 @@ Two things about the CLI that this module exists to absorb:
   *registered* and not whether it can run. This host's card is below
   onnxruntime's floor (issue #93), so auto would pick CUDA and die on the
   first segnet node without falling back. Every call passes ``no``.
+
+**A scan takes one of this host's heavy slots**, the same way the video render
+does (:mod:`heavy_slot`, issue #100). A page is ~30s of every core on a
+four-core host shared with the deck's own suites and a song rendering, and
+three such jobs at once finish no sooner than one after another. Failing to
+get a slot is fail-open and losing one stops the work — both of those are
+:mod:`heavy_slot`'s decisions and neither is re-argued here.
+
+**One slot per page, not one for the whole song.** A song is several pages and
+each is a separate homr call writing its own MusicXML, so the page is the unit
+this module has: releasing between pages lets a render or a suite in, and an
+interrupted scan costs the page in flight rather than the song. The pages
+already read are on disk. A caller that would rather hold one lease across a
+whole song passes ``queue=False`` and wraps the loop itself, so the two never
+nest.
 """
 
 from __future__ import annotations
@@ -34,7 +49,10 @@ import signal
 import subprocess
 import tempfile
 import threading
+from contextlib import contextmanager
 from typing import Callable, List, Optional
+
+from . import heavy_slot
 
 Logger = Callable[[str], None]
 
@@ -89,6 +107,8 @@ def read_page(
     out_dir: Optional[str] = None,
     log: Logger = _noop,
     timeout: int = DEFAULT_TIMEOUT,
+    label: Optional[str] = None,
+    queue: bool = True,
 ) -> str:
     """Read one page image and return the path of the MusicXML written for it.
 
@@ -98,7 +118,12 @@ def read_page(
 
     ``log`` is called with each line homr prints — that is the only progress
     this takes minutes to produce, so a caller with a person waiting should
-    pass one.
+    pass one. It is also where the run can be stopped: those lines are the
+    heavy slot's checkpoints, so a lease lost mid-page raises ``SlotLost``
+    there rather than at the end.
+
+    ``label`` is what the queue shows for this page; ``queue=False`` runs
+    without asking for a slot, for a caller already holding one.
     """
     if not os.path.exists(image_path):
         raise HomrError(f"No such image: {image_path}")
@@ -126,8 +151,13 @@ def read_page(
         shutil.copy2(image_path, scratch_image)
         produced = os.path.join(scratch, base + ".musicxml")
 
-        log(f"Reading {os.path.basename(image_path)} with homr")
-        output = _run([binary, "--gpu", "no", scratch_image], log, timeout)
+        with _queued(label or f"song app homr {base}", log, queue) as slot:
+            # homr's own output is the only place a page can be interrupted, so
+            # that is where the lease is checked (heavy_slot.Slot.guard).
+            watched = slot.guard(log)
+            watched(f"Reading {os.path.basename(image_path)} with homr")
+            output = _run([binary, "--gpu", "no", scratch_image], watched, timeout)
+            slot.check()
 
         if not os.path.exists(produced):
             # homr deletes its own output when parsing fails, so a zero exit
@@ -141,6 +171,16 @@ def read_page(
         shutil.move(produced, destination)
 
     return destination
+
+
+@contextmanager
+def _queued(label: str, log: Logger, queue: bool):
+    """A heavy slot for this page, or the un-held Slot when the caller has one."""
+    if not queue:
+        yield heavy_slot.Slot()
+        return
+    with heavy_slot.heavy_slot(label, log=log) as slot:
+        yield slot
 
 
 def _run(command: List[str], log: Logger, timeout: int) -> List[str]:
@@ -167,10 +207,7 @@ def _run(command: List[str], log: Logger, timeout: int) -> List[str]:
 
     def give_up() -> None:
         expired.set()
-        try:
-            os.killpg(process.pid, signal.SIGKILL)
-        except (ProcessLookupError, PermissionError):
-            process.kill()
+        _kill(process)
 
     deadline = threading.Timer(timeout, give_up)
     deadline.start()
@@ -184,6 +221,12 @@ def _run(command: List[str], log: Logger, timeout: int) -> List[str]:
                 lines.append(line)
                 log(line)
         returncode = process.wait()
+    except BaseException:
+        # The log callback carries the heavy slot's check, so it can raise
+        # here. Abandoning the loop without this would leave homr running on
+        # cores that have been promised to somebody else.
+        _kill(process)
+        raise
     finally:
         deadline.cancel()
         if process.stdout is not None:
@@ -194,6 +237,18 @@ def _run(command: List[str], log: Logger, timeout: int) -> List[str]:
     if returncode != 0:
         raise HomrError(f"homr exited {returncode}.\n" + _tail(lines))
     return lines
+
+
+def _kill(process: subprocess.Popen) -> None:
+    """Kill homr and anything it started (it runs in its own process group)."""
+    try:
+        os.killpg(process.pid, signal.SIGKILL)
+    except (ProcessLookupError, PermissionError):
+        process.kill()
+    try:
+        process.wait(timeout=10)
+    except subprocess.TimeoutExpired:
+        pass
 
 
 def _tail(lines: List[str]) -> str:

--- a/src/song_app/tests/test_omr.py
+++ b/src/song_app/tests/test_omr.py
@@ -10,14 +10,24 @@ The last test is the one the card asks for and the only one that runs the real
 thing: a page of the scanned fixture goes in, MusicXML comes out. It needs
 homr installed (scripts/install-homr.sh) and poppler, and skips without them.
 """
+import contextlib
 import os
 import shutil
 import stat
+import time
 
 import pytest
 from lxml import etree
 
-from src.song_app import omr
+from src.song_app import heavy_slot, omr
+
+
+@pytest.fixture(autouse=True)
+def _no_real_deck(monkeypatch):
+    """A scan asks AgentDeck for a heavy slot; tests must not take a real one
+    off the host they run on. Each test that cares fakes its own deck."""
+    monkeypatch.delenv("AGENTDECK_API_URL", raising=False)
+    monkeypatch.delenv("AGENTDECK_URL", raising=False)
 
 
 FIXTURE_PDF = os.path.join(
@@ -141,6 +151,111 @@ def test_progress_reaches_the_log(monkeypatch, tmp_path):
     # Both streams are a progress channel; homr talks on stderr.
     assert "Found 12 staff line fragments" in lines
     assert "Finished parsing 12 staves" in lines
+
+
+# --- the heavy slot ------------------------------------------------------
+
+
+def test_a_page_is_read_under_a_heavy_slot(monkeypatch, tmp_path):
+    """A page is ~30s of every core, so it waits its turn — and the slot is
+    held across the run, not merely asked for and dropped."""
+    order = []
+    monkeypatch.setenv("HOMR_BIN", stub_homr(
+        tmp_path,
+        'echo running\n'
+        'echo "<score/>" > "${!#%.*}.musicxml"\n',
+    ))
+
+    @contextlib.contextmanager
+    def fake_slot(label, **kwargs):
+        order.append(f"take {label}")
+        yield heavy_slot.Slot("lease-1")
+        order.append("release")
+
+    monkeypatch.setattr(omr.heavy_slot, "heavy_slot", fake_slot)
+    omr.read_page(
+        a_page(tmp_path),
+        log=lambda line: order.append("homr") if line == "running" else None,
+        label="song app homr MySong page 2",
+    )
+
+    assert order == ["take song app homr MySong page 2", "homr", "release"]
+
+
+def test_the_slot_is_labelled_after_the_page_by_default(monkeypatch, tmp_path):
+    seen = []
+    monkeypatch.setenv("HOMR_BIN", stub_homr(tmp_path, 'echo "<score/>" > "${!#%.*}.musicxml"\n'))
+
+    @contextlib.contextmanager
+    def fake_slot(label, **kwargs):
+        seen.append(label)
+        yield heavy_slot.Slot()
+
+    monkeypatch.setattr(omr.heavy_slot, "heavy_slot", fake_slot)
+    omr.read_page(a_page(tmp_path, "MySong-page-3.png"))
+    assert seen == ["song app homr MySong-page-3"]
+
+
+def test_a_caller_holding_a_slot_does_not_take_a_second(monkeypatch, tmp_path):
+    """One lease per song is the other way to do this, so queue=False has to
+    genuinely not ask — a nested lease would deadlock a one-slot pool."""
+    monkeypatch.setenv("HOMR_BIN", stub_homr(tmp_path, 'echo "<score/>" > "${!#%.*}.musicxml"\n'))
+
+    @contextlib.contextmanager
+    def never(label, **kwargs):
+        raise AssertionError("asked for a slot when the caller already held one")
+        yield
+
+    monkeypatch.setattr(omr.heavy_slot, "heavy_slot", never)
+    assert omr.read_page(a_page(tmp_path), queue=False).endswith(".musicxml")
+
+
+def test_losing_the_slot_stops_the_page(monkeypatch, tmp_path):
+    """A heartbeat answering 404 means the cores may already be somebody
+    else's. homr's own output is where a page can be stopped."""
+    monkeypatch.setenv("HOMR_BIN", stub_homr(
+        tmp_path,
+        'echo "Found 12 staff line fragments"\n'
+        'sleep 20\n'
+        'echo "<score/>" > "${!#%.*}.musicxml"\n',
+    ))
+    slot = heavy_slot.Slot("lease-1")
+
+    @contextlib.contextmanager
+    def fake_slot(label, **kwargs):
+        yield slot
+
+    monkeypatch.setattr(omr.heavy_slot, "heavy_slot", fake_slot)
+
+    def lose_it(_line):
+        slot._lose()          # the heartbeat thread's job, done inline
+
+    with pytest.raises(heavy_slot.SlotLost):
+        omr.read_page(a_page(tmp_path), log=lose_it)
+
+
+def test_a_stopped_page_takes_homr_with_it(monkeypatch, tmp_path):
+    """Abandoning the read loop must not leave homr running on cores that have
+    been handed to somebody else."""
+    marker = tmp_path / "still-running"
+    monkeypatch.setenv("HOMR_BIN", stub_homr(
+        tmp_path,
+        'echo starting\n'
+        'sleep 20\n'
+        'touch ' + str(marker) + '\n',
+    ))
+    slot = heavy_slot.Slot("lease-1")
+
+    @contextlib.contextmanager
+    def fake_slot(label, **kwargs):
+        yield slot
+
+    monkeypatch.setattr(omr.heavy_slot, "heavy_slot", fake_slot)
+    with pytest.raises(heavy_slot.SlotLost):
+        omr.read_page(a_page(tmp_path), log=lambda _line: slot._lose())
+
+    time.sleep(1.5)
+    assert not marker.exists(), "homr outlived the page that was stopped"
 
 
 # --- how it fails --------------------------------------------------------

--- a/src/song_app/tests/test_omr.py
+++ b/src/song_app/tests/test_omr.py
@@ -1,0 +1,210 @@
+"""Calling homr from the app's own environment.
+
+Most of this drives a stub standing in for homr, because what the module is
+responsible for is the boundary — where the binary is, that the answer ends up
+where the caller asked for it and the litter does not, that progress reaches a
+log, and that every way of failing says something. Whether homr can read music
+is homr's business.
+
+The last test is the one the card asks for and the only one that runs the real
+thing: a page of the scanned fixture goes in, MusicXML comes out. It needs
+homr installed (scripts/install-homr.sh) and poppler, and skips without them.
+"""
+import os
+import shutil
+import stat
+
+import pytest
+from lxml import etree
+
+from src.song_app import omr
+
+
+FIXTURE_PDF = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))),
+    "fixtures", "virta-venhetta-vie", "00-registered", "Virta venhettä vie.pdf",
+)
+
+
+def stub_homr(tmp_path, script):
+    """A fake homr on disk, with $1.. the arguments the module passed it."""
+    path = tmp_path / "fake-homr"
+    path.write_text("#!/usr/bin/env bash\n" + script)
+    path.chmod(path.stat().st_mode | stat.S_IEXEC)
+    return str(path)
+
+
+def a_page(tmp_path, name="page-1.png"):
+    image = tmp_path / name
+    image.write_bytes(b"not really a png, the stub does not look")
+    return str(image)
+
+
+# --- where homr is -------------------------------------------------------
+
+
+def test_homr_bin_wins_over_everything(monkeypatch, tmp_path):
+    monkeypatch.setenv("HOMR_BIN", "/somewhere/else/homr")
+    assert omr.homr_binary() == "/somewhere/else/homr"
+
+
+def test_falls_back_to_the_installed_venv(monkeypatch, tmp_path):
+    monkeypatch.delenv("HOMR_BIN", raising=False)
+    venv_bin = tmp_path / "bin"
+    venv_bin.mkdir()
+    (venv_bin / "homr").write_text("")
+    monkeypatch.setattr(omr, "DEFAULT_VENV", str(tmp_path))
+    assert omr.homr_binary() == str(venv_bin / "homr")
+
+
+def test_falls_back_to_the_path_when_no_venv(monkeypatch, tmp_path):
+    monkeypatch.delenv("HOMR_BIN", raising=False)
+    monkeypatch.setattr(omr, "DEFAULT_VENV", str(tmp_path / "no-such-venv"))
+    assert omr.homr_binary() == "homr"
+
+
+def test_not_installed_is_its_own_error(monkeypatch, tmp_path):
+    monkeypatch.setenv("HOMR_BIN", str(tmp_path / "no-such-homr"))
+    with pytest.raises(omr.HomrMissing) as caught:
+        omr.read_page(a_page(tmp_path))
+    assert "install-homr.sh" in str(caught.value)
+
+
+# --- what it hands back --------------------------------------------------
+
+
+def test_the_musicxml_lands_where_the_caller_asked(monkeypatch, tmp_path):
+    # The stub writes beside its input, the way homr does.
+    monkeypatch.setenv("HOMR_BIN", stub_homr(tmp_path, 'echo "<score/>" > "${!#%.*}.musicxml"\n'))
+    out = tmp_path / "scores"
+    produced = omr.read_page(a_page(tmp_path), out_dir=str(out))
+
+    assert produced == str(out / "page-1.musicxml")
+    assert open(produced).read().strip() == "<score/>"
+
+
+def test_without_an_out_dir_it_lands_beside_the_image(monkeypatch, tmp_path):
+    monkeypatch.setenv("HOMR_BIN", stub_homr(tmp_path, 'echo "<score/>" > "${!#%.*}.musicxml"\n'))
+    pages = tmp_path / "pages"
+    pages.mkdir()
+    produced = omr.read_page(a_page(pages))
+    assert produced == str(pages / "page-1.musicxml")
+
+
+def test_the_teaser_litter_does_not_follow_the_answer(monkeypatch, tmp_path):
+    # homr drops a _teaser.png (and in debug mode more) next to its input.
+    monkeypatch.setenv("HOMR_BIN", stub_homr(
+        tmp_path,
+        'echo "<score/>" > "${!#%.*}.musicxml"\n'
+        'echo teaser > "${!#%.*}_teaser.png"\n',
+    ))
+    pages = tmp_path / "pages"
+    pages.mkdir()
+    omr.read_page(a_page(pages))
+    assert sorted(os.listdir(pages)) == ["page-1.musicxml", "page-1.png"]
+
+
+def test_reading_a_page_again_replaces_its_answer(monkeypatch, tmp_path):
+    image = a_page(tmp_path)
+    monkeypatch.setenv("HOMR_BIN", stub_homr(tmp_path, 'echo "<first/>" > "${!#%.*}.musicxml"\n'))
+    first = omr.read_page(image)
+    monkeypatch.setenv("HOMR_BIN", stub_homr(tmp_path, 'echo "<second/>" > "${!#%.*}.musicxml"\n'))
+    second = omr.read_page(image)
+    assert first == second
+    assert open(second).read().strip() == "<second/>"
+
+
+# --- how it is called ----------------------------------------------------
+
+
+def test_the_gpu_is_switched_off_explicitly(monkeypatch, tmp_path):
+    # --gpu auto asks whether CUDA is registered, not whether it works, and
+    # this host's card is below onnxruntime's floor (#93).
+    monkeypatch.setenv("HOMR_BIN", stub_homr(
+        tmp_path,
+        'echo "$@" > ' + str(tmp_path / "args") + '\n'
+        'echo "<score/>" > "${!#%.*}.musicxml"\n',
+    ))
+    omr.read_page(a_page(tmp_path))
+    assert "--gpu no" in open(tmp_path / "args").read()
+
+
+def test_progress_reaches_the_log(monkeypatch, tmp_path):
+    monkeypatch.setenv("HOMR_BIN", stub_homr(
+        tmp_path,
+        'echo "Found 12 staff line fragments"\n'
+        'echo "Finished parsing 12 staves" >&2\n'
+        'echo "<score/>" > "${!#%.*}.musicxml"\n',
+    ))
+    lines = []
+    omr.read_page(a_page(tmp_path), log=lines.append)
+    # Both streams are a progress channel; homr talks on stderr.
+    assert "Found 12 staff line fragments" in lines
+    assert "Finished parsing 12 staves" in lines
+
+
+# --- how it fails --------------------------------------------------------
+
+
+def test_a_missing_image_is_refused_before_homr_runs(tmp_path):
+    with pytest.raises(omr.HomrError) as caught:
+        omr.read_page(str(tmp_path / "nothing.png"))
+    assert "No such image" in str(caught.value)
+
+
+def test_a_pdf_is_refused_rather_than_handed_over(monkeypatch, tmp_path):
+    # homr reads one image; feeding it a PDF fails deep inside opencv.
+    pdf = tmp_path / "song.pdf"
+    pdf.write_bytes(b"%PDF-1.4")
+    with pytest.raises(omr.HomrError) as caught:
+        omr.read_page(str(pdf))
+    assert ".pdf" in str(caught.value)
+
+
+def test_a_failing_run_carries_what_homr_said(monkeypatch, tmp_path):
+    monkeypatch.setenv("HOMR_BIN", stub_homr(
+        tmp_path, 'echo "No noteheads found" >&2\nexit 1\n'))
+    with pytest.raises(omr.HomrError) as caught:
+        omr.read_page(a_page(tmp_path))
+    assert "No noteheads found" in str(caught.value)
+
+
+def test_a_clean_exit_with_no_file_is_still_a_failure(monkeypatch, tmp_path):
+    # homr deletes its own output when parsing raises, so the exit code is not
+    # the whole story.
+    monkeypatch.setenv("HOMR_BIN", stub_homr(tmp_path, 'echo "gave up quietly" >&2\nexit 0\n'))
+    with pytest.raises(omr.HomrError) as caught:
+        omr.read_page(a_page(tmp_path))
+    assert "no MusicXML" in str(caught.value)
+    assert "gave up quietly" in str(caught.value)
+
+
+def test_a_wedged_run_is_killed(monkeypatch, tmp_path):
+    monkeypatch.setenv("HOMR_BIN", stub_homr(tmp_path, 'sleep 30\n'))
+    with pytest.raises(omr.HomrError) as caught:
+        omr.read_page(a_page(tmp_path), timeout=1)
+    assert "did not finish" in str(caught.value)
+
+
+# --- the real thing ------------------------------------------------------
+
+
+@pytest.mark.skipif(not omr.homr_available(), reason="homr not installed (scripts/install-homr.sh)")
+@pytest.mark.skipif(not shutil.which("pdftoppm"), reason="poppler (pdftoppm) is not installed")
+def test_a_scanned_page_comes_back_as_musicxml(tmp_path):
+    """The card's own acceptance: an image path in, a MusicXML path out."""
+    from src.song_app import pdf_systems
+
+    page = pdf_systems.render_page(FIXTURE_PDF, 1, 300, str(tmp_path))
+
+    lines = []
+    produced = omr.read_page(page, out_dir=str(tmp_path / "out"), log=lines.append)
+
+    assert os.path.exists(produced)
+    root = etree.parse(produced).getroot()
+    assert root.tag == "score-partwise"
+    assert root.findall(".//part"), "no parts in the MusicXML"
+    assert root.findall(".//measure"), "no measures in the MusicXML"
+    assert root.findall(".//note"), "no notes in the MusicXML"
+    # It took minutes; it had better have said something while it did.
+    assert lines


### PR DESCRIPTION
Closes #96

homr is the first thing the app depends on that cannot live in the app's own environment. This gives it a venv of its own and one call into it.

## Where it lives, and why not somewhere else

A `uv`-managed **python 3.12 venv outside the checkout**, built by the committed `scripts/install-homr.sh`.

- **Not the app's `.venv`.** homr is ~660 MB of onnxruntime and opencv wheels plus ~150 MB of model weights it stores *inside its own site-packages*, and `scripts/deploy-song-app.sh --unattended` reinstalls `pip-requirements.txt` every two minutes on merge. That is a specific failure, not general caution: a merge would re-resolve an ML stack and re-download the weights, and a resolution failure there takes the live app down.
- **Not the `omr` distrobox container.** Hand-built host state nothing in this repo describes — the cost CLAUDE.md's "Working in a worktree" section exists to complain about.
- **Not a container image.** A build system to hold one venv is a second thing to keep working, for no reproducibility a script does not already give.

**Where homr comes from is one variable**, `HOMR_SOURCE`. `homr==0.7.0` today; a `git+https://...` URL once #104 stands up the fork #97 decided on. Nothing else in the script or in `omr.py` moves with it.

Two things the map was carrying that turned out wrong, and are now pinned in the docs: homr 0.7.0 declares `>=3.11,<3.16` and resolves on 3.14 too, so python is a choice and not a wall (3.12 because every benchmark number in #93 and #95 came off 3.12); and there is **no `[cpu]` extra** on 0.7.0 — upstream's `uvx --from 'homr[cpu]' homr` warns and ignores it.

## The call

`src/song_app/omr.py` — `read_page(image_path, out_dir=..., log=...) -> musicxml_path`.

- homr writes `<image>.musicxml` beside its input, has no `--output`, and drops a `_teaser.png`. So the run happens on a copy in a scratch dir and only the answer is moved where the caller asked.
- `--gpu no` explicitly, never `auto`: auto asks whether the CUDA provider is *registered*, not whether it can run, and this host's card is below onnxruntime's floor (#93). The value is `no`, not `off`.
- Every line streamed to a `log` callback — a page is ~30s, a song 2–5 minutes, so that is the progress channel #93 asked for.
- Failures raise `HomrError` carrying the tail of what homr said, including the quiet one: homr **deletes its own MusicXML when parsing raises**, so a zero exit with no file is a failure. Not installed is `HomrMissing`, naming the install script. The deadline kills the process group, because reading the pipe is what blocks.
- `HOMR_BIN` in `.env`, else the default venv, else PATH — the same shape as `MUSESCORE_CLI_PATH`.

## The heavy slot

A page is read under one of this host's heavy slots, through the existing `src/song_app/heavy_slot.py` (#100/#101) — not a second client. A page is ~30s of every core on a four-core host shared with the deck's suites and a song rendering. Its two rules carry over unchanged: failing to get a slot is fail-open, losing one stops the work.

**One slot per page, not one for the whole song.** The page is the unit `read_page` owns, and each page writes its own MusicXML, so releasing between pages lets a render or a suite in and an interruption costs the page in flight rather than the song — the pages already read are on disk. The cost is that a scan can be interrupted mid-song; that seemed the better trade against holding four cores for five minutes while a practice video waits. A caller that would rather hold one lease across a whole song passes `queue=False` and wraps the loop itself, so the two never nest (nesting would deadlock a one-slot pool).

homr's own output lines are the checkpoints `Slot.guard` needs. Abandoning the read loop kills homr's process group — otherwise it would keep running on cores already handed away.

## Out of scope, deliberately

Nothing calls `read_page` yet. The stage machine and UI are #98, the page stitching is #97/#104, page-vs-system is #103, and the deploy and `/healthz` do not know homr exists.

## Verification

`.venv/bin/python -m pytest src/song_app/tests/test_omr.py -q` — 21 passed. Twenty drive a stub standing in for homr (the boundary is what this module owns); the last runs the real thing end to end: page 1 of the scanned fixture at 300 dpi in, parseable MusicXML with parts, measures and notes out, ~50s. It skips without homr or poppler. CI cited in the issue comment.

The install script was also run twice on this host to confirm it is idempotent and does not throw away the downloaded weights.

AgentDeck session: https://bazzite.taile8d16e.ts.net/chats/cef12e6db942473da69323ad0eb302b5

🤖 Generated with [Claude Code](https://claude.com/claude-code)

