### PR TITLE
Scan one printed system at a time

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,6 +38,7 @@ src/song_app/            Local web app tying the workflow together (see DESIGN.m
   health.py              Health check (malformed-tick / extra-voice scan; no mutation)
   pdf_systems.py         Crop the source PDF into one image per printed system
   omr.py                 Run homr on a page image -> MusicXML (its own venv; see below)
+  omr_systems.py         Scan one printed system at a time; flatten + assemble
   pipeline.py            Glue: convert + clean (clean_score) + lyric import (lyric_txt)
   server.py              FastAPI routes, WebSocket progress, file-watch re-check
   static/                Vanilla-JS SPA (library + 3-pane workspace, PDF viewer)
@@ -299,6 +300,23 @@ Key test modules:
   the real thing: a page of the scanned fixture rasterised at 300 dpi goes in and parseable
   MusicXML with parts, measures and notes comes out (~50s). It skips without homr or
   poppler, the same way the MuseScore-CLI and Playwright tests skip.
+- `src/song_app/tests/test_omr_systems.py` — added by this pull request. Two halves.
+  **Flattening** is tested with little documents in the shapes homr actually produced
+  on the benchmark — four one-staff "Voice" parts, two two-staff "Piano" parts, and a
+  mixture — so a fused grand staff still counts as two staves, the pair in the middle
+  stays in the middle, the name is never read, and a staff comes out with its own clef,
+  its own notes and its voices renumbered from 1. Two of them are about the backups:
+  they are dropped and rebuilt, so two voices sharing a staff still start together, and
+  a third voice winds back one voice rather than the running total. **Assembling** is
+  tested on the seams: continuous bar numbers, a break at each join and none at the
+  start, one `divisions` with the durations rescaled to it, a repeated key dropped and a
+  changed one kept, a meter change inside a crop left alone, a resting column given the
+  system's own bar length, and every part opening with something to read. The last test
+  is the acceptance minus homr and the only one needing MuseScore: systems of 2, 3 and 2
+  staves survive assembly, conversion and `per_system.system_layout` as those systems
+  with those staves. Nothing here runs homr — whether it can read music is homr's
+  business, and the card's own numbers came off the frozen benchmark, which is host
+  state.
 - `src/song_app/tests/test_clean_flow.py` — the song-app path: grid answers →
   `save_system_answers` → headless `run_clean` → rebuilt parts + lyric routing.
 - `src/song_app/tests/test_ui_flow.py` — the **SPA itself**, in a real browser: it
@@ -738,8 +756,55 @@ state model are in `DESIGN.md`.
   (nesting would deadlock a one-slot pool).
   Deliberately **not** here yet, because they belong to other cards on #92's map:
   nothing calls `read_page` (the stage machine and UI are #98), pages are not stitched
-  into one score (#97), the deploy and `/healthz` do not know homr exists, and whether
-  the unit of work is a page or a printed system is #103.
+  into one score (#97), and the deploy and `/healthz` do not know homr exists.
+- `omr_systems.py` is added by this pull request, and it settles what the unit of work
+  is: **one printed system, not one page.** Given a page, homr builds a part by taking
+  staff index N out of *every* system it found, which assumes the score is a rectangle
+  — the same staves, in the same order, in every system. Choral engraving is not a
+  rectangle: a part that rests through a system is simply not printed, so a page really
+  can be 2-3-2-3-3 staves. When the counts disagree homr deletes an edge system and,
+  failing that, breaks every group into singletons, which is how B5 — four vocal staves
+  — came out of a whole-page scan as one monophonic line of 70 bars. Given **one**
+  system there is nothing to reconcile and the assumption becomes vacuous rather than
+  wrong. That is why #105 was closed without a fork change: the defect does not occur
+  on this input.
+  Three calls, and the middle one is the idea. `read_systems` crops each band
+  (`pdf_systems.crop_systems`) and reads it with `omr.read_page`, **one heavy slot per
+  system** — the per-page lease taken one step further, which is if anything better:
+  shorter holds, so a render or a test suite waiting behind it waits less, and an
+  interruption costs the band in flight rather than the page. `flatten` reads a
+  system's MusicXML as an ordered list of **staves**, splitting a part on the `<staff>`
+  its notes carry, so a fused two-staff "Piano" contributes two exactly where a pair of
+  "Voice" parts would. **`part-name` is never read** — homr says "Voice" and "Piano"
+  and means neither, and since the notes of a fused part are fully separable,
+  grand-staff fusion is a labelling detail with no information loss. `assemble` writes
+  the systems out as one score, one part per staff column.
+  **Which voice is absent from a short system is not decided here**, because it is not
+  recoverable from pixels — you need the words, the range, or the piece. Columns are
+  filled from the top and the empty rows are measure rests; naming them is
+  `clean_score`'s `--per-system` grid's job, and that grid already asks a person.
+  Assembly closes the seams that exist only because each crop is its own document: one
+  `divisions` for the score with every duration rescaled to it, continuous bar numbers
+  instead of bar 1 five times over, a key or time signature written only where it says
+  something that was not already true, and a `<print new-system="yes"/>` at each join so
+  the grid cuts the score where the page is cut. **Only the seam is rewritten** — a
+  meter change *inside* a crop is a change the page prints (B4's last system goes 3/4,
+  5/4, 4/4) and correcting it away would be losing music to tidy a join.
+  Two things this cost. **Bounds become a precondition**: `.systems.json` exists for 5
+  of 48 songs and is made by a person dragging in the Systems viewer, or by an AI
+  reading `page_images(grid=True)`. Nothing here detects them — #80 measured that and
+  it failed badly — so `read_systems` refuses with no bounds and says where they come
+  from. And **the crop's resolution turned out to matter**: at 300 dpi, the dpi the
+  whole-page benchmark used, B4's first and fifth systems came back as one staff each
+  when the page plainly prints two and three; at 200 dpi every system of all seven
+  benchmark pages came back with the staves the page prints. `SCAN_DPI` is therefore a
+  measured default (env `OMR_SCAN_DPI`), worth re-measuring rather than nudging if a
+  page ever comes back short of staves.
+  Measured on the frozen benchmark at 200 dpi, ~10s a system: B5 comes out **4-4-4**
+  (against a 70-bar single-staff collapse), B4 comes out **2-3-2-3-3** with 18 bars
+  (against 26 bars on two staves), and the five two-staff pages — the majority of this
+  repertoire — come out of `clean_score` with **the same parts and the same bar counts**
+  as the whole-page route. Nothing calls it yet; the stage machine and UI are #98.
 - **Hazards guarded:** re-cleaning warns it discards manual edits (the Clean
   button label changes once a cleaned file exists); lyric import uses `--replace`.
   No automatic LLM (users have no API key) — the lyrics stage supports either a

--- a/src/song_app/omr_systems.py
+++ b/src/song_app/omr_systems.py
@@ -1,0 +1,599 @@
+"""Read a score one printed system at a time, and put the systems back together.
+
+The whole-page route asks homr a question it cannot answer. Given a page, homr
+assembles a part by taking staff index N out of *every* system it found, which
+assumes the score is a rectangle -- the same staves, in the same order, in every
+system. Choral engraving is not a rectangle: a part that rests through a system
+is simply not printed, so a page really can be 2-3-2-3-3 staves. When the counts
+disagree homr first deletes an edge system and then, failing that, breaks every
+group into singletons, which is how B5 -- four vocal staves -- came out of a
+whole-page scan as one monophonic line of 70 bars (issue #105).
+
+Given **one system**, there is nothing to reconcile. The assumption becomes
+vacuous rather than wrong. Measured on B5's three systems, cropped:
+
+    system 1   4 staves found, grouped [4]   -> 4 x "Voice"
+    system 2   4 staves found, grouped [2]   -> 2 x "Piano", two staves each
+    system 3   4 staves found, grouped [3]   -> "Voice", "Piano", "Voice"
+
+Four staves' worth of notes every time. The grouping moves around and the part
+names are fiction -- homr says "Voice" and "Piano" and means neither -- but the
+notes of a fused part carry ``<staff>1</staff>`` / ``<staff>2</staff>``, so
+nothing is lost. **Grand-staff fusion is a labelling detail.** Flatten every
+part into its staves and the grouping stops mattering, which is why this module
+ignores ``part-name`` entirely.
+
+So the division of labour is: **homr reports, the app assembles.** What homr is
+asked for is "the staves of this band, in order". What comes back out of here is
+one score, systems in order, one part per staff column.
+
+**Which voice is absent from a short system is not decided here**, because it is
+not recoverable from pixels -- you need the words, the range, or the piece. The
+columns are filled from the top and the empty rows are measure rests; naming
+them is ``clean_score``'s ``--per-system`` grid's job, and that grid already asks
+a person, which is the only reliable answer.
+
+**Bounds are a precondition.** This module is given the printed systems; it does
+not look for them. Detecting them from the image was measured and abandoned in
+issue #80 (staff-line detection died at half a degree of skew, and grouping by
+bracket agreed with the score twice in nine songs), so they come from
+``.systems.json`` -- an AI reading ``pdf_systems.page_images(grid=True)`` and a
+person correcting the bands in the Systems viewer.
+
+**Twenty seams instead of five.** Each crop is its own document: bar numbering
+restarts at 1, ``divisions`` is whatever that run chose, and key and time are
+re-declared. :func:`assemble` owns all of it -- one ``divisions`` for the whole
+score, continuous bar numbers, a re-declaration dropped when it says what was
+already true, and a system break written at each seam so the per-system grid
+sees the same systems the page has.
+"""
+
+from __future__ import annotations
+
+import copy
+import math
+import os
+from dataclasses import dataclass, field
+from typing import Callable, Dict, List, Optional, Sequence
+
+from lxml import etree
+
+from . import omr
+from .pdf_systems import SystemBounds, SystemImage, crop_systems
+
+Logger = Callable[[str], None]
+
+#: What a crop is rasterised at before homr sees it, and it is **not** the 300
+#: dpi the whole-page benchmark used.
+#:
+#: A crop is a much shorter image than the page it came from, and homr's staff
+#: detection turns out to care. Rasterised at 300 dpi, B4's first system -- two
+#: staves, plainly -- came back as one, and so did its fifth; at 200 dpi both
+#: come back with the staves the page prints, and so does every other system of
+#: all seven benchmark pages. Nothing else about the run changed. So this is a
+#: measured default rather than a preference, and it is worth re-measuring
+#: rather than nudging if a page ever comes back short of staves.
+SCAN_DPI = int(os.getenv("OMR_SCAN_DPI", "200"))
+
+#: The measure length assumed when a system declares no time signature at all.
+_FALLBACK_TIME = (4, 4)
+
+
+def _noop(_msg: str) -> None:
+    pass
+
+
+class ScanError(RuntimeError):
+    """A system could not be read, or the systems could not be assembled."""
+
+
+@dataclass
+class Staff:
+    """One staff of one printed system: its bars, already single-staff.
+
+    A "part" as homr emits it may hold two of these. What survives from it is
+    the notes and the barlines; the name does not, because it was never real.
+    """
+
+    measures: List[etree._Element]
+    divisions: int
+    clef: Optional[etree._Element] = None
+    key: Optional[etree._Element] = None
+    time: Optional[etree._Element] = None
+
+    @property
+    def bars(self) -> int:
+        return len(self.measures)
+
+
+@dataclass
+class SystemScan:
+    """What came back for one printed system."""
+
+    index: int                      # 1-based, the band's own index
+    musicxml: str
+    staves: List[Staff] = field(default_factory=list)
+
+    @property
+    def width(self) -> int:
+        return len(self.staves)
+
+    @property
+    def bars(self) -> int:
+        return max((s.bars for s in self.staves), default=0)
+
+
+# --- reading -------------------------------------------------------------
+
+
+def read_systems(
+    pdf_path: str,
+    bounds: Sequence[SystemBounds],
+    out_dir: str,
+    log: Logger = _noop,
+    dpi: int = SCAN_DPI,
+    queue: bool = True,
+) -> List[SystemScan]:
+    """Crop each printed system and read it, in order.
+
+    **One heavy slot per system, not one per song.** :mod:`omr` already made the
+    page the unit of the lease; a system is the same argument taken one step
+    further, and if anything better: the hold is ~20s rather than ~30s, so a
+    render or a test suite waiting behind it waits less, and an interruption
+    costs the band in flight rather than the page. The systems already read are
+    on disk. ``queue=False`` is for a caller that is holding a lease itself.
+
+    Nothing is retried and nothing is skipped: a band homr cannot read raises,
+    because a score silently missing one of its systems is worse than a scan
+    that stopped and said so.
+    """
+    if not bounds:
+        raise ScanError(
+            "No printed systems to read. Bounds come from .systems.json — set them "
+            "in the Systems viewer (or with pdf_systems.save_bounds) before scanning."
+        )
+
+    images = crop_systems(pdf_path, list(bounds), out_dir, dpi=dpi)
+    scans: List[SystemScan] = []
+    for n, image in enumerate(images, start=1):
+        log(f"System {image.index} of {len(images)}: reading")
+        scans.append(read_system(image, out_dir, log=log, queue=queue))
+        log(f"System {image.index}: {scans[-1].width} staves, {scans[-1].bars} bars")
+    return scans
+
+
+def read_system(
+    image: SystemImage,
+    out_dir: str,
+    log: Logger = _noop,
+    queue: bool = True,
+) -> SystemScan:
+    """Read one cropped system and flatten what comes back into staves."""
+    produced = omr.read_page(
+        image.path,
+        out_dir=out_dir,
+        log=log,
+        label=f"song app homr system {image.index}",
+        queue=queue,
+    )
+    staves = flatten(produced)
+    if not staves:
+        raise ScanError(f"System {image.index} came back with no staves ({produced}).")
+    return SystemScan(index=image.index, musicxml=produced, staves=staves)
+
+
+# --- flattening ----------------------------------------------------------
+
+
+def flatten(musicxml_path: str) -> List[Staff]:
+    """The staves of one system's MusicXML, in reading order.
+
+    Parts are walked in document order and each is split on the ``<staff>`` its
+    notes carry, so a two-staff "Piano" contributes two staves exactly where a
+    pair of "Voice" parts would have. The name is never read.
+    """
+    root = etree.parse(musicxml_path).getroot()
+    staves: List[Staff] = []
+    for part in root.findall("part"):
+        staves.extend(flatten_part(part))
+    return staves
+
+
+def flatten_part(part: etree._Element) -> List[Staff]:
+    """The staves one ``<part>`` holds, top to bottom.
+
+    A fused grand staff contributes two here exactly where a pair of separate
+    parts would contribute one each, which is what makes the grouping homr
+    chose stop mattering.
+    """
+    return [_extract_staff(part, number) for number in _staff_numbers(part)]
+
+
+def _staff_numbers(part: etree._Element) -> List[int]:
+    """Which staves this part actually holds.
+
+    ``<staves>`` is what the part *declares*; the ``<staff>`` on its notes is
+    what it *has*, and the two disagree often enough in an OMR parse that both
+    are consulted. An empty staff is still a staff: it is a line on the page and
+    the grid has to be able to point at it.
+    """
+    declared = 0
+    for attrs in part.iter("attributes"):
+        text = attrs.findtext("staves")
+        if text and text.strip().isdigit():
+            declared = max(declared, int(text.strip()))
+    used = {int(n.text.strip()) for n in part.iter("staff")
+            if n.text and n.text.strip().isdigit()}
+    return sorted(set(range(1, declared + 1)) | used) or [1]
+
+
+def _extract_staff(part: etree._Element, number: int) -> Staff:
+    """One staff of a part, rebuilt as a part of its own.
+
+    ``<backup>`` and ``<forward>`` are dropped rather than filtered: they exist
+    to move the cursor between staves *and* between voices, and telling those
+    two apart after the fact is guesswork. Instead each bar is rebuilt from its
+    notes -- grouped by voice, with a backup of the previous group's own length
+    written between groups -- which is well defined whatever the input did.
+    """
+    measures: List[etree._Element] = []
+    divisions = 0
+    clef = key = time = None
+
+    for source in part.findall("measure"):
+        measure = etree.Element("measure", number=source.get("number") or "")
+        notes: List[etree._Element] = []
+        trailing: List[etree._Element] = []
+        for child in source:
+            tag = child.tag
+            if tag == "attributes":
+                attrs = _staff_attributes(child, number)
+                divisions = divisions or _int(attrs.findtext("divisions"))
+                clef = clef if clef is not None else attrs.find("clef")
+                key = key if key is not None else attrs.find("key")
+                time = time if time is not None else attrs.find("time")
+                if len(attrs):
+                    measure.append(attrs)
+            elif tag == "note":
+                if _staff_of(child) == number:
+                    notes.append(copy.deepcopy(child))
+            elif tag in ("backup", "forward"):
+                continue
+            elif tag == "print":
+                continue
+            elif tag in ("direction", "harmony", "figured-bass"):
+                if _staff_of(child) == number:
+                    kept = copy.deepcopy(child)
+                    _drop(kept, "staff")
+                    measure.append(kept)
+            elif tag == "barline":
+                # A barline belongs after the music it closes, and the notes
+                # have not been written yet.
+                trailing.append(copy.deepcopy(child))
+            else:
+                measure.append(copy.deepcopy(child))
+
+        for element in _voiced(notes):
+            measure.append(element)
+        for element in trailing:
+            measure.append(element)
+        measures.append(measure)
+
+    return Staff(measures=measures, divisions=divisions or 1,
+                 clef=clef, key=key, time=time)
+
+
+def _voiced(notes: List[etree._Element]) -> List[etree._Element]:
+    """Notes regrouped voice by voice, with the backups that implies.
+
+    Voices are renumbered from 1, because a voice number is only meaningful
+    inside its part and this staff is about to become a part of its own -- a
+    staff whose notes said ``<voice>5</voice>`` would otherwise arrive claiming
+    to be the fifth voice of a part that has one.
+    """
+    groups: Dict[str, List[etree._Element]] = {}
+    for note in notes:
+        groups.setdefault((note.findtext("voice") or "1").strip(), []).append(note)
+
+    out: List[etree._Element] = []
+    spent = 0
+    for n, (_voice, group) in enumerate(groups.items(), start=1):
+        # Back up by the *previous* voice's own length, not by everything
+        # written so far: each voice starts again at the head of the bar, so a
+        # running total would wind the third voice back past the start of it.
+        if out and spent:
+            backup = etree.Element("backup")
+            etree.SubElement(backup, "duration").text = str(spent)
+            out.append(backup)
+        spent = 0
+        for note in group:
+            _set(note, "voice", str(n))
+            _drop(note, "staff")
+            spent += _duration(note)
+            out.append(note)
+    return out
+
+
+def _staff_attributes(attributes: etree._Element, number: int) -> etree._Element:
+    """The part of an ``<attributes>`` that belongs to one staff.
+
+    ``<staves>`` goes (there is one now), and anything numbered for another
+    staff goes with it. What survives loses its number, for the same reason the
+    voices are renumbered.
+    """
+    out = etree.Element("attributes")
+    for child in attributes:
+        if child.tag == "staves":
+            continue
+        which = child.get("number")
+        if which is not None and which.strip().isdigit() and int(which) != number:
+            continue
+        kept = copy.deepcopy(child)
+        if kept.get("number") is not None:
+            del kept.attrib["number"]
+        out.append(kept)
+    return out
+
+
+# --- assembling ----------------------------------------------------------
+
+
+def assemble(scans: Sequence[SystemScan], out_path: str) -> str:
+    """Write the systems out as one score, one part per staff column.
+
+    Columns are filled **from the top**: a system of two staves puts them in
+    columns 1 and 2 and leaves the rest resting. That is not a claim about which
+    voice is missing -- it is a refusal to make one. The per-system grid asks a
+    person, per system and per staff, and top-alignment is the shape it expects.
+
+    Three seams are closed here, all of them consequences of each crop being its
+    own document. ``divisions`` is unified across the score and every duration
+    scaled to it; bars are numbered continuously rather than restarting at 1 in
+    every system; and a key or time signature is written only where it says
+    something that was not already true. A ``<print new-system="yes"/>`` marks
+    each seam, so ``clean_score``'s per-system mode cuts the score where the page
+    is cut.
+    """
+    if not scans:
+        raise ScanError("Nothing to assemble: no systems were read.")
+
+    width = max(scan.width for scan in scans)
+    divisions = _common_divisions(scans)
+
+    score = etree.Element("score-partwise", version="4.0")
+    part_list = etree.SubElement(score, "part-list")
+    for column in range(width):
+        score_part = etree.SubElement(part_list, "score-part", id=f"P{column + 1}")
+        # The name is positional on purpose. Nothing downstream should read a
+        # voice out of it: which staff is which part is the grid's question.
+        etree.SubElement(score_part, "part-name").text = f"Staff {column + 1}"
+
+    for column in range(width):
+        part = etree.SubElement(score, "part", id=f"P{column + 1}")
+        _fill_column(part, scans, column, divisions)
+
+    tree = etree.ElementTree(score)
+    os.makedirs(os.path.dirname(os.path.abspath(out_path)), exist_ok=True)
+    tree.write(out_path, xml_declaration=True, encoding="UTF-8", pretty_print=True)
+    return out_path
+
+
+def _fill_column(
+    part: etree._Element,
+    scans: Sequence[SystemScan],
+    column: int,
+    divisions: int,
+) -> None:
+    number = 0
+    prevailing_key: Optional[str] = None
+    prevailing_time: Optional[str] = None
+    prevailing_clef: Optional[str] = None
+    first = True
+
+    for system, scan in enumerate(scans):
+        staff = scan.staves[column] if column < scan.width else None
+        beats = _measure_ticks(scan, divisions)
+
+        for bar in range(scan.bars):
+            number += 1
+            source = staff.measures[bar] if staff and bar < staff.bars else None
+            if source is None:
+                measure = _rest_measure(number, beats)
+            else:
+                measure = _scaled(source, staff.divisions, divisions)
+                measure.set("number", str(number))
+
+            if system and bar == 0:
+                measure.insert(0, etree.Element("print", {"new-system": "yes"}))
+
+            if bar == 0:
+                # Only the seam is rewritten. A bar in the middle of a crop is
+                # left with whatever it declares, because that is a change the
+                # page really prints -- B4's fifth system goes 3/4, 5/4, 4/4
+                # inside one system, and correcting those away would be losing
+                # music to tidy up a join.
+                wanted = _signature(scan, staff)
+                _merge_attributes(measure, _needed_attributes(
+                    first, divisions, wanted,
+                    (prevailing_key, prevailing_time, prevailing_clef),
+                ))
+                prevailing_key, prevailing_time, prevailing_clef = wanted
+            else:
+                _drop_global(measure)
+                declared = measure.find("attributes")
+                if declared is not None:
+                    prevailing_key = _canonical(declared.find("key")) or prevailing_key
+                    prevailing_time = _canonical(declared.find("time")) or prevailing_time
+                    prevailing_clef = _canonical(declared.find("clef")) or prevailing_clef
+            first = False
+            part.append(measure)
+
+
+def _signature(scan: SystemScan, staff: Optional[Staff]):
+    """What this column's bar should be declaring: its own, else the system's.
+
+    A resting column has no signature of its own, and inheriting the system's
+    is the only honest answer -- an empty staff is silent, not in another key.
+    """
+    donor = staff
+    if donor is None or (donor.key is None and donor.time is None and donor.clef is None):
+        donor = scan.staves[0] if scan.staves else None
+    key = _canonical(donor.key) if donor is not None else None
+    time = _canonical(donor.time) if donor is not None else None
+    clef = _canonical(staff.clef) if staff is not None and staff.clef is not None else None
+    return key, time, clef
+
+
+def _needed_attributes(first: bool, divisions: int, wanted, prevailing):
+    """An ``<attributes>`` holding only what has changed, or ``None``.
+
+    The first bar of a part always gets one -- ``divisions`` has to be declared
+    somewhere and a part with no clef is unreadable. After that a re-declaration
+    that repeats what is already in force is dropped, which is most of them:
+    every crop re-declares its key and time because every crop is a document
+    that has just begun.
+    """
+    key, time, clef = wanted
+    was_key, was_time, was_clef = prevailing
+    attrs = etree.Element("attributes")
+    if first:
+        etree.SubElement(attrs, "divisions").text = str(divisions)
+    if key is not None and (first or key != was_key):
+        attrs.append(etree.fromstring(key))
+    if time is not None and (first or time != was_time):
+        attrs.append(etree.fromstring(time))
+    if clef is not None and (first or clef != was_clef):
+        attrs.append(etree.fromstring(clef))
+    if first and attrs.find("clef") is None:
+        attrs.append(etree.fromstring("<clef><sign>G</sign><line>2</line></clef>"))
+    if first and attrs.find("key") is None:
+        attrs.append(etree.fromstring("<key><fifths>0</fifths></key>"))
+    if first and attrs.find("time") is None:
+        attrs.append(etree.fromstring(
+            f"<time><beats>{_FALLBACK_TIME[0]}</beats>"
+            f"<beat-type>{_FALLBACK_TIME[1]}</beat-type></time>"))
+    return attrs if len(attrs) else None
+
+
+def _merge_attributes(measure: etree._Element, attrs: Optional[etree._Element]) -> None:
+    """Replace the bar's opening declarations with the ones it should carry.
+
+    The crop's own are always taken out, whether or not anything replaces them:
+    they say "this document begins here", and it does not any more. Anything
+    else the bar declared -- a transposition, staff details -- is kept, because
+    nothing about the seam makes it untrue.
+    """
+    keep: List[etree._Element] = []
+    for existing in measure.findall("attributes"):
+        for child in existing:
+            if child.tag not in ("divisions", "key", "time", "clef", "staves"):
+                keep.append(copy.deepcopy(child))
+        measure.remove(existing)
+    if keep:
+        attrs = attrs if attrs is not None else etree.Element("attributes")
+        for child in keep:
+            attrs.append(child)
+    if attrs is None:
+        return
+    index = 1 if len(measure) and measure[0].tag == "print" else 0
+    measure.insert(index, attrs)
+
+
+def _drop_global(measure: etree._Element) -> None:
+    """Take ``divisions`` off a bar in the middle of a system.
+
+    There is one for the whole score now, declared in the first bar of the
+    part. Everything else the bar declares is a change the page prints.
+    """
+    for attributes in measure.findall("attributes"):
+        for child in list(attributes):
+            if child.tag in ("divisions", "staves"):
+                attributes.remove(child)
+        if not len(attributes):
+            measure.remove(attributes)
+
+
+def _rest_measure(number: int, ticks: int) -> etree._Element:
+    measure = etree.Element("measure", number=str(number))
+    note = etree.SubElement(measure, "note")
+    etree.SubElement(note, "rest", measure="yes")
+    etree.SubElement(note, "duration").text = str(ticks)
+    etree.SubElement(note, "voice").text = "1"
+    return measure
+
+
+def _measure_ticks(scan: SystemScan, divisions: int) -> int:
+    """How long a bar of this system is, for the columns that are resting."""
+    for staff in scan.staves:
+        canonical = _canonical(staff.time)
+        if canonical is None:
+            continue
+        parsed = etree.fromstring(canonical)
+        beats = _int(parsed.findtext("beats"))
+        beat_type = _int(parsed.findtext("beat-type"))
+        if beats and beat_type:
+            return max(1, round(divisions * 4 * beats / beat_type))
+    return divisions * 4
+
+
+def _common_divisions(scans: Sequence[SystemScan]) -> int:
+    divisions = 1
+    for scan in scans:
+        for staff in scan.staves:
+            divisions = _lcm(divisions, max(1, staff.divisions))
+    return divisions
+
+
+def _scaled(measure: etree._Element, was: int, now: int) -> etree._Element:
+    """A copy of a bar with every duration expressed in the score's divisions."""
+    out = copy.deepcopy(measure)
+    if was == now or was <= 0:
+        return out
+    factor = now / was
+    for node in out.iter("duration"):
+        value = _int(node.text)
+        node.text = str(max(1, round(value * factor)))
+    return out
+
+
+# --- small shared helpers ------------------------------------------------
+
+
+def _staff_of(element: etree._Element) -> int:
+    text = element.findtext("staff")
+    return int(text.strip()) if text and text.strip().isdigit() else 1
+
+
+def _duration(note: etree._Element) -> int:
+    if note.tag != "note" or note.find("chord") is not None or note.find("grace") is not None:
+        return 0
+    return _int(note.findtext("duration"))
+
+
+def _canonical(element: Optional[etree._Element]) -> Optional[str]:
+    if element is None:
+        return None
+    return etree.tostring(element, encoding="unicode").strip()
+
+
+def _int(text: Optional[str]) -> int:
+    try:
+        return int(float((text or "").strip()))
+    except ValueError:
+        return 0
+
+
+def _set(parent: etree._Element, tag: str, value: str) -> None:
+    node = parent.find(tag)
+    if node is None:
+        node = etree.SubElement(parent, tag)
+    node.text = value
+
+
+def _drop(parent: etree._Element, tag: str) -> None:
+    for node in parent.findall(tag):
+        parent.remove(node)
+
+
+def _lcm(a: int, b: int) -> int:
+    return abs(a * b) // math.gcd(a, b) if a and b else max(a, b, 1)

--- a/src/song_app/tests/test_omr_systems.py
+++ b/src/song_app/tests/test_omr_systems.py
@@ -1,0 +1,406 @@
+"""Reading a score one printed system at a time.
+
+Two halves, and they are tested differently. **Flattening** is about what homr
+emits: a part is not a part, it is one or two staves wearing a name that means
+nothing, and the tests here are little documents in the shapes homr actually
+produced on the benchmark -- four one-staff "Voice" parts, two two-staff
+"Piano" parts, and a mixture of the two. **Assembling** is about the seams that
+only exist because each crop is its own document: bar 1 five times over, a
+different ``divisions`` each time, and a key and time signature re-declared at
+every join.
+
+The last test is the one that matters and the only one that needs MuseScore: a
+score assembled from systems of two, three and two staves, converted and handed
+to ``clean_score``'s per-system machinery, has to come back as those systems
+with those staves. That is the whole point -- the app assembles, and the grid
+asks a person which staff is which part.
+
+No test here runs homr. Whether it can read music is homr's business, and the
+card's own acceptance ran on the frozen benchmark, which is host state.
+"""
+import os
+import subprocess
+
+import pytest
+from lxml import etree
+
+from src.clean_score.utils import per_system
+from src.song_app import omr, omr_systems
+from src.song_app.pdf_systems import SystemBounds, SystemImage
+
+
+# --- little documents in the shapes homr emits ---------------------------
+
+
+def a_note(step="C", octave="4", duration=4, voice="1", staff=None):
+    staff_tag = f"<staff>{staff}</staff>" if staff else ""
+    return (f"<note><pitch><step>{step}</step><octave>{octave}</octave></pitch>"
+            f"<duration>{duration}</duration><voice>{voice}</voice><type>quarter</type>"
+            f"{staff_tag}</note>")
+
+
+def a_part(part_id, name, staves, bars=2, divisions=4, fifths=0, time=(4, 4)):
+    """One ``<part>`` as homr writes it: ``staves`` staff rows inside it."""
+    clefs = "".join(f'<clef number="{n}"><sign>G</sign><line>2</line></clef>'
+                    for n in range(1, staves + 1))
+    attributes = (f"<attributes><divisions>{divisions}</divisions>"
+                  f"<key><fifths>{fifths}</fifths></key>"
+                  f"<time><beats>{time[0]}</beats><beat-type>{time[1]}</beat-type></time>"
+                  f"<staves>{staves}</staves>{clefs}</attributes>")
+    body = []
+    for bar in range(1, bars + 1):
+        content = attributes if bar == 1 else ""
+        for staff in range(1, staves + 1):
+            if staff > 1:
+                content += f"<backup><duration>{divisions * 4}</duration></backup>"
+            content += "".join(
+                a_note("CDEFG"[(staff + n) % 5], duration=divisions,
+                       staff=staff if staves > 1 else None, voice=str(staff))
+                for n in range(4))
+        body.append(f'<measure number="{bar}">{content}</measure>')
+    return (f'<score-part id="{part_id}"><part-name>{name}</part-name></score-part>',
+            f'<part id="{part_id}">{"".join(body)}</part>')
+
+
+def a_system(tmp_path, name, parts):
+    """A MusicXML file holding ``parts`` -- ``[(id, name, staff count), ...]``."""
+    declared, bodies = zip(*[a_part(*p) for p in parts])
+    path = tmp_path / f"{name}.musicxml"
+    path.write_text(
+        '<?xml version="1.0" encoding="UTF-8"?><score-partwise version="4.0">'
+        f'<part-list>{"".join(declared)}</part-list>{"".join(bodies)}'
+        "</score-partwise>")
+    return str(path)
+
+
+def scan(index, staves, bars=2, divisions=4, fifths=0, time=(4, 4)):
+    """A already-flattened system, for the assembly tests."""
+    made = []
+    for n in range(staves):
+        source = a_part(f"P{n + 1}", "Voice", 1, bars=bars, divisions=divisions,
+                        fifths=fifths, time=time)[1]
+        part = etree.fromstring(source)
+        made.extend(omr_systems.flatten_part(part))
+    return omr_systems.SystemScan(index=index, musicxml="", staves=made)
+
+
+# --- flattening ----------------------------------------------------------
+
+
+def test_four_one_staff_parts_are_four_staves(tmp_path):
+    path = a_system(tmp_path, "sys1", [(f"P{n}", "Voice", 1) for n in range(1, 5)])
+    assert len(omr_systems.flatten(path)) == 4
+
+
+def test_a_fused_grand_staff_is_still_two_staves(tmp_path):
+    """B5's second system: four staves reported as two "Piano" parts."""
+    path = a_system(tmp_path, "sys2", [("P1", "Piano", 2), ("P2", "Piano", 2)])
+    staves = omr_systems.flatten(path)
+    assert len(staves) == 4
+
+
+def test_a_mixture_flattens_in_reading_order(tmp_path):
+    """B5's third system: Voice, Piano (two staves), Voice.
+
+    The pair in the middle stays in the middle -- its two staves are the second
+    and third of the system, not two extra ones appended after the Voices. A
+    system is an ordered list of lines on a page, and the order is all the grid
+    has to point at them with.
+    """
+    def voice(part_id, octave):
+        return (f'<part id="{part_id}"><measure number="1">'
+                "<attributes><divisions>1</divisions></attributes>"
+                + a_note("C", octave, duration=1) + "</measure></part>")
+
+    piano = ('<part id="P2"><measure number="1">'
+             "<attributes><divisions>1</divisions><staves>2</staves></attributes>"
+             + a_note("C", "5", duration=1, staff=1)
+             + "<backup><duration>1</duration></backup>"
+             + a_note("C", "3", duration=1, staff=2) + "</measure></part>")
+
+    path = tmp_path / "sys3.musicxml"
+    path.write_text('<?xml version="1.0" encoding="UTF-8"?>'
+                    "<score-partwise><part-list/>"
+                    + voice("P1", "6") + piano + voice("P3", "2")
+                    + "</score-partwise>")
+    staves = omr_systems.flatten(str(path))
+    octaves = [s.measures[0].find("note/pitch/octave").text for s in staves]
+    assert octaves == ["6", "5", "3", "2"]
+
+
+def test_the_part_name_is_never_read(tmp_path):
+    """homr says "Voice" and "Piano" and means neither, so nothing may depend
+    on which word it chose."""
+    voices = a_system(tmp_path, "as-voices", [("P1", "Voice", 2)])
+    pianos = a_system(tmp_path, "as-pianos", [("P1", "Piano", 2)])
+    assert len(omr_systems.flatten(voices)) == len(omr_systems.flatten(pianos)) == 2
+
+
+def test_a_staff_keeps_only_its_own_notes_and_its_own_clef(tmp_path):
+    path = a_system(tmp_path, "pair", [("P1", "Piano", 2)])
+    upper, lower = omr_systems.flatten(path)
+    for staff in (upper, lower):
+        first = staff.measures[0]
+        assert first.findall("backup") == []
+        assert [n.findtext("staff") for n in first.findall("note")] == [None] * 4
+        assert first.find("attributes/staves") is None
+        assert first.find("attributes/clef").get("number") is None
+
+
+def test_voices_are_renumbered_from_one(tmp_path):
+    """A voice number means something only inside its part, and each staff is
+    about to become a part of its own."""
+    path = a_system(tmp_path, "pair", [("P1", "Piano", 2)])
+    lower = omr_systems.flatten(path)[1]
+    assert {n.findtext("voice") for n in lower.measures[0].findall("note")} == {"1"}
+
+
+def test_two_voices_on_one_staff_keep_their_backup():
+    """Dropping the backups is only safe because they are rebuilt: two voices
+    sharing a staff must still start at the same point in the bar."""
+    part = etree.fromstring(
+        '<part id="P1"><measure number="1">'
+        "<attributes><divisions>1</divisions></attributes>"
+        + a_note("C", duration=1, voice="1") + a_note("D", duration=1, voice="1")
+        + "<backup><duration>2</duration></backup>"
+        + a_note("E", duration=1, voice="2") + a_note("F", duration=1, voice="2")
+        + "</measure></part>")
+    staff = omr_systems.flatten_part(part)[0]
+    backups = staff.measures[0].findall("backup")
+    assert [b.findtext("duration") for b in backups] == ["2"]
+
+
+def test_three_voices_wind_back_only_one_voice_at_a_time():
+    """A running total would put the third voice before the start of the bar."""
+    notes = "".join(a_note("C", duration=1, voice=str(v)) for v in (1, 2, 3))
+    part = etree.fromstring(
+        '<part id="P1"><measure number="1">'
+        "<attributes><divisions>1</divisions></attributes>" + notes + "</measure></part>")
+    staff = omr_systems.flatten_part(part)[0]
+    assert [b.findtext("duration")
+            for b in staff.measures[0].findall("backup")] == ["1", "1"]
+
+
+# --- assembling ----------------------------------------------------------
+
+
+def read(path):
+    return etree.parse(path).getroot()
+
+
+def test_one_part_per_staff_column(tmp_path):
+    out = omr_systems.assemble([scan(1, 4), scan(2, 4)], str(tmp_path / "s.musicxml"))
+    assert len(read(out).findall("part")) == 4
+
+
+def test_the_widest_system_sets_the_part_count(tmp_path):
+    out = omr_systems.assemble([scan(1, 2), scan(2, 3), scan(3, 2)],
+                               str(tmp_path / "s.musicxml"))
+    assert len(read(out).findall("part")) == 3
+
+
+def test_a_column_a_system_does_not_have_is_measure_rests(tmp_path):
+    """Not a claim about which voice is absent -- a refusal to make one. The
+    per-system grid asks a person."""
+    out = omr_systems.assemble([scan(1, 2, bars=2), scan(2, 3, bars=2)],
+                               str(tmp_path / "s.musicxml"))
+    third = read(out).findall("part")[2]
+    first_system = third.findall("measure")[:2]
+    for measure in first_system:
+        assert measure.find("note/rest").get("measure") == "yes"
+
+
+def test_bars_are_numbered_across_the_whole_score(tmp_path):
+    """Every crop starts its own bar 1, and a score cannot."""
+    out = omr_systems.assemble([scan(1, 2, bars=3), scan(2, 2, bars=4)],
+                               str(tmp_path / "s.musicxml"))
+    numbers = [m.get("number") for m in read(out).findall("part")[0].findall("measure")]
+    assert numbers == ["1", "2", "3", "4", "5", "6", "7"]
+
+
+def test_each_seam_is_a_system_break(tmp_path):
+    out = omr_systems.assemble([scan(1, 2, bars=3), scan(2, 2, bars=4), scan(3, 2, bars=2)],
+                               str(tmp_path / "s.musicxml"))
+    for part in read(out).findall("part"):
+        broken = [m.get("number") for m in part.findall("measure")
+                  if m.find("print") is not None]
+        assert broken == ["4", "8"]
+
+
+def test_the_first_bar_is_not_a_break(tmp_path):
+    out = omr_systems.assemble([scan(1, 2)], str(tmp_path / "s.musicxml"))
+    assert read(out).find("part/measure/print") is None
+
+
+def test_one_divisions_for_the_whole_score(tmp_path):
+    """Each run picks its own, and a score has one."""
+    out = omr_systems.assemble([scan(1, 2, divisions=2), scan(2, 2, divisions=3)],
+                               str(tmp_path / "s.musicxml"))
+    root = read(out)
+    declared = {d.text for d in root.iter("divisions")}
+    assert declared == {"6"}
+
+
+def test_durations_are_rescaled_with_the_divisions(tmp_path):
+    """Renaming the unit without restating the lengths would halve the music."""
+    one = omr_systems.assemble([scan(1, 1, divisions=2)], str(tmp_path / "one.musicxml"))
+    both = omr_systems.assemble([scan(1, 1, divisions=2), scan(2, 1, divisions=4)],
+                                str(tmp_path / "both.musicxml"))
+    alone = [d.text for d in read(one).find("part/measure").iter("duration")]
+    joined = [d.text for d in read(both).find("part/measure").iter("duration")]
+    assert alone == ["2", "2", "2", "2"]
+    assert joined == ["4", "4", "4", "4"]
+
+
+def test_a_repeated_key_is_not_declared_again(tmp_path):
+    """Every crop re-declares its key, because every crop has just begun."""
+    out = omr_systems.assemble([scan(1, 2, fifths=2), scan(2, 2, fifths=2)],
+                               str(tmp_path / "s.musicxml"))
+    part = read(out).findall("part")[0]
+    assert len(part.findall("measure/attributes/key")) == 1
+
+
+def test_a_key_that_really_changed_is_kept(tmp_path):
+    out = omr_systems.assemble([scan(1, 2, fifths=2), scan(2, 2, fifths=-1)],
+                               str(tmp_path / "s.musicxml"))
+    part = read(out).findall("part")[0]
+    assert [k.findtext("fifths") for k in part.findall("measure/attributes/key")] == ["2", "-1"]
+
+
+def test_a_meter_change_inside_a_system_is_left_alone(tmp_path):
+    """Only the seam is rewritten. B4's last system goes 3/4, 5/4, 4/4 inside
+    one system, and correcting those away would be losing music to tidy a join.
+    """
+    part = etree.fromstring(
+        '<part id="P1">'
+        '<measure number="1"><attributes><divisions>1</divisions>'
+        "<time><beats>3</beats><beat-type>4</beat-type></time>"
+        "<clef><sign>G</sign><line>2</line></clef></attributes>"
+        + a_note("C", duration=1) + "</measure>"
+        '<measure number="2"><attributes><divisions>1</divisions>'
+        "<time><beats>5</beats><beat-type>4</beat-type></time></attributes>"
+        + a_note("D", duration=1) + "</measure></part>")
+    only = omr_systems.SystemScan(index=1, musicxml="",
+                                  staves=omr_systems.flatten_part(part))
+    out = omr_systems.assemble([only], str(tmp_path / "s.musicxml"))
+    bars = read(out).find("part").findall("measure")
+    assert bars[1].findtext("attributes/time/beats") == "5"
+    # ...but the one divisions the score has is not restated bar by bar.
+    assert bars[1].find("attributes/divisions") is None
+
+
+def test_a_resting_column_inherits_the_system_meter(tmp_path):
+    """Its bars have to be as long as everybody else's, or the rest overruns."""
+    out = omr_systems.assemble([scan(1, 3, bars=1, divisions=4, time=(3, 4)),
+                                scan(2, 2, bars=1, divisions=4, time=(3, 4))],
+                               str(tmp_path / "s.musicxml"))
+    third = read(out).findall("part")[2]
+    resting = third.findall("measure")[1]
+    assert resting.findtext("note/duration") == "12"      # 3/4 at 4 per quarter
+
+
+def test_every_part_gets_a_clef_and_a_key_to_start_with(tmp_path):
+    """A column that is silent in the first system still has to open somehow."""
+    out = omr_systems.assemble([scan(1, 1, bars=1), scan(2, 2, bars=1)],
+                               str(tmp_path / "s.musicxml"))
+    opening = read(out).findall("part")[1].find("measure/attributes")
+    assert opening.find("divisions") is not None
+    assert opening.find("clef") is not None
+    assert opening.find("key") is not None
+    assert opening.find("time") is not None
+
+
+def test_nothing_to_assemble_says_so(tmp_path):
+    with pytest.raises(omr_systems.ScanError):
+        omr_systems.assemble([], str(tmp_path / "s.musicxml"))
+
+
+# --- reading -------------------------------------------------------------
+
+
+def test_no_bounds_names_where_bounds_come_from(tmp_path):
+    """Bounds are a precondition, and the error has to say so: there is nothing
+    a caller can do about "no systems" without being told where they live."""
+    with pytest.raises(omr_systems.ScanError) as caught:
+        omr_systems.read_systems("score.pdf", [], str(tmp_path))
+    assert ".systems.json" in str(caught.value)
+
+
+def test_a_system_is_read_under_its_own_slot(tmp_path, monkeypatch):
+    """One lease per system, not one per song: a shorter hold lets a render or
+    a suite in between bands, and an interruption costs one band."""
+    asked = []
+
+    def fake_read_page(image_path, out_dir=None, log=None, label=None, queue=True, **kw):
+        asked.append((label, queue))
+        produced = os.path.join(out_dir, os.path.basename(image_path) + ".musicxml")
+        with open(produced, "w") as f:
+            f.write('<score-partwise><part-list><score-part id="P1"/></part-list>'
+                    '<part id="P1"><measure number="1"/></part></score-partwise>')
+        return produced
+
+    monkeypatch.setattr(omr_systems.omr, "read_page", fake_read_page)
+    monkeypatch.setattr(omr_systems, "crop_systems", lambda *a, **k: [
+        SystemImage(bounds=SystemBounds(index=n, page=1, top=0.0, bottom=0.5),
+                    path=str(tmp_path / f"band-{n}.png"))
+        for n in (1, 2, 3)])
+
+    scans = omr_systems.read_systems("score.pdf", [1, 2, 3], str(tmp_path))
+    assert len(scans) == 3
+    assert [q for _label, q in asked] == [True, True, True]
+    # The label has to name the band, or the queue shows three of the same job.
+    assert len({label for label, _ in asked}) == 3
+
+
+def test_a_caller_holding_a_lease_does_not_ask_for_another(tmp_path, monkeypatch):
+    """Nesting would deadlock a one-slot pool."""
+    asked = []
+
+    def fake_read_page(image_path, out_dir=None, log=None, label=None, queue=True, **kw):
+        asked.append(queue)
+        produced = os.path.join(out_dir, "one.musicxml")
+        with open(produced, "w") as f:
+            f.write('<score-partwise><part-list/><part id="P1">'
+                    '<measure number="1"/></part></score-partwise>')
+        return produced
+
+    monkeypatch.setattr(omr_systems.omr, "read_page", fake_read_page)
+    monkeypatch.setattr(omr_systems, "crop_systems", lambda *a, **k: [
+        SystemImage(bounds=SystemBounds(index=1, page=1, top=0.0, bottom=0.5),
+                    path=str(tmp_path / "band-1.png"))])
+
+    omr_systems.read_systems("score.pdf", [1], str(tmp_path), queue=False)
+    assert asked == [False]
+
+
+# --- what the whole thing is for -----------------------------------------
+
+
+def _musescore():
+    import dotenv
+    dotenv.load_dotenv(".env")
+    return os.getenv("MUSESCORE_CLI_PATH")
+
+
+@pytest.mark.skipif(not _musescore() or not os.path.exists(_musescore() or ""),
+                    reason="needs the MuseScore CLI")
+def test_the_per_system_grid_sees_the_systems_the_page_has(tmp_path):
+    """The acceptance, minus homr: systems of 2, 3 and 2 staves survive
+    assembly, conversion and ``clean_score``'s per-system reading.
+
+    This is the shape B4 comes out in (2-3-2-3-3) and the reason the whole
+    route exists: a page whose staves change role per system is not a
+    rectangle, and the grid is what asks a person which staff is which part.
+    """
+    assembled = omr_systems.assemble(
+        [scan(1, 2, bars=2), scan(2, 3, bars=2), scan(3, 2, bars=2)],
+        str(tmp_path / "assembled.musicxml"))
+    mscx = str(tmp_path / "assembled.mscx")
+    subprocess.run([_musescore(), "-o", mscx, assembled],
+                   check=True, capture_output=True, timeout=300)
+
+    root = etree.parse(mscx).getroot()
+    layout = per_system.system_layout(root)
+    assert [(s.start, s.end) for s in layout] == [(1, 2), (3, 4), (5, 6)]
+    assert [[row.staff_id for row in s.staves] for s in layout] == [
+        [1, 2], [1, 2, 3], [1, 2]]


### PR DESCRIPTION
Closes #103

## What this changes

`src/song_app/omr_systems.py` reads a score **one printed system at a time** instead of one page at a time.

Given a page, homr builds a part by taking staff index N out of *every* system it found — it assumes the score is a rectangle. Choral engraving is not one: a part that rests through a system is simply not printed, so a page really can be 2-3-2-3-3 staves. When the counts disagree homr deletes an edge system and then breaks every group into singletons, which is how B5's four vocal staves came out of a whole-page scan as one monophonic line of 70 bars. Given **one** system there is nothing to reconcile — which is why #105 closed without a fork change.

Three calls:

- `read_systems` crops each band (`pdf_systems.crop_systems`) and reads it with `omr.read_page`, **one heavy slot per system** — the per-page lease taken a step further, so a render or a suite waiting behind it waits ~10s rather than ~30s, and an interruption costs the band in flight.
- `flatten` reads a system's MusicXML as an ordered list of **staves**, splitting a part on the `<staff>` its notes carry. A fused two-staff "Piano" contributes two exactly where a pair of "Voice" parts would. `part-name` is never read.
- `assemble` writes the systems out as one score, one part per staff column, closing the seams that exist only because each crop is its own document: one `divisions` with durations rescaled, continuous bar numbers, a signature written only where it changed, and `<print new-system="yes"/>` at each join. Only the seam is rewritten — a meter change *inside* a crop is music the page prints.

Which voice is absent from a short system is **not** decided here. Columns fill from the top, the empty rows are measure rests, and `clean_score`'s `--per-system` grid asks a person.

Nothing calls it yet: the stage machine and UI are #98.

## Verification

Frozen benchmark, per-system at 200 dpi, ~10s a system:

| item | whole-page (baseline) | per-system | after `clean_score` |
| --- | --- | --- | --- |
| B5 | 1 staff, 70 bars | **4-4-4**, 23 bars | 4 parts x 23 bars (was 2 x 70) |
| B4 | 2 staves, 26 bars | **2-3-2-3-3**, 18 bars | 4 parts x 18 bars (was 4 x 26) |
| B1a / B1b / B2 / B3 / B6 | 2 staves | 2 staves in every system | **same parts, same bar counts** |

The two-staff guard passes: the majority of this repertoire is unchanged end to end.

Two costs, both real:

- **Bounds are a precondition.** Nothing here detects them (#80 measured that and it failed); `read_systems` refuses without them and names where they come from. The benchmark's bands were read off `page_images(grid=True)`.
- **The crop's resolution matters.** At 300 dpi — the dpi the whole-page benchmark used — B4's first and fifth systems came back as one staff each where the page prints two and three. At 200 dpi every system of all seven pages came back right. `SCAN_DPI` is a measured default, not a preference.

`.venv/bin/python -m pytest src/song_app/tests/test_omr_systems.py src/song_app/tests/test_omr.py -q` — 47 passed. CI runs the suite.

[AgentDeck session](https://bazzite.taile8d16e.ts.net/chats/7eb3c5c4f3d34cc4b24ab32d667ec97f)
