### PR TITLE
Drop the slurs homr never engraved

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -299,6 +299,15 @@ Key test modules:
   the real thing: a page of the scanned fixture rasterised at 300 dpi goes in and parseable
   MusicXML with parts, measures and notes comes out (~50s). It skips without homr or
   poppler, the same way the MuseScore-CLI and Playwright tests skip.
+  A second half is added for #113: the **slurs**, written as little token streams
+  (`"1( 1) 3( 5)"`) because that is the level the defect lives at. A slur inside a bar
+  and one across a single barline survive; two barlines is dropped and the slurs on
+  either side of it are not; a redundant start, an unmatched stop and a start that
+  never stops all go; B5's own m46 shape resolves in one pass and finds nothing on a
+  second; `read_page` applies it and says so in the log; and a parse with nothing to
+  change comes back byte for byte as homr wrote it. The last needs MuseScore and is the
+  defect where it is felt: twelve notes over three bars offer four lyric slots with the
+  runaway and twelve without it.
 - `src/song_app/tests/test_clean_flow.py` — the song-app path: grid answers →
   `save_system_answers` → headless `run_clean` → rebuilt parts + lyric routing.
 - `src/song_app/tests/test_ui_flow.py` — the **SPA itself**, in a real browser: it
@@ -736,6 +745,40 @@ state model are in `DESIGN.md`.
   pages already read are on disk. A caller that would rather hold one lease across a
   whole song passes `queue=False` and wraps the loop itself, so the two never nest
   (nesting would deadlock a one-slot pool).
+  **Every parse comes back with its slurs paired and the runaways dropped**
+  (`resolve_slurs`, proposed by this pull request for #113). homr predicts
+  `slurStart` / `slurStop` one note at a time and never pairs them, and the MusicXML
+  `number` that pairing depends on is the *staff* number — the same for every slur on
+  the staff. So a dropped stop does not merely lose its own slur: it leaves the start
+  open to be closed by whatever stop comes next. On B5's whole page that produces two
+  slurs nobody engraved, one of 5¼ bars and one of 3, covering 21 notes; a slur
+  continuation takes no syllable, so the page offers **91 lyric slots for 132 notes**.
+  Sixteen swallowed. The direction is the trap: it reads as `too_few`, which the
+  playbook below teaches a reader to attribute to a voice sharing another staff's
+  words. So `read_page` pairs the tokens the way MuseScore does and keeps only pairs at
+  most **one barline** apart (`MAX_SLUR_BARS`, env `OMR_MAX_SLUR_BARS`). That threshold
+  is measured, not assumed: across all seven benchmark parses every pair is nought or
+  one bar apart except those two runaways, the human-corrected `Lemmen nosto` has no
+  longer slur in the 68 bars of the page they come from, and one barline is what a
+  genuine melisma crosses (`il-man il-ki-rii-vi-`). It is a claim about *this input*,
+  not about engraving — real scores in `songs/` do print four-bar phrase marks, but
+  homr has no way to write one deliberately.
+  **This is the boundary and not the assembler**, which is where #113 first put it. The
+  `number` the mis-pairing turns on is the staff number, so nothing about the defect is
+  per-page or per-crop: a whole-page parse has it and so does one system cut out of the
+  same page. Normalising it here means every parse gets it however it was cropped, and
+  it does not go down with #103 if that card is thrown away.
+  **The unmatched tokens go as well, and that is the part that cost the most to find.**
+  #112 measured a lone dangler as cosmetic, and in isolation it is — MuseScore drops it.
+  In a stream it is not: an unmatched stop loses *every later slur of that number*, and
+  a redundant start is merely promoted when the runaway in front of it is removed, so it
+  closes on a stop further away still. Measured on B5: dropping the runaway pairs alone
+  left a fresh 2-bar runaway at m51, taking out the redundant starts alone took the page
+  from 21 slurs to 6, and doing all of it in one pass gives 24, none over a bar — five
+  of them short slurs homr got right that the noise had been costing it. What is written
+  back is one alternating stream, so the score and the pairing cannot drift apart, and
+  running it again finds nothing. A parse with nothing to change is left byte for byte
+  as homr wrote it.
   Deliberately **not** here yet, because they belong to other cards on #92's map:
   nothing calls `read_page` (the stage machine and UI are #98), pages are not stitched
   into one score (#97), the deploy and `/healthz` do not know homr exists, and whether
@@ -1451,9 +1494,21 @@ the numbers bent to fit is wrong. `place_lyrics` returns the same numbers as
 | | means |
 |---|---|
 | `too_many` | the **reading** is wrong — too many syllables for the notes |
-| `too_few`, by a lot | usually a voice **sharing** another staff's words (below) |
+| `too_few`, by a lot | a voice **sharing** another staff's words (below) — **or** a **runaway slur** swallowing the slots (next paragraph) |
 | `too_few`, by exactly one or two | usually a **dropped slur** — a melisma the OCR lost |
 | all `too_few`, never `too_many` | do **not** conclude "missing slurs" from this alone; that inference was made once and was mostly wrong |
+
+**Look at the slurs before you conclude "sharing".** The two readings of a large
+`too_few` want opposite responses — sharing is correct engraving and is written down
+in the lyric JSON, a runaway slur is a defect in the score and has to come out of it —
+and they are easy to confuse, because a runaway is invisible in the numbers and points
+straight at the wrong answer. What tells them apart: sharing shows up as a voice whose
+per-measure note counts match another voice's exactly, while a runaway shows up as
+**one bar losing most of its slots to a slur crossing several barlines**. Look for the
+long slur first, since that is a single check: `lyric_txt.syllable_slots(root, staff,
+measure)` says note by note which are being swallowed. This pull request proposes
+repairing it at the boundary for homr parses (`omr.resolve_slurs`), which would leave
+a score scanned before that, or one from another OMR tool, as the cases to watch for.
 
 **Voices sing words that are not printed under them.** Older choral engraving prints
 a text once and expects more than one voice to use it, so notes with no text beneath

--- a/src/song_app/omr.py
+++ b/src/song_app/omr.py
@@ -14,7 +14,7 @@ built by ``scripts/install-homr.sh`` outside the checkout, and is called as a
 subprocess. A page is ~30 seconds, so the cost of a process is not a number
 worth thinking about.
 
-Two things about the CLI that this module exists to absorb:
+Three things about homr that this module exists to absorb:
 
 * It takes one image, writes ``<image>.musicxml`` beside it, and has no
   ``--output``. It also drops a ``_teaser.png`` and, in debug mode, more. So
@@ -24,6 +24,14 @@ Two things about the CLI that this module exists to absorb:
   *registered* and not whether it can run. This host's card is below
   onnxruntime's floor (issue #93), so auto would pick CUDA and die on the
   first segnet node without falling back. Every call passes ``no``.
+* Its **slurs are not paired**. ``slurStart`` and ``slurStop`` are predicted one
+  note at a time, and the MusicXML ``number`` they would pair by is the staff
+  number, the same for every slur on the staff — so a dropped stop leaves its
+  start open to be closed by whatever stop comes next, and the slur that
+  results swallows the syllable slots of everything under it. Every parse this
+  module returns has been through :func:`resolve_slurs`, which is where that is
+  argued out. It is a property of the tool, not of a page or a crop, so it is
+  normalised once, here.
 
 **A scan takes one of this host's heavy slots**, the same way the video render
 does (:mod:`heavy_slot`, issue #100). A page is ~30s of every core on a
@@ -52,6 +60,8 @@ import threading
 from contextlib import contextmanager
 from typing import Callable, List, Optional
 
+from lxml import etree
+
 from . import heavy_slot
 
 Logger = Callable[[str], None]
@@ -65,6 +75,10 @@ DEFAULT_VENV = os.path.join(
 DEFAULT_TIMEOUT = 600
 
 IMAGE_EXTS = (".png", ".jpg", ".jpeg")
+
+#: How many barlines a slur may cross before it is read as a pairing accident
+#: rather than music. See :func:`resolve_slurs`.
+MAX_SLUR_BARS = int(os.getenv("OMR_MAX_SLUR_BARS", "1"))
 
 #: How much of homr's output an error carries. Its stderr is chatty and the
 #: line that explains the failure is at the end.
@@ -124,6 +138,8 @@ def read_page(
 
     ``label`` is what the queue shows for this page; ``queue=False`` runs
     without asking for a slot, for a caller already holding one.
+
+    The MusicXML that comes back has had its slurs resolved (:func:`resolve_slurs`).
     """
     if not os.path.exists(image_path):
         raise HomrError(f"No such image: {image_path}")
@@ -167,10 +183,122 @@ def read_page(
                 + _tail(output)
             )
 
+        resolve_slurs_in(produced, log=watched)
         os.makedirs(os.path.dirname(destination), exist_ok=True)
         shutil.move(produced, destination)
 
     return destination
+
+
+def resolve_slurs_in(musicxml_path: str, log: Logger = _noop) -> int:
+    """Resolve the slurs of every part in a MusicXML file, in place.
+
+    A parse with nothing to change is left untouched rather than rewritten, so
+    a page homr got right comes back exactly as homr wrote it.
+    """
+    tree = etree.parse(musicxml_path)
+    root = tree.getroot()
+    before = len(root.findall(".//slur"))
+    dropped = sum(resolve_slurs(part) for part in root.findall("part"))
+    if len(root.findall(".//slur")) != before:
+        tree.write(musicxml_path, xml_declaration=True, encoding="UTF-8")
+    if dropped:
+        log(f"Dropped {dropped} slur{'s' if dropped > 1 else ''} homr never engraved")
+    return dropped
+
+
+def resolve_slurs(part: etree._Element, max_bars: int = MAX_SLUR_BARS) -> int:
+    """Pair up homr's slur tokens, and drop the pairs that run away.
+
+    homr predicts ``slurStart`` / ``slurStop`` as **per-note tokens, one at a
+    time** (``music_xml_generator.build_slurs``), and there is no pairing pass
+    anywhere. The MusicXML ``number`` that pairing depends on is set to the
+    *staff* number, so it is identical for every slur on that staff. Two things
+    follow, and the second is the damaging one: homr cannot express two
+    overlapping slurs, and a dropped stop does not merely lose its own slur --
+    it leaves the start open to be closed by whatever stop comes next.
+
+    On B5's whole-page parse, 42 starts and 37 stops import as 21 slurs, two of
+    them runaway: one spanning 5 1/4 bars from m46, one spanning 3 bars from
+    m54. Between them they cover 21 notes, and a slur continuation takes no
+    syllable, so the page offers 91 lyric slots for 132 notes. **Sixteen
+    syllable slots swallowed by two slurs nobody engraved** -- and they surface
+    as ``too_few``, which the reading playbook teaches a reader to attribute to
+    a voice sharing another staff's words. The failure points at a wrong
+    diagnosis rather than at itself.
+
+    So: walk the tokens in order, pair them, and keep only the pairs whose ends
+    are at most ``max_bars`` barlines apart. Everything else goes -- the runaway
+    pairs, a start made while one is already open, and a stop with nothing open.
+    What is written back is one unambiguous alternating stream, which is the
+    point: it says what we mean and leaves the importer nothing to guess at.
+    Returns how many runaway pairs were dropped.
+
+    **This belongs here and not further downstream**, because the ``number``
+    the mis-pairing turns on is the staff number and nothing about it is
+    per-page or per-crop. A whole-page parse has it, and so does one system cut
+    out of the same page. It is a property of the tool, so it is normalised
+    once at the boundary where the app meets the tool -- next to the missing
+    ``--output``, the teaser litter and the MusicXML homr deletes when parsing
+    raises.
+
+    **The threshold was measured, not assumed.** Across all seven homr parses of
+    the benchmark, every pair spans nought or one bar apart from those two
+    runaways; on the very page they come from, the human-corrected ``Lemmen
+    nosto`` has no slur crossing more than one barline in its first 68 bars, and
+    the hand-verified fixture has none at all. One barline is what a genuine
+    melisma crosses (``il-man il-ki-rii-vi-`` is the worked example in the lyric
+    tests), so the rule leaves real music alone. It is not a claim about
+    engraving in general -- modern choral scores in ``songs/`` do print phrase
+    marks over four bars. It is a claim about *this input*, where a long slur
+    cannot be told from an accident because homr has no way to write one
+    deliberately.
+
+    **Taking the unmatched tokens out is not tidiness, and this is the part that
+    cost the most to find.** Issue #112 measured a lone dangler as cosmetic --
+    MuseScore drops it, silently -- and it is, in isolation. It is not cosmetic
+    in a stream. Put four quarter-note bars through the CLI with a stop that
+    closes nothing, and *every later slur of that number is lost too*; and
+    leaving the redundant starts in means that removing a runaway pair merely
+    promotes one, which closes on a stop further away still. Removing the
+    runaway pairs alone left B5 with a fresh 2-bar runaway at m51. Removing the
+    redundant starts alone dropped B5 from 21 slurs to 6. Doing all of it in one
+    pass gives 24 slurs, none of them spanning more than a bar -- exactly the
+    pairing computed here, so what the score says and what this function decided
+    cannot drift apart. Five of those 24 are short slurs homr got right and the
+    unmatched tokens were costing it.
+    """
+    doomed: List[etree._Element] = []
+    dropped = 0
+    open_slurs: dict = {}
+
+    for bar, measure in enumerate(part.findall("measure")):
+        for note in measure.findall("note"):
+            for slur in note.findall("notations/slur"):
+                number = slur.get("number", "1")
+                kind = slur.get("type")
+                if kind == "start":
+                    if number in open_slurs:
+                        # MuseScore keeps the first of two starts sharing a
+                        # number and discards this one; so do we, explicitly.
+                        doomed.append(slur)
+                    else:
+                        open_slurs[number] = (bar, slur)
+                elif kind == "stop":
+                    began = open_slurs.pop(number, None)
+                    if began is None:
+                        doomed.append(slur)
+                    elif bar - began[0] > max_bars:
+                        doomed.extend((began[1], slur))
+                        dropped += 1
+
+    doomed.extend(slur for _, slur in open_slurs.values())
+    for slur in doomed:
+        notations = slur.getparent()
+        notations.remove(slur)
+        if len(notations) == 0:
+            notations.getparent().remove(notations)
+    return dropped
 
 
 @contextmanager

--- a/src/song_app/tests/test_omr.py
+++ b/src/song_app/tests/test_omr.py
@@ -14,6 +14,7 @@ import contextlib
 import os
 import shutil
 import stat
+import subprocess
 import time
 
 import pytest
@@ -323,3 +324,189 @@ def test_a_scanned_page_comes_back_as_musicxml(tmp_path):
     assert root.findall(".//note"), "no notes in the MusicXML"
     # It took minutes; it had better have said something while it did.
     assert lines
+
+
+# --- slurs ---------------------------------------------------------------
+#
+# homr writes ``slurStart`` / ``slurStop`` one note at a time and never pairs
+# them, and the ``number`` they would pair by is the staff number, the same for
+# every slur on the staff. These read as little token streams for that reason:
+# ``"1( 1) 3( 5)"`` is a start and a stop in bar 1 and a slur from bar 3 to bar
+# 5, which is the level the defect lives at.
+
+
+def a_slurred_part(stream, bars=8, per_bar=4):
+    """A one-staff part whose slur tokens are ``"1( 2) ..."`` -- bar and end."""
+    wanted = {}
+    for token in stream.split():
+        wanted.setdefault(int(token[:-1]), []).append(
+            "start" if token[-1] == "(" else "stop")
+
+    measures = []
+    for bar in range(1, bars + 1):
+        attributes = ("<attributes><divisions>1</divisions>"
+                      "<key><fifths>0</fifths></key>"
+                      "<time><beats>4</beats><beat-type>4</beat-type></time>"
+                      "<clef><sign>G</sign><line>2</line></clef></attributes>"
+                      if bar == 1 else "")
+        notes = ""
+        for n in range(per_bar):
+            slurs = ""
+            here = wanted.get(bar, [])
+            # One token per note, in the order they were written.
+            if n < len(here):
+                slurs = f'<notations><slur type="{here[n]}" number="1"/></notations>'
+            notes += ("<note><pitch><step>C</step><octave>4</octave></pitch>"
+                      f"<duration>1</duration><type>quarter</type>{slurs}</note>")
+        measures.append(f'<measure number="{bar}">{attributes}{notes}</measure>')
+    return etree.fromstring(f'<part id="P1">{"".join(measures)}</part>')
+
+
+def slur_pairs(part):
+    """The pairs left in a part, as ``(start bar, stop bar)``, in order."""
+    seen, open_bars = [], []
+    for bar, measure in enumerate(part.findall("measure"), 1):
+        for slur in measure.findall("note/notations/slur"):
+            if slur.get("type") == "start":
+                open_bars.append(bar)
+            else:
+                seen.append((open_bars.pop(), bar))
+    assert not open_bars, "a start was left open"
+    return seen
+
+
+def test_a_slur_inside_one_bar_is_kept():
+    part = a_slurred_part("1( 1)")
+    assert omr.resolve_slurs(part) == 0
+    assert slur_pairs(part) == [(1, 1)]
+
+
+def test_a_melisma_across_one_barline_is_kept():
+    """``il-man il-ki-rii-vi-`` is the worked example in the lyric tests: a
+    word whose syllables span a barline is real music, and the rule must not
+    eat it. One barline is the most any slur in the benchmark crosses."""
+    part = a_slurred_part("1( 2)")
+    assert omr.resolve_slurs(part) == 0
+    assert slur_pairs(part) == [(1, 2)]
+
+
+def test_a_slur_across_two_barlines_is_dropped():
+    part = a_slurred_part("1( 3)")
+    assert omr.resolve_slurs(part) == 1
+    assert slur_pairs(part) == []
+
+
+def test_a_runaway_does_not_take_the_slurs_around_it_with_it():
+    part = a_slurred_part("1( 1) 2( 6) 7( 7)")
+    assert omr.resolve_slurs(part) == 1
+    assert slur_pairs(part) == [(1, 1), (7, 7)]
+
+
+def test_a_start_made_while_one_is_open_goes():
+    """MuseScore keeps the first and discards the second, so this changes
+    nothing about how the file reads -- and it is what stops a removed runaway
+    promoting the leftover start onto a stop further away still."""
+    part = a_slurred_part("1( 1( 2)")
+    assert omr.resolve_slurs(part) == 0
+    assert slur_pairs(part) == [(1, 2)]
+
+
+def test_a_stop_that_closes_nothing_goes():
+    """#112 measured a lone dangler as cosmetic, and in isolation it is. In a
+    stream it is not: four bars through the MuseScore CLI with one unmatched
+    stop lose every later slur of that number too."""
+    part = a_slurred_part("1) 2( 2)")
+    assert omr.resolve_slurs(part) == 0
+    assert slur_pairs(part) == [(2, 2)]
+
+
+def test_a_start_that_never_stops_goes():
+    part = a_slurred_part("1( 1) 3(")
+    assert omr.resolve_slurs(part) == 0
+    assert slur_pairs(part) == [(1, 1)]
+
+
+def test_the_b5_shape_leaves_one_alternating_stream():
+    """B5's own m46 region: five starts and one stop, then music that is fine.
+
+    Resolving it once has to settle it -- running again must find nothing, or
+    the fix is a cascade rather than a repair. Removing the runaway pairs alone
+    left the real B5 with a fresh 2-bar runaway at m51.
+    """
+    part = a_slurred_part("1( 1( 2( 3( 3) 4( 4) 5( 6) 7( 7)", bars=8)
+    assert omr.resolve_slurs(part) == 1
+    assert slur_pairs(part) == [(4, 4), (5, 6), (7, 7)]
+    assert omr.resolve_slurs(part) == 0
+
+
+def test_an_empty_notations_element_does_not_survive_its_slur():
+    part = a_slurred_part("1( 3)")
+    omr.resolve_slurs(part)
+    assert part.findall(".//notations") == []
+
+
+def _musescore():
+    import dotenv
+    dotenv.load_dotenv(".env")
+    return os.getenv("MUSESCORE_CLI_PATH")
+
+
+def test_a_page_comes_back_with_its_slurs_resolved(monkeypatch, tmp_path):
+    """The seam: what ``read_page`` hands back has been through the rule.
+
+    A whole page and one cropped system both come through here, which is the
+    reason it lives at this boundary rather than in the assembler -- the
+    ``number`` the mis-pairing turns on is the staff number, and nothing about
+    that is per-crop.
+    """
+    part = etree.tostring(a_slurred_part("1( 1) 2( 6) 7( 7)"), encoding="unicode")
+    score = ('<?xml version="1.0" encoding="UTF-8"?><score-partwise version="4.0">'
+             '<part-list><score-part id="P1"><part-name>V</part-name></score-part>'
+             f'</part-list>{part}</score-partwise>')
+    written = tmp_path / "homr-said.musicxml"
+    written.write_text(score)
+    monkeypatch.setenv("HOMR_BIN", stub_homr(
+        tmp_path, f'cp "{written}" "${{!#%.*}}.musicxml"\n'))
+
+    lines = []
+    produced = omr.read_page(a_page(tmp_path), out_dir=str(tmp_path / "out"),
+                             log=lines.append)
+
+    assert slur_pairs(etree.parse(produced).getroot().find("part")) == [(1, 1), (7, 7)]
+    assert any("slur" in line for line in lines), lines
+
+
+def test_a_page_homr_got_right_is_not_rewritten(monkeypatch, tmp_path):
+    monkeypatch.setenv("HOMR_BIN", stub_homr(
+        tmp_path, 'echo "<score-partwise/>" > "${!#%.*}.musicxml"\n'))
+    produced = omr.read_page(a_page(tmp_path), out_dir=str(tmp_path / "out"))
+    assert open(produced).read() == "<score-partwise/>\n"
+
+
+@pytest.mark.skipif(not _musescore() or not os.path.exists(_musescore() or ""),
+                    reason="needs the MuseScore CLI")
+def test_a_runaway_slur_swallows_syllable_slots_and_the_rule_gives_them_back(tmp_path):
+    """The defect and the repair, measured where they are felt.
+
+    A slur continuation takes no syllable, so a slur nobody engraved is a lyric
+    line that will not fit. This is B5's m46 in miniature: twelve notes over
+    three bars, a start in the first and an unrelated stop in the third.
+    """
+    from src.clean_score.lyric_txt import slot_counts
+
+    def slots(part, name):
+        path = tmp_path / f"{name}.musicxml"
+        path.write_text(
+            '<?xml version="1.0" encoding="UTF-8"?><score-partwise version="4.0">'
+            '<part-list><score-part id="P1"><part-name>V</part-name></score-part>'
+            f'</part-list>{etree.tostring(part, encoding="unicode")}</score-partwise>')
+        mscx = str(tmp_path / f"{name}.mscx")
+        subprocess.run([_musescore(), "-o", mscx, str(path)],
+                       check=True, capture_output=True, timeout=300)
+        counts = slot_counts(etree.parse(mscx).getroot())
+        return sum(sum(bars.values()) for bars in counts.values())
+
+    assert slots(a_slurred_part("1( 3)", bars=3), "runaway") == 4
+    resolved = a_slurred_part("1( 3)", bars=3)
+    assert omr.resolve_slurs(resolved) == 1
+    assert slots(resolved, "resolved") == 12


### PR DESCRIPTION
Closes #113

homr predicts `slurStart` / `slurStop` as per-note tokens, one at a time, and never pairs them — and the MusicXML `number` that pairing depends on is the *staff* number, identical for every slur on the staff. So a dropped stop does not merely lose its own slur: it leaves the start open to be closed by whatever stop comes next. On B5's whole page that builds two slurs nobody engraved, one of 5¼ bars from m46 and one of 3 bars from m54, covering 21 notes between them. A slur continuation takes no syllable, so the page offers **91 lyric slots for 132 notes** — sixteen swallowed, and they read as `too_few`, which the playbook teaches a reader to blame on a voice sharing another staff's words.

`read_page` now pairs the tokens the way MuseScore does and keeps only pairs at most **one barline** apart (`omr.resolve_slurs`, `MAX_SLUR_BARS`, env `OMR_MAX_SLUR_BARS`).

**At the homr boundary, not in the assembler.** The `number` the mis-pairing turns on is the staff number, so nothing about the defect is per-page or per-crop — the measured case was a whole-page scan. Normalising it in `omr.py` puts it beside the other homr quirks that module absorbs (the missing `--output`, the teaser litter, the MusicXML homr deletes when parsing raises), gives it to every parse however it was cropped, and keeps it from going down with #103 if that card is thrown away.

### The threshold is measured, not assumed

Across all seven homr parses of the frozen benchmark, every pair is nought or one bar apart *except* those two runaways (and one more on B4, `19( 24( 25( 25) 25)` — three lost stops). On the very page the runaways come from, the human-corrected `Lemmen nosto` has no slur crossing more than one barline in its first 68 bars, and the hand-verified fixture has none at all. One barline is what a genuine melisma crosses — `il-man il-ki-rii-vi-`, the worked example in the lyric tests — and that case has its own test.

It is a claim about *this input*, not about engraving. Real scores in `songs/` do print four-bar phrase marks (Ave Maria, 28 of 82 slurs over a bar). homr has no way to write one deliberately, so in its output a long slur cannot be told from an accident.

### The unmatched tokens go too — the part that cost the most to find

#112 measured a lone dangler as cosmetic, and in isolation it is: MuseScore drops it. In a stream it is not. Both of these were measured through the MuseScore CLI, not read off the source:

* an unmatched **stop** loses *every later slur of that number* — four bars with one stray stop came back with the second slur simply gone;
* a redundant **start** is merely promoted when the runaway in front of it is removed, and closes on a stop further away still.

Measured on the real B5 parse:

| what was removed | slurs MuseScore builds | longest |
| --- | ---: | --- |
| nothing (today) | 21 | 5¼ bars |
| the runaway pairs only | 19 | **2 bars — a fresh one at m51** |
| the redundant starts only | **6** | 1 bar |
| all of it, one pass (this change) | **24** | 1 bar |

Twenty-four, not nineteen, because five of them are short slurs homr got right that the unmatched tokens had been costing it. What is written back is one alternating stream, so the score and the pairing cannot drift apart, and running the pass again finds nothing. A parse with nothing to change is left byte for byte as homr wrote it.

Also in here: `CLAUDE.md`'s scanned-score playbook now gives `too_few` by a lot its second reading — a runaway slur, not only a voice sharing another staff's words — and says what tells the two apart.

### Verification

`.venv/bin/python -m pytest src/song_app/tests/test_omr.py -q` → **33 passed, none skipped** (homr, poppler and the MuseScore CLI are all present on this host, so the real-scan and slot-count tests ran). CI runs the rest.

[AgentDeck session](https://bazzite.taile8d16e.ts.net/chats/ee116700861b4568aad2b6d45efb9f0b)
