### PR TITLE
Install homr from the pinned fork

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -692,19 +692,19 @@ state model are in `DESIGN.md`.
   So: a `uv`-managed python 3.12 venv outside the checkout, built by
   **`scripts/install-homr.sh`** (idempotent; `HOMR_VENV` moves it), called as a
   subprocess. A fresh clone runs one script.
-  **Where homr comes from is one variable in that script, `HOMR_SOURCE`, and it is
-  expected to stop being a PyPI pin.** #97 decided to fork homr and build the
-  multi-page joining, the staff-grouping fix and PDF input *inside the fork*, because
-  the app only ever sees homr's output and by then the staves are gone; #104 stands
-  that fork up. So `homr==0.7.0` today becomes a `git+https://...` URL then, changed in
-  one line, and nothing in `omr.py` or in the rest of the script moves with it. Do not
-  be surprised to find a git URL where a version pin is written here.
+  **Where homr comes from is one variable in that script, `HOMR_SOURCE`.** It defaults
+  to the immutable `eerovil/homr` commit matching upstream `v0.7.0`; an explicit
+  `HOMR_SOURCE` still wins. #97 put multi-page joining, the staff-grouping fix and PDF
+  input *inside the fork*, because the app only ever sees homr's output and by then the
+  staves are gone. The fork is pinned rather than automatically synced: moving the
+  source commit is a deliberate upgrade followed by the frozen benchmark run. Nothing
+  in `omr.py` or in the rest of the installer moves with it.
   Two things the earlier notes got wrong
   and this pins: homr 0.7.0 declares `>=3.11,<3.16` and installs on 3.14 too, so the
   version is a choice and not a wall — 3.12 because every benchmark number in #93 and
   #95 came off 3.12; and there is **no `[cpu]` extra** on 0.7.0, so upstream's
-  `uvx --from 'homr[cpu]' homr` recipe silently ignores it. Plain `homr==0.7.0` pulls
-  the CPU onnxruntime, which is all this host can use anyway.
+  `uvx --from 'homr[cpu]' homr` recipe silently ignores it. The normal source install
+  pulls CPU onnxruntime, which is all this host can use anyway.
   What the module absorbs is the CLI's shape. homr takes one image, writes
   `<image>.musicxml` **beside it**, has no `--output`, and drops a `_teaser.png` next
   to the input, so the run happens on a copy in a scratch dir and only the answer is

--- a/SETUP.md
+++ b/SETUP.md
@@ -64,8 +64,8 @@ That creates `~/.local/share/musescore-choir-plugins/homr-venv` on python 3.12
 and downloads the model weights, so the first scan is not the slow one.
 Re-running it is safe. Set `HOMR_VENV` to put it elsewhere, and then `HOMR_BIN`
 in `.env` so the app can find it. `HOMR_SOURCE` is where homr is installed
-from — a PyPI pin now, our own fork's git URL once
-[#104](https://github.com/eerovil/musescore-choir-plugins/issues/104) lands.
+from. It defaults to an immutable commit in our fork, pinned to the upstream
+0.7.0 baseline; set `HOMR_SOURCE` explicitly to test another source.
 Without homr, `src/song_app/omr.py` raises a message saying so and its tests
 skip; nothing else in the app is affected.
 

--- a/scripts/install-homr.sh
+++ b/scripts/install-homr.sh
@@ -19,13 +19,11 @@
 
 set -euo pipefail
 
-# Where homr comes from. ONE PLACE, deliberately: issue #97 decided to fork
-# homr and fix multi-page joining, staff grouping and PDF input inside the
-# fork, because by the time the app sees homr's output the staves are gone. So
-# this line becomes a git URL once #104 stands the fork up —
-#   "git+https://github.com/<owner>/homr@<ref>"
-# — and nothing else in this script or in src/song_app/omr.py changes with it.
-HOMR_SOURCE="${HOMR_SOURCE:-homr==0.7.0}"
+# Where homr comes from. ONE PLACE, deliberately: the fork is pinned to the
+# stock upstream v0.7.0 commit that passed the frozen benchmark. Moving this
+# pin is a deliberate upgrade followed by another benchmark run; it is never
+# advanced automatically. An explicit HOMR_SOURCE still overrides the pin.
+HOMR_SOURCE="${HOMR_SOURCE:-git+https://github.com/eerovil/homr.git@8b5dcf7d7bdd1a47911dc0c661c573b957271eab}"
 
 # homr 0.7.0 declares >=3.11,<3.16, but every benchmark number recorded for this
 # project came off 3.12. uv fetches the interpreter, so this costs nothing.
@@ -39,13 +37,13 @@ fi
 
 echo "Creating $HOMR_VENV (python $HOMR_PYTHON)"
 mkdir -p "$(dirname "$HOMR_VENV")"
-# --allow-existing rather than --clear: re-running this to move HOMR_SOURCE on
-# to the fork must not throw away the 150 MB of weights already downloaded.
+# --allow-existing rather than --clear: re-running this after moving the source
+# pin must not throw away the 150 MB of weights already downloaded.
 uv venv --allow-existing --python "$HOMR_PYTHON" "$HOMR_VENV"
 
 # There is no [cpu] extra on 0.7.0 despite what upstream's README suggests —
-# uv warns and ignores it. Plain homr pulls the CPU onnxruntime, which is all
-# this host can use anyway (see issue #93: the GTX 970 is sm_52, below
+# uv warns and ignores it. The normal source install pulls CPU onnxruntime,
+# which is all this host can use anyway (see issue #93: the GTX 970 is sm_52, below
 # onnxruntime's sm_60 floor).
 echo "Installing $HOMR_SOURCE"
 VIRTUAL_ENV="$HOMR_VENV" uv pip install "$HOMR_SOURCE"

--- a/src/song_app/tests/test_install_homr.py
+++ b/src/song_app/tests/test_install_homr.py
@@ -1,0 +1,60 @@
+"""The homr installer keeps its pinned source behind one environment override."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+
+DEFAULT_SOURCE = (
+    "git+https://github.com/eerovil/homr.git@"
+    "8b5dcf7d7bdd1a47911dc0c661c573b957271eab"
+)
+
+
+@pytest.mark.parametrize(
+    ("override", "expected"),
+    [(None, DEFAULT_SOURCE), ("homr==9.9.9", "homr==9.9.9")],
+)
+def test_installer_resolves_source(tmp_path: Path, override: str | None, expected: str) -> None:
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    uv_log = tmp_path / "uv.log"
+    homr_log = tmp_path / "homr.log"
+    fake_uv = fake_bin / "uv"
+    fake_uv.write_text(
+        """#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\\n' "$*" >> "$UV_LOG"
+if [[ "$1" == "venv" ]]; then
+    venv="${@: -1}"
+    mkdir -p "$venv/bin"
+    printf '#!/usr/bin/env bash\\nprintf "%%s\\\\n" "$*" >> "$HOMR_LOG"\\n' > "$venv/bin/homr"
+    chmod +x "$venv/bin/homr"
+fi
+""",
+        encoding="utf-8",
+    )
+    fake_uv.chmod(0o755)
+
+    env = os.environ.copy()
+    env.update(
+        {
+            "PATH": f"{fake_bin}:{env['PATH']}",
+            "HOMR_VENV": str(tmp_path / "venv"),
+            "UV_LOG": str(uv_log),
+            "HOMR_LOG": str(homr_log),
+        }
+    )
+    if override is None:
+        env.pop("HOMR_SOURCE", None)
+    else:
+        env["HOMR_SOURCE"] = override
+
+    subprocess.run(["scripts/install-homr.sh"], check=True, env=env, text=True)
+
+    assert f"pip install {expected}" in uv_log.read_text(encoding="utf-8").splitlines()
+    assert homr_log.read_text(encoding="utf-8").splitlines() == ["--init"]


### PR DESCRIPTION
Closes #104

## Summary

- make the verified `eerovil/homr` commit the installer's default source while preserving `HOMR_SOURCE`
- update setup and design documentation from the planned fork switch to the pinned-fork policy
- cover both default and override source resolution through the installer

## Verification

- `python -m pytest src/song_app/tests/test_install_homr.py -q` — 2 passed
- `uv pip install --dry-run --python /home/eero/.local/share/musescore-choir-plugins/homr-venv/bin/python 'git+https://github.com/eerovil/homr.git@8b5dcf7d7bdd1a47911dc0c661c573b957271eab'` — resolved homr 0.7.0 from the pinned git commit
- `bash -n scripts/install-homr.sh`
- [CI run](https://github.com/eerovil/musescore-choir-plugins/actions/runs/33498855575)

AgentDeck session: https://bazzite.taile8d16e.ts.net/chats/986430c90e0b4ed5be8d48a668a974d1
