### PR TITLE
Run a homr branch from a local checkout instead of installing it

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -332,13 +332,15 @@ Key test modules:
   the real thing: a page of the scanned fixture rasterised at 300 dpi goes in and parseable
   MusicXML with parts, measures and notes comes out (~50s). It skips without homr or
   poppler, the same way the MuseScore-CLI and Playwright tests skip.
-  A third half pins the **engines**: one install is one engine, a branch venv is
-  offered beside it under the branch's own name rather than the mangled directory's,
-  a half-built venv with no `homr` in it is not offered at all, an unlabelled install
-  falls back to its source, and an engine that is not installed is refused rather than
-  quietly becoming the default. `test_install_homr.py` pins the other end — a branch
-  gets its own venv and does not overwrite the default, each venv says what is in it,
-  and an explicit `HOMR_SOURCE` still wins and is then the label.
+  A third half pins the **engines**: one install with no checkout beside it is one
+  engine; a working copy and each of its git worktrees are engines labelled with the
+  branch they have out now; a directory that is not a homr checkout is not one; there
+  are no checkout engines without an install to borrow dependencies from; an engine
+  that is not there is refused rather than quietly becoming the default; the weights
+  are linked rather than downloaded again and a real file is never replaced; and the
+  chosen engine's argv *and environment* are what read the page. `test_install_homr.py`
+  pins the other end — the one venv, what it says about itself, and an explicit
+  `HOMR_SOURCE` being its own label.
   A second half is added for #113: the **slurs**, written as little token streams
   (`"1( 1) 3( 5)"`) because that is the level the defect lives at. A slur inside a bar
   and one across a single barline survive; two barlines is dropped and the slurs on
@@ -865,22 +867,37 @@ state model are in `DESIGN.md`.
   never touches its venv — so the day the parse changes is a day somebody ran the
   script, and running it is when the frozen benchmark should be run again. Nothing in
   `omr.py` or in the rest of the installer moves with it.
-  **A branch of the fork can be installed beside the default one, and this pull
-  request proposes that too.** `HOMR_BRANCH=prototype/system-4
-  scripts/install-homr.sh` builds a second venv named after the branch and leaves the
-  first alone. Beside rather than over, because the only question a homr branch exists
-  to answer is whether it reads *this* repertoire better than what we already have,
-  and an install that replaced the thing it is being compared against cannot answer
-  it. A directory name cannot carry `prototype/system-4`, so each venv gets a
-  `homr-engine.txt` naming its source and its branch — that file is what the picker
-  reads its labels off, and undoing the name-mangling instead would be guessing. An
-  explicit `HOMR_SOURCE` still wins over both and is then the label, since a
-  hand-written source is not a branch.
-  `omr.engines()` lists what is installed — the default one (`homr_binary()`) first,
-  then the `homr-venv-*` siblings — and `engine_binary(key)` resolves a choice,
-  **refusing an engine that is not there** rather than falling back to the default: a
-  parse nobody can account for is worse than a refused request. `read_page(binary=...)`
-  is the whole of the rest, threaded through `omr_systems.read_system` and `scan.run`.
+  **A branch of the fork is not installed at all.** That install is the one homr
+  install there is; a branch is run from a **local working copy**, and this is the
+  shape that pull request settled on after trying a venv per branch. The only
+  question a homr branch exists to answer is whether it reads *this* repertoire
+  better than what we already have, and answering it means editing, re-reading a
+  page, editing again — a 660 MB reinstall between passes is not a loop anybody
+  uses. So the checkout at `HOMR_CHECKOUT` (default `~/homr`) **and every git
+  worktree beside it** are engines: the dependencies come from the installed venv
+  and the code comes from the working copy, put in front of it on `PYTHONPATH`
+  (`<venv>/bin/python -c "from homr.main import main; main()"` — the package has no
+  `__main__`, and the venv's own `bin/homr` would import the installed copy whatever
+  `PYTHONPATH` said). Switching a branch there changes what the next
+  scan runs, with nothing to rebuild and nothing to keep in step. The label is the
+  branch, **read live from git** rather than remembered, because that is the whole
+  point; the price is that such an engine is whatever is checked out at the moment it
+  runs, which is why the installed venv stays as the fixed thing to compare against
+  (`homr-engine.txt` still labels it, and an explicit `HOMR_SOURCE` is then its label,
+  since a hand-written source is not a branch).
+  One thing this costs and pays for: homr keeps its ~150 MB of weights **beside its
+  own source**, so a working copy run this way would download its own set — per
+  worktree, four times over here. `link_weights` symlinks the installed venv's
+  `.onnx` files into a checkout the first time it is picked. Safe because the file
+  names carry a content hash: a branch wanting different weights asks for a different
+  name and downloads it. Only missing files are linked and a real file is never
+  replaced.
+  `omr.engines()` lists what this host can run — the installed one first, then the
+  working copies — and `engine_for(key)` resolves a choice, **refusing an engine that
+  is not there** rather than falling back to the default: a parse nobody can account
+  for is worse than a refused request. `read_page(engine=...)` is the whole of the
+  rest (an `Engine` carries its argv and the environment it needs), threaded through
+  `omr_systems.read_system` and `scan.run`.
   The choice is **per scan run and is not recorded**. What a fragment has to carry is
   what came back, not what produced it, and comparing two engines is reading a system
   with one and then the other — the retry button that already exists — and looking at

--- a/SETUP.md
+++ b/SETUP.md
@@ -70,20 +70,27 @@ Set `HOMR_SOURCE` to a commit to get a particular parse back.
 Without homr, `src/song_app/omr.py` raises a message saying so and its tests
 skip; nothing else in the app is affected.
 
-A branch of the fork can be installed **beside** the default one, which is how a
-homr change is tried against real repertoire:
+A branch of the fork needs **no install at all**. Clone the fork somewhere (or
+add a git worktree to an existing clone) and the app will run it from source,
+borrowing the installed venv's dependencies:
 
 ```bash
-HOMR_BRANCH=prototype/system-4 scripts/install-homr.sh
+git clone https://github.com/eerovil/homr.git ~/homr
+git -C ~/homr worktree add ~/homr-trees/system-4 prototype/system-4
 ```
 
-That builds a second venv (`homr-venv-prototype-system-4`) and leaves the first
-alone — a branch that replaced what it is being compared against could not be
-judged. The Scan panel then offers a **Read with** picker of everything
-installed, and the choice applies to that scan run only; nothing is recorded, so
-comparing two engines means reading a system with one, then the other, and
-looking at both against the page. The picker is hidden when only one homr is
-installed.
+`HOMR_CHECKOUT` says where the working copy is (default `~/homr`); its git
+worktrees are found from it. The Scan panel then offers a **Read with** picker
+listing the installed venv plus each working copy, labelled with the branch it
+has out *at that moment* — switch a branch there and the next scan runs it, with
+nothing to reinstall. The choice applies to that scan run only; nothing is
+recorded, so comparing two engines means reading a system with one, then the
+other, and looking at both against the page. The picker is hidden when the
+installed venv is all there is.
+
+The first time a working copy is picked, the venv's model weights are symlinked
+into it — homr keeps its weights beside its own source, so otherwise every
+worktree would download its own 150 MB.
 
 Install the QML plugins separately by copying or symlinking `plugins/` into
 `~/Documents/MuseScore3/Plugins` — MuseScore loads them from there, not from this

--- a/scripts/install-homr.sh
+++ b/scripts/install-homr.sh
@@ -11,9 +11,13 @@
 # Idempotent: re-running upgrades homr in place and re-downloads only whatever
 # weights are missing.
 #
-#   scripts/install-homr.sh                             # the default engine
-#   HOMR_BRANCH=prototype/system-4 scripts/install-homr.sh   # beside it, a fork branch
+#   scripts/install-homr.sh                 # default location
 #   HOMR_VENV=/somewhere/else scripts/install-homr.sh
+#
+# This is the ONLY install. A branch of the fork is not installed at all: the
+# app runs a local working copy of it straight from source, borrowing this
+# venv's dependencies (see src/song_app/omr.py, "engines"). Editing a branch and
+# reading a page again is then a loop with no install in it.
 #
 # Afterwards, point the app at it if you used a non-default location:
 #   HOMR_BIN=/somewhere/else/bin/homr   in .env
@@ -38,28 +42,13 @@ set -euo pipefail
 # (issue #93: the GTX 970 is sm_52, below onnxruntime's sm_60 floor).
 HOMR_REPO="${HOMR_REPO:-https://github.com/eerovil/homr.git}"
 
-# A branch of the fork, installed BESIDE the default rather than over it. A
-# branch is where a homr change is tried out (prototype/system-4, say), and the
-# question it exists to answer is "does this read the page better than what we
-# have?" — which cannot be answered by an install that replaced the thing it is
-# being compared against. So a branch gets a venv of its own, named after it,
-# and the app offers both as engines to scan with (omr.engines). Unset means the
-# default engine, and the default engine is `main`.
-HOMR_BRANCH="${HOMR_BRANCH:-}"
-
 DEFAULT_VENV="$HOME/.local/share/musescore-choir-plugins/homr-venv"
-if [ -n "$HOMR_BRANCH" ]; then
-    # prototype/system-4 -> homr-venv-prototype-system-4. A directory name is
-    # not a branch name, so the app reads the branch back out of the marker
-    # file below rather than trying to undo this.
-    DEFAULT_VENV="$DEFAULT_VENV-${HOMR_BRANCH//[^A-Za-z0-9]/-}"
-fi
 
-# A branch is a label a person recognises; a hand-written HOMR_SOURCE is not one,
+# `main` is a label a person recognises; a hand-written HOMR_SOURCE is not one,
 # so an install made from an explicit source is labelled by that source instead.
 if [ -z "${HOMR_SOURCE:-}" ]; then
-    HOMR_SOURCE="homr[cpu] @ git+$HOMR_REPO@${HOMR_BRANCH:-main}"
-    HOMR_LABEL="${HOMR_BRANCH:-main}"
+    HOMR_SOURCE="homr[cpu] @ git+$HOMR_REPO@main"
+    HOMR_LABEL="main"
 else
     HOMR_LABEL=""
 fi
@@ -83,10 +72,9 @@ uv venv --allow-existing --python "$HOMR_PYTHON" "$HOMR_VENV"
 echo "Installing $HOMR_SOURCE"
 VIRTUAL_ENV="$HOMR_VENV" uv pip install "$HOMR_SOURCE"
 
-# What this venv is, in a file, because a directory name cannot say it. The app
-# lists the installed engines and has to label them with something a person
-# recognises — the branch, not `homr-venv-prototype-system-4`. Written after the
-# install, so a venv that failed to build is not labelled as a working engine.
+# What this venv is, in a file: the app labels the default engine with it, and a
+# host reinstalled a month later can say what it got. Written after the install,
+# so a venv that failed to build is not labelled as a working engine.
 echo "source=$HOMR_SOURCE" > "$HOMR_VENV/homr-engine.txt"
 if [ -n "$HOMR_LABEL" ]; then
     echo "branch=$HOMR_LABEL" >> "$HOMR_VENV/homr-engine.txt"
@@ -104,6 +92,6 @@ if [ "$HOMR_VENV" != "$DEFAULT_VENV" ]; then
     # put elsewhere still has to be pointed at by hand.
     echo "Non-default location — add to .env:"
     echo "  HOMR_BIN=$HOMR_VENV/bin/homr"
-elif [ -n "$HOMR_BRANCH" ]; then
-    echo "Offered in the Scan panel as: $HOMR_BRANCH"
 fi
+echo "A branch of the fork needs no install: check it out under \$HOMR_CHECKOUT"
+echo "(default ~/homr, git worktrees included) and pick it in the Scan panel."

--- a/src/song_app/omr.py
+++ b/src/song_app/omr.py
@@ -51,6 +51,7 @@ nest.
 
 from __future__ import annotations
 
+import glob
 import os
 import shutil
 import signal
@@ -58,8 +59,8 @@ import subprocess
 import tempfile
 import threading
 from contextlib import contextmanager
-from dataclasses import dataclass
-from typing import Callable, List, Optional
+from dataclasses import dataclass, field
+from typing import Callable, Dict, List, Optional
 
 from lxml import etree
 
@@ -119,12 +120,26 @@ def homr_available(binary: Optional[str] = None) -> bool:
 
 # --- engines -------------------------------------------------------------
 #
-# There can be more than one homr installed, because a homr change is tried out
-# on a branch and the only question worth asking about it is whether it reads
-# *this* repertoire better than what we have. That cannot be answered by an
-# install that replaced what it is being compared against, so
-# ``scripts/install-homr.sh HOMR_BRANCH=...`` puts a branch in a venv of its own
-# beside the default one, and the Scan panel offers the lot.
+# A homr change is tried out on a branch, and the only question worth asking
+# about one is whether it reads *this* repertoire better than what we have. That
+# needs both to be runnable at once, and it needs the branch to be runnable
+# **without an install**: a branch is edited, re-read, edited again, and a
+# 660 MB reinstall between each pass is not a loop anybody uses.
+#
+# So a branch is not installed at all. The local fork checkout and every git
+# worktree beside it are engines in their own right: the dependencies come from
+# the installed venv, and the *code* comes from the working copy, put in front of
+# it on ``PYTHONPATH``. Switching a branch in that checkout changes what the next
+# scan runs, with nothing to rebuild and nothing to keep in step.
+#
+# The entry point is spelled out rather than run as ``-m homr``: homr's package
+# has no ``__main__``, its console script is ``homr.main:main``, and the venv's
+# own ``bin/homr`` would import the *installed* copy however PYTHONPATH is set.
+#
+# What that costs is one thing worth naming: an engine is now whatever is
+# checked out at the moment it runs, so the label is read live from git and a
+# parse is only accounted for by what the checkout says at the time. The
+# installed venv stays as it was — an immutable-ish default to compare against.
 #
 # The choice is per scan run and is not recorded anywhere: which homr read a
 # system is not something the app reasons about, and a fragment already carries
@@ -135,20 +150,30 @@ def homr_available(binary: Optional[str] = None) -> bool:
 
 @dataclass(frozen=True)
 class Engine:
-    """One installed homr: what to call it, what to show, what to run."""
+    """One homr this host can run: what to call it, what to show, what to run.
+
+    ``command`` is the argv the image path is appended to, and ``env`` is what
+    has to be added to the environment for it — ``PYTHONPATH`` for a checkout,
+    nothing at all for the installed venv.
+    """
 
     key: str
     label: str
-    binary: str
+    command: List[str]
+    env: Dict[str, str] = field(default_factory=dict)
     default: bool = False
 
 
-#: Written by the installer into each venv it builds. A directory name cannot
-#: say which branch is in it, and undoing the name-mangling would be guessing.
+#: Written by the installer into the venv it builds, saying what is in it.
 ENGINE_MARKER = "homr-engine.txt"
 
 #: The key standing for "whatever homr the app would use anyway".
 DEFAULT_ENGINE = "default"
+
+#: The local fork's working copy. Its git worktrees are found from it, so this
+#: is one path rather than a list, and the app never writes to any of them
+#: except to link the model weights it would otherwise re-download per worktree.
+CHECKOUT = os.getenv("HOMR_CHECKOUT", os.path.join(os.path.expanduser("~"), "homr"))
 
 
 def _marker(venv: str) -> dict:
@@ -165,52 +190,148 @@ def _label(venv: str, fallback: str) -> str:
     return fields.get("branch") or fields.get("source") or fallback
 
 
-def engines() -> List[Engine]:
-    """Every homr this host has, the default one first.
-
-    The default is whatever :func:`homr_binary` resolves to; the rest are the
-    ``homr-venv-*`` siblings the installer makes for a branch. A venv put
-    somewhere else with ``HOMR_VENV`` is not found — it is reached with
-    ``HOMR_BIN``, and then it *is* the default.
-    """
-    found: List[Engine] = []
+def default_engine() -> Optional[Engine]:
+    """The installed homr, or ``None`` when this host has not got one."""
     binary = homr_binary()
-    if homr_available(binary):
-        venv = os.path.dirname(os.path.dirname(binary))
-        found.append(Engine(key=DEFAULT_ENGINE,
-                            label=_label(venv, "main"), binary=binary, default=True))
+    if not homr_available(binary):
+        return None
+    venv = os.path.dirname(os.path.dirname(binary))
+    return Engine(key=DEFAULT_ENGINE, label=_label(venv, "main"),
+                  command=[binary], default=True)
 
-    parent, base = os.path.split(DEFAULT_VENV)
+
+def _venv_python() -> Optional[str]:
+    """The interpreter beside the installed homr — where the dependencies are."""
+    binary = homr_binary()
+    if not homr_available(binary) or os.path.sep not in binary:
+        return None
+    python = os.path.join(os.path.dirname(binary), "python")
+    return python if os.access(python, os.X_OK) else None
+
+
+def _worktrees(checkout: str) -> List[tuple]:
+    """``(path, label)`` for the checkout and each of its git worktrees.
+
+    The label is the branch, read now rather than remembered, because that is
+    the whole point: switching a branch in a working copy changes the engine
+    without anything being reinstalled or re-registered.
+    """
     try:
-        siblings = sorted(os.listdir(parent))
-    except OSError:
-        siblings = []
-    for name in siblings:
-        if not name.startswith(base + "-"):
-            continue
-        venv = os.path.join(parent, name)
-        candidate = os.path.join(venv, "bin", "homr")
-        if not homr_available(candidate) or candidate == binary:
-            continue
-        key = name[len(base) + 1:]
-        found.append(Engine(key=key, label=_label(venv, key), binary=candidate))
+        out = subprocess.run(
+            ["git", "-C", checkout, "worktree", "list", "--porcelain"],
+            capture_output=True, text=True, timeout=10)
+    except (OSError, subprocess.SubprocessError):
+        return []
+    if out.returncode != 0:
+        return []
+    found, path, label = [], None, None
+    for line in out.stdout.splitlines() + [""]:
+        if line.startswith("worktree "):
+            path, label = line[len("worktree "):], None
+        elif line.startswith("branch "):
+            label = line[len("branch refs/heads/"):]
+        elif line.startswith("detached"):
+            label = "detached"
+        elif not line and path:
+            found.append((path, label or "detached"))
+            path = None
     return found
 
 
-def engine_binary(key: Optional[str]) -> str:
-    """The executable for an engine key, or the default one for ``None``.
+#: What the checkout engines run. ``homr`` is a package with no ``__main__``, so
+#: its console script's entry point is called directly.
+RUN_HOMR = "from homr.main import main; main()"
+
+
+def _package_dir(root: str) -> str:
+    return os.path.join(root, "homr")
+
+
+def link_weights(checkout: str) -> int:
+    """Point a checkout at the installed venv's model weights.
+
+    homr keeps its ~150 MB of weights *beside its own source*, so a working copy
+    run from ``PYTHONPATH`` would download its own set — per worktree. The file
+    names carry a content hash, so a symlink cannot be the wrong weights: a
+    branch wanting different ones asks for a different name and downloads it.
+    Only missing files are linked and nothing real is ever replaced.
+    """
+    binary = homr_binary()
+    if os.path.sep not in binary:
+        return 0
+    venv = os.path.dirname(os.path.dirname(binary))
+    installed = None
+    for lib in sorted(glob.glob(os.path.join(venv, "lib", "python3.*", "site-packages"))):
+        if os.path.isdir(os.path.join(lib, "homr")):
+            installed = os.path.join(lib, "homr")
+    if not installed or not os.path.isdir(_package_dir(checkout)):
+        return 0
+    linked = 0
+    for source in glob.glob(os.path.join(installed, "**", "*.onnx"), recursive=True):
+        target = os.path.join(_package_dir(checkout),
+                              os.path.relpath(source, installed))
+        if os.path.exists(target):
+            continue
+        try:
+            os.makedirs(os.path.dirname(target), exist_ok=True)
+            os.symlink(source, target)
+            linked += 1
+        except OSError:
+            pass
+    return linked
+
+
+def engines() -> List[Engine]:
+    """Every homr this host can run, the installed one first.
+
+    The rest are the local fork's checkout and its git worktrees (``HOMR_CHECKOUT``),
+    each labelled with the branch it has out at this moment. They need the
+    installed venv for their dependencies, so without it there are none.
+    """
+    found: List[Engine] = []
+    default = default_engine()
+    if default:
+        found.append(default)
+
+    python = _venv_python()
+    if not python:
+        return found
+    used = {DEFAULT_ENGINE}
+    for path, label in _worktrees(CHECKOUT):
+        if not os.path.isdir(_package_dir(path)):
+            continue                       # not a homr working copy after all
+        key = os.path.basename(os.path.normpath(path))
+        while key in used:
+            key += "-"
+        used.add(key)
+        found.append(Engine(key=key, label=label,
+                            command=[python, "-c", RUN_HOMR],
+                            env={"PYTHONPATH": path}))
+    return found
+
+
+def engine_for(key: Optional[str]) -> Engine:
+    """The engine a key names, or the default one for ``None``.
 
     An unknown key is refused rather than falling back: a scan run with a homr
     other than the one that was asked for is a parse nobody can account for.
     """
     if not key or key == DEFAULT_ENGINE:
-        return homr_binary()
+        engine = default_engine()
+        if not engine:
+            raise HomrMissing(
+                f"homr is not installed ({homr_binary()}). Run "
+                "scripts/install-homr.sh, or set HOMR_BIN if it lives elsewhere.")
+        return engine
     for engine in engines():
         if engine.key == key:
-            return engine.binary
+            if engine.env.get("PYTHONPATH"):
+                link_weights(engine.env["PYTHONPATH"])
+            return engine
     raise HomrMissing(
-        f"No homr engine called {key!r} is installed. Install it with "
-        f"HOMR_BRANCH=... scripts/install-homr.sh, or scan with the default one.")
+        f"No homr engine called {key!r} is available. Engines are the installed "
+        f"venv and the working copies under {CHECKOUT}; check it is checked out "
+        "there, or scan with the default one.")
 
 
 def read_page(
@@ -220,7 +341,7 @@ def read_page(
     timeout: int = DEFAULT_TIMEOUT,
     label: Optional[str] = None,
     queue: bool = True,
-    binary: Optional[str] = None,
+    engine: Optional[Engine] = None,
 ) -> str:
     """Read one page image and return the path of the MusicXML written for it.
 
@@ -235,8 +356,9 @@ def read_page(
     there rather than at the end.
 
     ``label`` is what the queue shows for this page; ``queue=False`` runs
-    without asking for a slot, for a caller already holding one. ``binary``
-    reads the page with a homr other than the default one (:func:`engines`).
+    without asking for a slot, for a caller already holding one. ``engine``
+    reads the page with a homr other than the installed one (:func:`engines`) —
+    a working copy of the fork, run from its own source.
 
     The MusicXML that comes back has had its slurs resolved (:func:`resolve_slurs`).
     """
@@ -248,10 +370,10 @@ def read_page(
             f"{image_path}"
         )
 
-    binary = binary or homr_binary()
-    if not homr_available(binary):
+    engine = engine or default_engine()
+    if not engine:
         raise HomrMissing(
-            f"homr is not installed ({binary}). Run scripts/install-homr.sh, "
+            f"homr is not installed ({homr_binary()}). Run scripts/install-homr.sh, "
             "or set HOMR_BIN if it lives somewhere else."
         )
 
@@ -271,7 +393,8 @@ def read_page(
             # that is where the lease is checked (heavy_slot.Slot.guard).
             watched = slot.guard(log)
             watched(f"Reading {os.path.basename(image_path)} with homr")
-            output = _run([binary, "--gpu", "no", scratch_image], watched, timeout)
+            output = _run(list(engine.command) + ["--gpu", "no", scratch_image],
+                          watched, timeout, engine.env)
             slot.check()
 
         if not os.path.exists(produced):
@@ -410,7 +533,8 @@ def _queued(label: str, log: Logger, queue: bool):
         yield slot
 
 
-def _run(command: List[str], log: Logger, timeout: int) -> List[str]:
+def _run(command: List[str], log: Logger, timeout: int,
+         extra_env: Optional[Dict[str, str]] = None) -> List[str]:
     """Run homr, streaming its output to ``log``, and return the lines.
 
     The deadline is a timer that kills the process, not ``wait(timeout=...)``:
@@ -426,6 +550,7 @@ def _run(command: List[str], log: Logger, timeout: int) -> List[str]:
             bufsize=1,
             # Its own process group, so a deadline can take any child with it.
             start_new_session=True,
+            env={**os.environ, **(extra_env or {})},
         )
     except OSError as exc:
         raise HomrMissing(f"Could not run {command[0]}: {exc}") from exc

--- a/src/song_app/omr_systems.py
+++ b/src/song_app/omr_systems.py
@@ -133,7 +133,7 @@ def read_systems(
     log: Logger = _noop,
     dpi: int = SCAN_DPI,
     queue: bool = True,
-    binary: Optional[str] = None,
+    engine: Optional[omr.Engine] = None,
 ) -> List[SystemScan]:
     """Crop each printed system and read it, in order.
 
@@ -158,7 +158,7 @@ def read_systems(
     scans: List[SystemScan] = []
     for n, image in enumerate(images, start=1):
         log(f"System {image.index} of {len(images)}: reading")
-        scans.append(read_system(image, out_dir, log=log, queue=queue, binary=binary))
+        scans.append(read_system(image, out_dir, log=log, queue=queue, engine=engine))
         log(f"System {image.index}: {scans[-1].width} staves, {scans[-1].bars} bars")
     return scans
 
@@ -168,12 +168,12 @@ def read_system(
     out_dir: str,
     log: Logger = _noop,
     queue: bool = True,
-    binary: Optional[str] = None,
+    engine: Optional[omr.Engine] = None,
 ) -> SystemScan:
     """Read one cropped system and flatten what comes back into staves.
 
-    ``binary`` picks which installed homr reads it (:func:`omr.engines`); the
-    default one otherwise.
+    ``engine`` picks which homr reads it (:func:`omr.engines`); the installed
+    one otherwise.
     """
     produced = omr.read_page(
         image.path,
@@ -181,7 +181,7 @@ def read_system(
         log=log,
         label=f"song app homr system {image.index}",
         queue=queue,
-        binary=binary,
+        engine=engine,
     )
     staves = flatten(produced)
     if not staves:

--- a/src/song_app/scan.py
+++ b/src/song_app/scan.py
@@ -421,7 +421,7 @@ def run(
     only: Optional[Sequence[int]] = None,
     pad: float = PAD,
     dpi: int = omr_systems.SCAN_DPI,
-    binary: Optional[str] = None,
+    engine: Optional[omr.Engine] = None,
 ) -> Dict:
     """Read every printed system that is not already read, and assemble.
 
@@ -431,8 +431,8 @@ def run(
     the re-read actually came back different, which is the only case in which
     anything derived from it was wrong.
 
-    ``binary`` reads with a homr other than the default one (:func:`omr.engines`)
-    — a branch being tried against this repertoire. It is not recorded: what a
+    ``engine`` reads with a homr other than the installed one (:func:`omr.engines`)
+    — a working copy of the fork being tried against this repertoire. It is not recorded: what a
     fragment has to carry is what came back, not what produced it, and the
     comparison people actually make is re-reading one system with the other
     engine and looking at both.
@@ -470,7 +470,7 @@ def run(
                 and not current.get("error"):
             log(f"System {band.index}: already read.")
             continue
-        _read_one(song, pdf, band, stamp, out_dir, pad, dpi, len(bands), log, binary)
+        _read_one(song, pdf, band, stamp, out_dir, pad, dpi, len(bands), log, engine)
         song.save()
 
     # Everything downstream of a fragment that just changed goes here, through
@@ -482,7 +482,7 @@ def run(
 
 def _read_one(song: state.Song, pdf: str, band: SystemBounds, stamp: str,
               out_dir: str, pad: float, dpi: int, total: int, log: Logger,
-              binary: Optional[str] = None) -> None:
+              engine: Optional[omr.Engine] = None) -> None:
     """Read one band, and record either its fragment or its hole.
 
     A lost lease is a hole like any other: each band takes its own slot, so band
@@ -496,7 +496,7 @@ def _read_one(song: state.Song, pdf: str, band: SystemBounds, stamp: str,
     try:
         log(f"System {band.index} of {total}: cropping")
         image = pdf_systems.crop_systems(pdf, [padded(band, pad)], out_dir, dpi=dpi)[0]
-        produced = omr_systems.read_system(image, out_dir, log=log, binary=binary)
+        produced = omr_systems.read_system(image, out_dir, log=log, engine=engine)
         entry.update(
             musicxml=os.path.relpath(produced.musicxml, song.dir),
             content=content_stamp(produced.musicxml),

--- a/src/song_app/server.py
+++ b/src/song_app/server.py
@@ -395,7 +395,7 @@ def _run_scan(slug: str, opts: Dict) -> None:
         # five minutes, so its lines go straight to the song's log the way a
         # clean's and a render's do, unparsed.
         result = scan.run(song, log=log, only=opts.get("systems"),
-                          binary=opts.get("binary"))
+                          engine=opts.get("engine"))
         holes = result["holes"]
         log(f"Read {result['read']} of {result['systems']} system(s)."
             + (f" Still to read: {', '.join(str(i) for i in holes)}." if holes
@@ -435,7 +435,7 @@ async def api_scan(slug: str, body: Dict = None) -> Dict:
     # that is not installed has to be a refused request, not a scan that starts,
     # takes a lock and then fails on the first band.
     try:
-        opts["binary"] = omr.engine_binary(opts.get("engine"))
+        opts["engine"] = omr.engine_for(opts.get("engine"))
     except omr.HomrMissing as exc:
         raise HTTPException(400, str(exc)) from None
     if is_scanning(song) or not job_state.start_if_idle(

--- a/src/song_app/server.py
+++ b/src/song_app/server.py
@@ -431,13 +431,18 @@ async def api_scan(slug: str, body: Dict = None) -> Dict:
         opts["systems"] = [int(i) for i in (opts.get("systems") or [])]
     except (TypeError, ValueError):
         raise HTTPException(400, "systems must be whole numbers") from None
-    # Which homr reads it, resolved here rather than in the worker: an engine
-    # that is not installed has to be a refused request, not a scan that starts,
-    # takes a lock and then fails on the first band.
-    try:
-        opts["engine"] = omr.engine_for(opts.get("engine"))
-    except omr.HomrMissing as exc:
-        raise HTTPException(400, str(exc)) from None
+    # A *named* engine is resolved here rather than in the worker: one that is not
+    # there has to be a refused request, not a scan that starts, takes a lock and
+    # then fails on the first band. Asking for no engine in particular is left
+    # alone — `omr` picks the installed one when the read happens, and a host with
+    # no homr at all should fail where it always did, saying so in the song's log.
+    key = opts.get("engine")
+    opts["engine"] = None
+    if key and key != omr.DEFAULT_ENGINE:
+        try:
+            opts["engine"] = omr.engine_for(key)
+        except omr.HomrMissing as exc:
+            raise HTTPException(400, str(exc)) from None
     if is_scanning(song) or not job_state.start_if_idle(
             song.dir, "scan", ("scan", "clean", "render", "upload"),
             pdf_systems.file_version(song.source_path("pdf"))):

--- a/src/song_app/tests/test_install_homr.py
+++ b/src/song_app/tests/test_install_homr.py
@@ -1,9 +1,8 @@
-"""The homr installer: where homr comes from, and where a branch of it goes.
+"""The homr installer: one venv, and what it says about itself.
 
-A branch is installed *beside* the default rather than over it, because the only
-question a homr branch exists to answer is whether it reads this repertoire
-better than what we already have — and an install that replaced the thing it is
-being compared against cannot answer it.
+A branch of the fork is deliberately NOT installed — the app runs a local working
+copy from source against this venv's dependencies (see test_omr.py). So all this
+has to get right is where homr comes from and how the one install is labelled.
 """
 
 from __future__ import annotations
@@ -51,7 +50,7 @@ def install(tmp_path: Path):
                 "HOMR_LOG": str(homr_log),
             }
         )
-        for key in ("HOMR_SOURCE", "HOMR_BRANCH", "HOMR_VENV"):
+        for key in ("HOMR_SOURCE", "HOMR_VENV"):
             env.pop(key, None)
         for key, value in overrides.items():
             if value is not None:
@@ -76,41 +75,19 @@ def test_installer_resolves_source(install, tmp_path: Path,
     assert homr_log == ["--init"]
 
 
-def test_a_branch_installs_beside_the_default_one(install) -> None:
-    """A branch gets a venv of its own, so both engines stay installed."""
-    uv_log, _ = install(HOMR_BRANCH="prototype/system-4")
-
-    base = install.home / ".local/share/musescore-choir-plugins"
-    venv = base / "homr-venv-prototype-system-4"
-    assert venv.is_dir()
-    assert not (base / "homr-venv").exists()
-    assert ("pip install homr[cpu] @ git+https://github.com/eerovil/homr.git"
-            "@prototype/system-4") in uv_log
-
-
-def test_each_venv_says_what_is_in_it(install) -> None:
-    """The directory name cannot carry the branch, so a marker file does.
-
-    That file is what the app's engine picker reads its labels off.
-    """
-    install(HOMR_BRANCH="prototype/system-4")
+def test_the_venv_says_what_is_in_it(install) -> None:
+    """The app labels the default engine off this file."""
     install()
 
     base = install.home / ".local/share/musescore-choir-plugins"
-    branch = (base / "homr-venv-prototype-system-4" / "homr-engine.txt").read_text()
-    assert "branch=prototype/system-4" in branch.splitlines()
-
     default = (base / "homr-venv" / "homr-engine.txt").read_text().splitlines()
     assert default == [f"source={DEFAULT_SOURCE}", "branch=main"]
 
 
-def test_an_explicit_source_still_wins_over_a_branch(install) -> None:
-    """A commit is how an old parse is got back, whatever else is set."""
-    uv_log, _ = install(HOMR_BRANCH="prototype/system-4", HOMR_SOURCE="homr==9.9.9")
+def test_an_explicit_source_is_its_own_label(install) -> None:
+    """A commit is how an old parse is got back, and "main" would then be a lie."""
+    uv_log, _ = install(HOMR_SOURCE="homr==9.9.9")
 
     assert "pip install homr==9.9.9" in uv_log
-    venv = install.home / ".local/share/musescore-choir-plugins/homr-venv-prototype-system-4"
-    assert venv.is_dir()
-    # Labelled by what it was installed from: "prototype/system-4" would be a lie
-    # about a venv holding whatever homr==9.9.9 is.
+    venv = install.home / ".local/share/musescore-choir-plugins/homr-venv"
     assert (venv / "homr-engine.txt").read_text().splitlines() == ["source=homr==9.9.9"]

--- a/src/song_app/tests/test_omr.py
+++ b/src/song_app/tests/test_omr.py
@@ -83,72 +83,101 @@ def test_not_installed_is_its_own_error(monkeypatch, tmp_path):
 
 # --- which homr ----------------------------------------------------------
 #
-# A homr branch is installed beside the default one rather than over it, so the
-# app has to be able to list what is installed and run a named one.
+# A homr change is tried out on a branch, and the branch is never installed: the
+# app runs a local working copy from source against the installed venv's
+# dependencies. So what these pin is the discovery, the labels, and that the
+# working copy is what actually runs.
 
 
 def a_venv(path, branch=None, source="homr[cpu] @ git+.../homr.git@main"):
     """A venv shaped the way scripts/install-homr.sh leaves one."""
     (path / "bin").mkdir(parents=True)
-    homr = path / "bin" / "homr"
-    homr.write_text("#!/usr/bin/env bash\n")
-    homr.chmod(homr.stat().st_mode | stat.S_IEXEC)
+    for name in ("homr", "python"):
+        exe = path / "bin" / name
+        exe.write_text("#!/usr/bin/env bash\n")
+        exe.chmod(exe.stat().st_mode | stat.S_IEXEC)
     lines = [f"source={source}"] + ([f"branch={branch}"] if branch else [])
     (path / "homr-engine.txt").write_text("\n".join(lines) + "\n")
-    return str(homr)
+    return str(path / "bin" / "homr")
 
 
-def test_one_install_is_one_engine(monkeypatch, tmp_path):
+def a_checkout(path, branch="main", worktrees=()):
+    """A homr working copy, with git worktrees beside it if asked for."""
+    import subprocess as sp
+    path.mkdir(parents=True)
+    (path / "homr").mkdir()
+    (path / "homr" / "__init__.py").write_text("")
+    run = lambda *a: sp.run(a, cwd=str(path), check=True, capture_output=True)
+    run("git", "init", "-q", "-b", branch)
+    run("git", "config", "user.email", "t@example.com")
+    run("git", "config", "user.name", "T")
+    run("git", "add", "-A")
+    run("git", "commit", "-qm", "homr")
+    for name, tree_branch in worktrees:
+        run("git", "worktree", "add", "-q", "-b", tree_branch, str(path.parent / name))
+    return str(path)
+
+
+def test_one_install_and_no_checkout_is_one_engine(monkeypatch, tmp_path):
     monkeypatch.delenv("HOMR_BIN", raising=False)
     binary = a_venv(tmp_path / "homr-venv", branch="main")
     monkeypatch.setattr(omr, "DEFAULT_VENV", str(tmp_path / "homr-venv"))
+    monkeypatch.setattr(omr, "CHECKOUT", str(tmp_path / "no-such-checkout"))
 
     engines = omr.engines()
-    assert [(e.key, e.label, e.binary, e.default) for e in engines] == [
-        ("default", "main", binary, True)]
+    assert [(e.key, e.label, e.command, e.default) for e in engines] == [
+        ("default", "main", [binary], True)]
 
 
-def test_a_branch_venv_is_offered_beside_the_default(monkeypatch, tmp_path):
-    """The label is the branch, not the mangled directory name."""
+def test_a_working_copy_and_its_worktrees_are_engines(monkeypatch, tmp_path):
+    """No install: the code comes from the checkout, the dependencies from the venv."""
     monkeypatch.delenv("HOMR_BIN", raising=False)
     a_venv(tmp_path / "homr-venv", branch="main")
-    branch = a_venv(tmp_path / "homr-venv-prototype-system-4", branch="prototype/system-4")
     monkeypatch.setattr(omr, "DEFAULT_VENV", str(tmp_path / "homr-venv"))
+    checkout = a_checkout(tmp_path / "homr", branch="main",
+                          worktrees=[("system-4", "prototype/system-4")])
+    monkeypatch.setattr(omr, "CHECKOUT", checkout)
 
     engines = omr.engines()
-    assert [e.label for e in engines] == ["main", "prototype/system-4"]
-    assert [e.default for e in engines] == [True, False]
-    assert engines[1].key == "prototype-system-4"
-    assert omr.engine_binary("prototype-system-4") == branch
+
+    assert [e.key for e in engines] == ["default", "homr", "system-4"]
+    # The label is the branch each working copy has out *now* -- switching a
+    # branch there changes the engine with nothing to reinstall.
+    assert [e.label for e in engines] == ["main", "main", "prototype/system-4"]
+    tree = engines[2]
+    assert tree.command[1:] == ["-c", omr.RUN_HOMR]
+    assert tree.command[0].endswith("/bin/python"), "the venv's interpreter"
+    assert tree.env == {"PYTHONPATH": str(tmp_path / "system-4")}
 
 
-def test_a_venv_with_no_homr_in_it_is_not_an_engine(monkeypatch, tmp_path):
-    """A half-built venv must not be offered as something to scan with."""
+def test_a_directory_that_is_not_a_homr_checkout_is_not_an_engine(monkeypatch, tmp_path):
     monkeypatch.delenv("HOMR_BIN", raising=False)
     a_venv(tmp_path / "homr-venv", branch="main")
-    (tmp_path / "homr-venv-broken" / "bin").mkdir(parents=True)
     monkeypatch.setattr(omr, "DEFAULT_VENV", str(tmp_path / "homr-venv"))
+    checkout = a_checkout(tmp_path / "homr")
+    import shutil as sh
+    sh.rmtree(os.path.join(checkout, "homr"))
+    monkeypatch.setattr(omr, "CHECKOUT", checkout)
 
     assert [e.key for e in omr.engines()] == ["default"]
 
 
-def test_an_unlabelled_engine_falls_back_to_its_source(monkeypatch, tmp_path):
-    monkeypatch.delenv("HOMR_BIN", raising=False)
-    a_venv(tmp_path / "homr-venv", branch="main")
-    a_venv(tmp_path / "homr-venv-pinned", source="homr==9.9.9")
-    monkeypatch.setattr(omr, "DEFAULT_VENV", str(tmp_path / "homr-venv"))
+def test_without_an_install_there_are_no_checkout_engines(monkeypatch, tmp_path):
+    """The working copies borrow the venv's dependencies; there is nothing to borrow."""
+    monkeypatch.setenv("HOMR_BIN", str(tmp_path / "no-such-homr"))
+    monkeypatch.setattr(omr, "CHECKOUT", a_checkout(tmp_path / "homr"))
 
-    assert [e.label for e in omr.engines()][1] == "homr==9.9.9"
+    assert omr.engines() == []
 
 
-def test_no_key_means_the_default_engine(monkeypatch, tmp_path):
+def test_no_key_means_the_installed_engine(monkeypatch, tmp_path):
     binary = a_venv(tmp_path / "homr-venv", branch="main")
     monkeypatch.setenv("HOMR_BIN", binary)
-    assert omr.engine_binary(None) == binary
-    assert omr.engine_binary("default") == binary
+    assert omr.engine_for(None).command == [binary]
+    assert omr.engine_for("default").command == [binary]
 
 
-def test_an_engine_that_is_not_installed_is_refused(monkeypatch, tmp_path):
+def test_an_engine_that_is_not_there_is_refused(monkeypatch, tmp_path):
     """Not silently the default: a parse nobody can account for is worse.
 
     The whole point of picking an engine is to know which homr read the page.
@@ -156,22 +185,52 @@ def test_an_engine_that_is_not_installed_is_refused(monkeypatch, tmp_path):
     monkeypatch.delenv("HOMR_BIN", raising=False)
     a_venv(tmp_path / "homr-venv", branch="main")
     monkeypatch.setattr(omr, "DEFAULT_VENV", str(tmp_path / "homr-venv"))
+    monkeypatch.setattr(omr, "CHECKOUT", str(tmp_path / "nothing-here"))
 
     with pytest.raises(omr.HomrMissing) as caught:
-        omr.engine_binary("prototype-system-4")
-    assert "prototype-system-4" in str(caught.value)
+        omr.engine_for("system-4")
+    assert "system-4" in str(caught.value)
 
 
-def test_a_named_binary_is_what_reads_the_page(monkeypatch, tmp_path):
-    """The picked engine runs, and the default one is not consulted."""
+def test_the_weights_are_linked_rather_than_downloaded_again(monkeypatch, tmp_path):
+    """homr keeps its weights beside its own source, so a working copy would
+    fetch its own 150 MB -- per worktree. The names carry a content hash, so a
+    link cannot be the wrong weights."""
+    monkeypatch.delenv("HOMR_BIN", raising=False)
+    venv = tmp_path / "homr-venv"
+    a_venv(venv, branch="main")
+    package = venv / "lib" / "python3.12" / "site-packages" / "homr" / "segmentation"
+    package.mkdir(parents=True)
+    (package / "segnet_308-abc.onnx").write_bytes(b"weights")
+    monkeypatch.setattr(omr, "DEFAULT_VENV", str(venv))
+    checkout = a_checkout(tmp_path / "homr")
+    monkeypatch.setattr(omr, "CHECKOUT", checkout)
+
+    engine = omr.engine_for("homr")
+
+    linked = os.path.join(checkout, "homr", "segmentation", "segnet_308-abc.onnx")
+    assert os.path.islink(linked) and open(linked, "rb").read() == b"weights"
+    assert engine.env["PYTHONPATH"] == checkout
+    # Idempotent, and a real file is never replaced by a link to another one.
+    os.unlink(linked)
+    open(linked, "wb").write(b"its own")
+    omr.engine_for("homr")
+    assert not os.path.islink(linked)
+
+
+def test_the_chosen_engine_is_what_reads_the_page(monkeypatch, tmp_path):
+    """The picked engine runs, with its environment, and the default is not consulted."""
     other = tmp_path / "other"
     other.mkdir()
     monkeypatch.setenv("HOMR_BIN", stub_homr(tmp_path, "exit 1\n"))
-    chosen = stub_homr(other, 'echo "<picked/>" > "${!#%.*}.musicxml"\n')
+    chosen = stub_homr(other, 'echo "<picked>$MARK</picked>" > "${!#%.*}.musicxml"\n')
+    engine = omr.Engine(key="system-4", label="prototype/system-4",
+                        command=[chosen], env={"MARK": "here"})
 
     out = omr.read_page(a_page(tmp_path), out_dir=str(tmp_path / "out"),
-                        binary=chosen, queue=False)
-    assert "<picked/>" in open(out).read()
+                        engine=engine, queue=False)
+
+    assert "<picked>here</picked>" in open(out).read()
 
 
 # --- what it hands back --------------------------------------------------

--- a/src/song_app/tests/test_scan.py
+++ b/src/song_app/tests/test_scan.py
@@ -59,7 +59,7 @@ class Reader:
     def __init__(self, staves=2, bars=2):
         self.cropped = []
         self.read = []
-        self.binaries = []
+        self.engines = []
         self.fail = {}
         self.staves, self.bars = staves, bars
 
@@ -73,9 +73,9 @@ class Reader:
             images.append(pdf_systems.SystemImage(bounds=band, path=path))
         return images
 
-    def read_system(self, image, out_dir, log=None, queue=True, binary=None):
+    def read_system(self, image, out_dir, log=None, queue=True, engine=None):
         self.read.append(image.index)
-        self.binaries.append(binary)
+        self.engines.append(engine)
         boom = self.fail.get(image.index)
         if boom:
             raise boom
@@ -623,14 +623,17 @@ def test_a_scanned_system_is_rendered_from_its_own_fragment(client, songs, reade
 
 def test_the_chosen_homr_is_what_reads_every_band(songs, reader):
     song = _song(songs)
-    scan.run(song, binary="/engines/prototype/bin/homr")
-    assert reader.binaries == ["/engines/prototype/bin/homr"] * 3
+    engine = omr.Engine(key="system-4", label="prototype/system-4",
+                        command=["/venv/bin/python", "-m", "homr"],
+                        env={"PYTHONPATH": "/home/eero/homr-trees/system-4"})
+    scan.run(song, engine=engine)
+    assert reader.engines == [engine] * 3
 
 
 def test_no_choice_leaves_the_engine_to_the_module(songs, reader):
     song = _song(songs)
     scan.run(song)
-    assert reader.binaries == [None] * 3
+    assert reader.engines == [None] * 3
 
 
 def test_the_route_resolves_the_engine_before_taking_the_lock(client, songs, reader,
@@ -652,14 +655,15 @@ def test_the_route_resolves_the_engine_before_taking_the_lock(client, songs, rea
 
 def test_the_panel_is_told_what_is_installed(client, monkeypatch):
     monkeypatch.setattr(server.omr, "engines", lambda: [
-        omr.Engine(key="default", label="main", binary="/a/homr", default=True),
-        omr.Engine(key="prototype-system-4", label="prototype/system-4",
-                   binary="/b/homr"),
+        omr.Engine(key="default", label="main", command=["/a/homr"], default=True),
+        omr.Engine(key="system-4", label="prototype/system-4",
+                   command=["/a/python", "-m", "homr"],
+                   env={"PYTHONPATH": "/home/eero/homr-trees/system-4"}),
     ])
 
     body = client.get("/api/homr-engines").json()
 
     assert body["engines"] == [
         {"key": "default", "label": "main", "default": True},
-        {"key": "prototype-system-4", "label": "prototype/system-4", "default": False},
+        {"key": "system-4", "label": "prototype/system-4", "default": False},
     ]

--- a/src/song_app/tests/test_scan.py
+++ b/src/song_app/tests/test_scan.py
@@ -667,3 +667,17 @@ def test_the_panel_is_told_what_is_installed(client, monkeypatch):
         {"key": "default", "label": "main", "default": True},
         {"key": "system-4", "label": "prototype/system-4", "default": False},
     ]
+
+
+def test_a_host_with_no_homr_still_starts_the_scan(client, songs, reader, monkeypatch):
+    """Asking for no engine in particular must not be refused at the door.
+
+    Resolving the default here would make a host without homr — CI, a fresh
+    clone — unable to start a scan at all, when the honest failure is the one
+    the read itself gives, in the song's log.
+    """
+    song = _song(songs)
+    monkeypatch.setattr(server.omr, "engines", lambda: [])
+    monkeypatch.setattr(server.omr, "default_engine", lambda: None)
+
+    assert client.post(f"/api/songs/{song.slug}/scan").status_code == 200

--- a/src/song_app/tests/test_scan_panel_ui.py
+++ b/src/song_app/tests/test_scan_panel_ui.py
@@ -226,7 +226,8 @@ def test_the_engine_picker_appears_only_when_there_is_a_choice(live, page, monke
     base, song = live
     _read(state.load(song.slug), 3)
     monkeypatch.setattr(server.omr, "engines", lambda: [
-        server.omr.Engine(key="default", label="main", binary="/a/homr", default=True)])
+        server.omr.Engine(key="default", label="main", command=["/a/homr"],
+                          default=True)])
 
     errors = _open(page, base, song.slug)
 
@@ -239,12 +240,14 @@ def test_the_picked_engine_is_the_one_that_reads_the_system(live, page, monkeypa
     base, song = live
     _read(state.load(song.slug), 3, failed=(2,))
     monkeypatch.setattr(server.omr, "engines", lambda: [
-        server.omr.Engine(key="default", label="main", binary="/a/homr", default=True),
-        server.omr.Engine(key="prototype-system-4", label="prototype/system-4",
-                          binary="/b/homr")])
+        server.omr.Engine(key="default", label="main", command=["/a/homr"],
+                          default=True),
+        server.omr.Engine(key="system-4", label="prototype/system-4",
+                          command=["/a/python", "-m", "homr"],
+                          env={"PYTHONPATH": "/checkouts/system-4"})])
     asked = []
     monkeypatch.setattr(server.scan, "run", lambda song, **kw: (
-        asked.append(kw.get("binary")) or {"read": 2, "systems": 3, "holes": [2]}))
+        asked.append(kw.get("engine")) or {"read": 2, "systems": 3, "holes": [2]}))
 
     errors = _open(page, base, song.slug)
     picker = page.locator(".panel select")
@@ -252,13 +255,13 @@ def test_the_picked_engine_is_the_one_that_reads_the_system(live, page, monkeypa
     assert picker.locator("option").all_inner_texts() == [
         "main (default)", "prototype/system-4"]
 
-    picker.select_option("prototype-system-4")
+    picker.select_option("system-4")
     page.get_by_role("button", name="Read system 2 again").click()
     deadline = time.time() + 10
     while not asked and time.time() < deadline:
         page.wait_for_timeout(100)
 
-    assert asked == ["/b/homr"]
+    assert [e.env["PYTHONPATH"] for e in asked] == ["/checkouts/system-4"]
     assert not errors, f"the panel raised: {errors}"
 
 


### PR DESCRIPTION
#131 gave a branch its own venv. Using it showed why that is the wrong shape: the
question a branch exists to answer is whether it reads *this* repertoire better,
and answering it means editing, re-reading a page, editing again. A 660 MB
reinstall between passes is not a loop anybody uses.

So `HOMR_BRANCH` is gone, and the installer builds the one dependency venv it
always did. Instead:

- the fork's working copy at **`HOMR_CHECKOUT`** (default `~/homr`) **and every
  git worktree beside it** are engines;
- dependencies come from the installed venv, the *code* comes from the working
  copy, in front of it on `PYTHONPATH`;
- the label is the branch that copy has out **right now**, read live from git —
  switch a branch there and the next scan runs it, nothing to rebuild.

The installed venv stays as the fixed thing to compare against.

**Weights.** homr keeps its ~150 MB of weights beside its own source, so a
working copy would download its own set — per worktree. `link_weights` symlinks
the installed `.onnx` files in the first time a checkout is picked. Safe because
the names carry a content hash: a branch wanting different weights asks for a
different name and downloads it. Only missing files are linked; a real file is
never replaced.

An `Engine` now carries its argv and the environment it needs rather than a path,
so `read_page(engine=...)` threads through `read_system` and `scan.run`. The argv
spells the entry point out (`python -c "from homr.main import main; main()"`) —
the package has no `__main__`, and the venv's own `bin/homr` would import the
installed copy however `PYTHONPATH` was set.

Verified on this host: a page of the scanned fixture read by the `system-4`
worktree's code (branch `fix/staff-coordinates`), with no install and no weight
download. Song-app suite green locally (398 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)