### PR TITLE
Pin homr where it reports the staves it saw

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -693,12 +693,31 @@ state model are in `DESIGN.md`.
   **`scripts/install-homr.sh`** (idempotent; `HOMR_VENV` moves it), called as a
   subprocess. A fresh clone runs one script.
   **Where homr comes from is one variable in that script, `HOMR_SOURCE`.** It defaults
-  to the immutable `eerovil/homr` commit matching upstream `v0.7.0`; an explicit
-  `HOMR_SOURCE` still wins. #97 put multi-page joining, the staff-grouping fix and PDF
-  input *inside the fork*, because the app only ever sees homr's output and by then the
-  staves are gone. The fork is pinned rather than automatically synced: moving the
-  source commit is a deliberate upgrade followed by the frozen benchmark run. Nothing
-  in `omr.py` or in the rest of the installer moves with it.
+  to an immutable `eerovil/homr` commit; an explicit `HOMR_SOURCE` still wins. #97 put
+  multi-page joining, the staff-grouping fix and PDF input *inside the fork*, because
+  the app only ever sees homr's output and by then the staves are gone. The fork is
+  pinned rather than automatically synced: moving the source commit is a deliberate
+  upgrade followed by the frozen benchmark run. Nothing in `omr.py` or in the rest of
+  the installer moves with it.
+  This pull request proposes moving that pin off stock `v0.7.0` for the first time, to
+  `1ebd593` (eerovil/homr#3), which carries one fix: **homr reports the staves of each
+  printed system instead of assembling parts across them.** Stock homr builds a part
+  out of staff index N of *every* system, which assumes the page is a rectangle — and
+  an engraver prints no empty staff for a part that is resting, so a system where a
+  voice is silent simply has fewer staves. Index 1 of a two-staff system and index 1 of
+  a three-staff system are then different voices spliced into one part, and where the
+  counts disagreed homr either deleted an edge system or broke every group into
+  singletons: twelve staves of a four-part page became one monophonic part of 70 bars.
+  So on a page whose systems disagree, homr now emits **one part per staff per system**
+  in reading order, with each printed system bracketed in the part list
+  (`<part-group>`) so the boundaries survive, and it drops a grand-staff pairing that
+  would leave the systems disagreeing — a wrong pair welds two voices into one part,
+  which renders as tidy music and nothing downstream can see. Which voice a system left
+  out is **not** guessed: it is not in the pixels, and `clean_score`'s `--per-system`
+  grid already answers it by asking a person. **homr reports, the app assembles.** A
+  page whose systems do agree — the two-staff engravings that dominate this repertoire
+  and that homr is strongest on — is assembled exactly as before, and all five
+  two-staff benchmark pages come out byte for byte as they did on stock 0.7.0.
   Two things the earlier notes got wrong
   and this pins: homr 0.7.0 declares `>=3.11,<3.16` and installs on 3.14 too, so the
   version is a choice and not a wall — 3.12 because every benchmark number in #93 and

--- a/SETUP.md
+++ b/SETUP.md
@@ -64,8 +64,9 @@ That creates `~/.local/share/musescore-choir-plugins/homr-venv` on python 3.12
 and downloads the model weights, so the first scan is not the slow one.
 Re-running it is safe. Set `HOMR_VENV` to put it elsewhere, and then `HOMR_BIN`
 in `.env` so the app can find it. `HOMR_SOURCE` is where homr is installed
-from. It defaults to an immutable commit in our fork, pinned to the upstream
-0.7.0 baseline; set `HOMR_SOURCE` explicitly to test another source.
+from. It defaults to an immutable commit in our fork — upstream 0.7.0 plus the
+fix that makes homr report the staves of each printed system rather than
+assemble parts across them; set `HOMR_SOURCE` explicitly to test another source.
 Without homr, `src/song_app/omr.py` raises a message saying so and its tests
 skip; nothing else in the app is affected.
 

--- a/scripts/install-homr.sh
+++ b/scripts/install-homr.sh
@@ -19,11 +19,16 @@
 
 set -euo pipefail
 
-# Where homr comes from. ONE PLACE, deliberately: the fork is pinned to the
-# stock upstream v0.7.0 commit that passed the frozen benchmark. Moving this
-# pin is a deliberate upgrade followed by another benchmark run; it is never
-# advanced automatically. An explicit HOMR_SOURCE still overrides the pin.
-HOMR_SOURCE="${HOMR_SOURCE:-git+https://github.com/eerovil/homr.git@8b5dcf7d7bdd1a47911dc0c661c573b957271eab}"
+# Where homr comes from. ONE PLACE, deliberately: the fork is pinned to one
+# immutable commit that passed the frozen benchmark. Moving this pin is a
+# deliberate upgrade followed by another benchmark run; it is never advanced
+# automatically. An explicit HOMR_SOURCE still overrides the pin.
+#
+# This commit is stock upstream v0.7.0 plus one fix (issue #105, eerovil/homr#3):
+# homr no longer builds a part out of staff index N of every system, so a page
+# whose systems hold different staffs is reported rather than collapsed. The
+# five two-staff benchmark pages come out byte-for-byte as they did before.
+HOMR_SOURCE="${HOMR_SOURCE:-git+https://github.com/eerovil/homr.git@1ebd5933fac352d48d2e44243723e21b7dd783f7}"
 
 # homr 0.7.0 declares >=3.11,<3.16, but every benchmark number recorded for this
 # project came off 3.12. uv fetches the interpreter, so this costs nothing.

--- a/src/song_app/tests/test_install_homr.py
+++ b/src/song_app/tests/test_install_homr.py
@@ -11,7 +11,7 @@ import pytest
 
 DEFAULT_SOURCE = (
     "git+https://github.com/eerovil/homr.git@"
-    "8b5dcf7d7bdd1a47911dc0c661c573b957271eab"
+    "1ebd5933fac352d48d2e44243723e21b7dd783f7"
 )
 
 


### PR DESCRIPTION
Closes #105

Moves `HOMR_SOURCE` off stock `v0.7.0` for the first time, to `eerovil/homr@1ebd593` (eerovil/homr#3). The fork change is the card's work; this repository's change is the pin, its test fixture, and the notes.

## What the fork fix is

Stock homr builds a part out of **staff index N of every system**, which assumes the page is a rectangle. An engraver prints no empty staff for a part that is resting, so a system where a voice is silent simply has fewer staves — and then index 1 of a two-staff system and index 1 of a three-staff system are different voices spliced into one part. Where the counts disagreed, `_ensure_same_number_of_staffs` deleted an edge system, or failing that broke every group into singletons: twelve staves of a four-part page came out as one monophonic part of 70 bars.

The fork now reports what it saw — one part per staff per system, in reading order, with each printed system bracketed in the part list so the boundaries survive — and drops a grand-staff pairing that would leave the systems disagreeing, because a wrong pair welds two voices into one part and that renders as tidy music with nothing downstream able to see it. Which voice a system left out is deliberately not guessed: it is not in the pixels, and `clean_score`'s `--per-system` grid already answers it by asking a person. **homr reports, the app assembles.**

## Verification

The frozen seven-page benchmark (`~/omr-benchmark`), run through the fork branch:

| page | before | after |
| --- | --- | --- |
| B5 Lemmen nosto (4 staves × 3 systems) | 1 part, 70 bars | 4 parts, 23 bars each |
| B4 Kaksi laulua krapulasta (2-3-2-3-3) | 8 parts, pairs welded | 13 parts, every staff reported, systems bracketed `[2, 3, 2, 3, 2, 1]` |
| B1a, B1b, B2, B3, B6 (two staves) | — | MusicXML **byte-for-byte identical** to the frozen 0.7.0 outputs |

The two-staff guard is met at the strongest available level: identical bytes in, so `clean_score` cannot produce anything different. B4's remaining defect is one missed bracket connection inside the last printed system (reported as 2 + 1 rather than 3); every staff is present and in order, and the app's system boundaries come from a human-corrected `.systems.json` anyway.

Both new outputs convert cleanly through the MuseScore CLI: B4 → 13 parts, 6 brackets; B5 → 4 parts × 23 measures.

- `src/song_app/tests/test_install_homr.py`, `test_omr.py` — 23 passed (includes the real-homr acceptance page).
- In the fork: `tests/test_staff_parsing.py`, `tests/test_brace_dot_detection.py`, `tests/test_music_xml_part_list.py`, `tests/test_model.py` — 19 passed; `ruff check` clean; `mypy` reports nothing in the changed files.

The host's `homr-venv` is **not** reinstalled by this — it is host state the deploy deliberately never touches, and nothing calls `read_page` yet (#98). Run `scripts/install-homr.sh` to pick the new pin up.

[AgentDeck session](https://bazzite.taile8d16e.ts.net/chats/68d950b677bd4d03a0f41dea2e13586e)