### PR TITLE
Say what each engine actually is

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -882,9 +882,17 @@ state model are in `DESIGN.md`.
   scan runs, with nothing to rebuild and nothing to keep in step. The label is the
   branch, **read live from git** rather than remembered, because that is the whole
   point; the price is that such an engine is whatever is checked out at the moment it
-  runs, which is why the installed venv stays as the fixed thing to compare against
-  (`homr-engine.txt` still labels it, and an explicit `HOMR_SOURCE` is then its label,
-  since a hand-written source is not a branch).
+  runs, which is why the installed venv stays as the fixed thing to compare against.
+  **Both labels name what they actually are**, which took a second pass to get right.
+  A checkout is `<branch> — <directory>`: neither half identifies it alone, since a
+  worktree keeps its directory name when its branch changes (a tree called `system-4`
+  is on `main` on this host) and two trees can be on branches that read alike. The
+  installed one is `installed: <revision> @ <commit>`, read out of pip's own
+  `direct_url.json` — it said `main` before, which was a guess this venv could not
+  support: it predates `homr-engine.txt`, so the label would have read `main` whatever
+  commit was installed, and "the frozen one" is worth nothing if it cannot say what it
+  is frozen at. The marker file and an explicit `HOMR_SOURCE` are the fallbacks behind
+  it.
   One thing this costs and pays for: homr keeps its ~150 MB of weights **beside its
   own source**, so a working copy run this way would download its own set — per
   worktree, four times over here. `link_weights` symlinks the installed venv's

--- a/src/song_app/omr.py
+++ b/src/song_app/omr.py
@@ -52,6 +52,7 @@ nest.
 from __future__ import annotations
 
 import glob
+import json
 import os
 import shutil
 import signal
@@ -185,18 +186,47 @@ def _marker(venv: str) -> dict:
     return dict(line.split("=", 1) for line in lines if "=" in line)
 
 
-def _label(venv: str, fallback: str) -> str:
-    fields = _marker(venv)
-    return fields.get("branch") or fields.get("source") or fallback
+def _installed_from(venv: str) -> Optional[str]:
+    """What pip actually installed, read out of the wheel's own metadata.
+
+    ``direct_url.json`` records the revision that was asked for and the commit
+    it resolved to, which is the only account of the installed engine that
+    cannot be out of date. Saying "main" without it was a guess: the venv here
+    predates the marker file, so the label read `main` and would have read
+    `main` whatever commit had been installed.
+    """
+    for info in sorted(glob.glob(os.path.join(
+            venv, "lib", "python3.*", "site-packages", "homr-*.dist-info"))):
+        try:
+            with open(os.path.join(info, "direct_url.json"), encoding="utf-8") as f:
+                direct = json.load(f)
+        except (OSError, ValueError):
+            continue
+        vcs = direct.get("vcs_info") or {}
+        revision = vcs.get("requested_revision")
+        commit = (vcs.get("commit_id") or "")[:7]
+        if revision and commit:
+            return f"{revision} @ {commit}"
+        return revision or commit or None
+    return None
 
 
 def default_engine() -> Optional[Engine]:
-    """The installed homr, or ``None`` when this host has not got one."""
+    """The installed homr, or ``None`` when this host has not got one.
+
+    It is the one engine that does not move: pip put a copy of the source in
+    the venv, so it stays where it was installed while every checkout engine
+    follows whatever is checked out. That is what makes it the thing to compare
+    a branch against, and it is why the label says the commit.
+    """
     binary = homr_binary()
     if not homr_available(binary):
         return None
     venv = os.path.dirname(os.path.dirname(binary))
-    return Engine(key=DEFAULT_ENGINE, label=_label(venv, "main"),
+    fields = _marker(venv)
+    label = (_installed_from(venv) or fields.get("branch")
+             or fields.get("source") or "installed")
+    return Engine(key=DEFAULT_ENGINE, label=f"installed: {label}",
                   command=[binary], default=True)
 
 
@@ -304,7 +334,11 @@ def engines() -> List[Engine]:
         while key in used:
             key += "-"
         used.add(key)
-        found.append(Engine(key=key, label=label,
+        # Branch *and* directory, because neither alone identifies a working
+        # copy: a worktree keeps its directory name when its branch changes
+        # (a tree called `system-4` is currently on `main`), and two trees can
+        # be on branches that look alike.
+        found.append(Engine(key=key, label=f"{label} — {key}",
                             command=[python, "-c", RUN_HOMR],
                             env={"PYTHONPATH": path}))
     return found

--- a/src/song_app/tests/test_omr.py
+++ b/src/song_app/tests/test_omr.py
@@ -11,6 +11,7 @@ thing: a page of the scanned fixture goes in, MusicXML comes out. It needs
 homr installed (scripts/install-homr.sh) and poppler, and skips without them.
 """
 import contextlib
+import json
 import os
 import shutil
 import stat
@@ -126,7 +127,7 @@ def test_one_install_and_no_checkout_is_one_engine(monkeypatch, tmp_path):
 
     engines = omr.engines()
     assert [(e.key, e.label, e.command, e.default) for e in engines] == [
-        ("default", "main", [binary], True)]
+        ("default", "installed: main", [binary], True)]
 
 
 def test_a_working_copy_and_its_worktrees_are_engines(monkeypatch, tmp_path):
@@ -142,8 +143,10 @@ def test_a_working_copy_and_its_worktrees_are_engines(monkeypatch, tmp_path):
 
     assert [e.key for e in engines] == ["default", "homr", "system-4"]
     # The label is the branch each working copy has out *now* -- switching a
-    # branch there changes the engine with nothing to reinstall.
-    assert [e.label for e in engines] == ["main", "main", "prototype/system-4"]
+    # branch there changes the engine with nothing to reinstall -- and it names
+    # the directory too, since a worktree keeps its name when its branch moves.
+    assert [e.label for e in engines] == [
+        "installed: main", "main — homr", "prototype/system-4 — system-4"]
     tree = engines[2]
     assert tree.command[1:] == ["-c", omr.RUN_HOMR]
     assert tree.command[0].endswith("/bin/python"), "the venv's interpreter"
@@ -662,3 +665,24 @@ def test_a_runaway_slur_swallows_syllable_slots_and_the_rule_gives_them_back(tmp
     resolved = a_slurred_part("1( 3)", bars=3)
     assert omr.resolve_slurs(resolved) == 1
     assert slots(resolved, "resolved") == 12
+
+
+def test_the_installed_engine_says_which_commit_it_is(monkeypatch, tmp_path):
+    """"main" alone was a guess: the label read `main` whatever was installed.
+
+    pip's own record of the install is the one account of it that cannot go
+    stale, and being frozen is what makes this engine worth comparing against.
+    """
+    monkeypatch.delenv("HOMR_BIN", raising=False)
+    venv = tmp_path / "homr-venv"
+    a_venv(venv, branch="main")
+    info = venv / "lib" / "python3.12" / "site-packages" / "homr-0.7.0.post37.dist-info"
+    info.mkdir(parents=True)
+    (info / "direct_url.json").write_text(json.dumps({
+        "url": "https://github.com/eerovil/homr.git",
+        "vcs_info": {"vcs": "git", "requested_revision": "main",
+                     "commit_id": "3fe86a3e84db43af19eae452e29830c1f46c3b34"}}))
+    monkeypatch.setattr(omr, "DEFAULT_VENV", str(venv))
+    monkeypatch.setattr(omr, "CHECKOUT", str(tmp_path / "none"))
+
+    assert omr.engines()[0].label == "installed: main @ 3fe86a3"


### PR DESCRIPTION
Follow-up to #133. Asked what "main" meant in the picker, the honest answer was
"a guess" — and by then the host had a working copy with the fork's `main`
checked out, so two entries read `main` and neither label could be trusted.

- A checkout is now **`<branch> — <directory>`**. Neither half identifies it
  alone: a worktree keeps its directory name when its branch changes (the tree
  called `system-4` is on `main` on this host) and two trees can be on branches
  that read alike.
- The installed one is **`installed: <revision> @ <commit>`**, read out of pip's
  own `direct_url.json`. It said `main` before, which this venv could not
  support — it predates `homr-engine.txt`, so the label would have read `main`
  whatever commit was installed. Being the frozen engine to compare against is
  worth nothing if it cannot say what it is frozen at.

On this host the picker now reads:

```
installed: main @ 3fe86a3
agent/choir-fixture-loop — homr
main — system-4
prototype/verify — verify
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)