### PR TITLE
Let a system that read again be seen again

### DIFF
--- a/src/song_app/pipeline.py
+++ b/src/song_app/pipeline.py
@@ -586,9 +586,15 @@ def scan_system_render(song_dir: str, musicxml_path: str, dpi: int = 200) -> str
         [cli, "-T", "10", "-r", str(dpi), musicxml_path, "-o", out],
         capture_output=True, text=True, timeout=MUSESCORE_TIMEOUT)
     # MuseScore numbers the pages it writes, so a one-page export lands as
-    # <name>-1.png rather than under the name it was asked for.
+    # <name>-1.png rather than under the name it was asked for. It is moved into
+    # place *whenever it exists*, stale target or not: guarding on the target
+    # being absent meant a system read a second time re-engraved correctly and
+    # then kept serving the old picture, since the old file was still sitting
+    # there. Nothing about that is visible — the picture is plausible, it is
+    # just the previous parse — so it read as the new engine having changed
+    # nothing.
     numbered = f"{os.path.splitext(out)[0]}-1.png"
-    if not os.path.exists(out) and os.path.exists(numbered):
+    if os.path.exists(numbered):
         os.replace(numbered, out)
     if result.returncode != 0 or not os.path.exists(out):
         raise RuntimeError(

--- a/src/song_app/tests/test_scan.py
+++ b/src/song_app/tests/test_scan.py
@@ -13,6 +13,7 @@ assembled score untested, which is where a hole would go unnoticed.
 
 import json
 import os
+import time
 
 import pytest
 
@@ -21,7 +22,8 @@ pytest.importorskip("httpx")
 from fastapi.testclient import TestClient
 
 from src.clean_score.utils import per_system
-from src.song_app import heavy_slot, omr, omr_systems, pdf_systems, scan, server, state
+from src.song_app import (heavy_slot, omr, omr_systems, pdf_systems, pipeline, scan,
+                          server, state)
 
 
 # --- a stub score, small enough to read -----------------------------------
@@ -681,3 +683,42 @@ def test_a_host_with_no_homr_still_starts_the_scan(client, songs, reader, monkey
     monkeypatch.setattr(server.omr, "default_engine", lambda: None)
 
     assert client.post(f"/api/songs/{song.slug}/scan").status_code == 200
+
+
+def _fake_musescore(tmp_path):
+    """A CLI that writes MuseScore's numbered page, copying its input's bytes."""
+    cli = tmp_path / "fake-musescore"
+    cli.write_text(
+        "#!/usr/bin/env bash\n"
+        'out="${@: -1}"\n'
+        'src="${@: -3:1}"\n'
+        'cp "$src" "${out%.png}-1.png"\n',
+        encoding="utf-8")
+    cli.chmod(0o755)
+    return str(cli)
+
+
+def test_a_system_read_again_is_engraved_again(tmp_path, monkeypatch):
+    """The picture has to follow the parse, or a re-read looks like it did nothing.
+
+    MuseScore writes `<name>-1.png` and the mover used to skip while the old
+    file was still there, so a second reading re-engraved correctly and then
+    served the previous picture — plausible, wrong, and silent. It is how a new
+    engine reads as having changed nothing.
+    """
+    monkeypatch.setenv("MUSESCORE_CLI_PATH", _fake_musescore(tmp_path))
+    song_dir = tmp_path / "song"
+    (song_dir / "scan").mkdir(parents=True)
+    fragment = song_dir / "scan" / "system-01@200-abc.musicxml"
+    fragment.write_bytes(b"first reading")
+
+    first = pipeline.scan_system_render(str(song_dir), str(fragment))
+    assert open(first, "rb").read() == b"first reading"
+
+    fragment.write_bytes(b"second reading")
+    os.utime(fragment, (time.time() + 2, time.time() + 2))
+    again = pipeline.scan_system_render(str(song_dir), str(fragment))
+
+    assert open(again, "rb").read() == b"second reading"
+    # And nothing is left behind for the next render to trip over.
+    assert not os.path.exists(os.path.splitext(again)[0] + "-1.png")


### PR DESCRIPTION
Re-reading a printed system with a different homr engine looked like it changed
nothing. It had: the parse was new and the **picture** was old.

`pipeline.scan_system_render` asks MuseScore for `<name>.png`; MuseScore writes
`<name>-1.png` (it numbers pages), and the mover put it in place only
`if not os.path.exists(out)`. The first render therefore worked, and every render
after it left the fresh engraving as `-1.png` and returned the stale file that
was still sitting there.

Measured on `songs/test` system 2: the parse from 07:04 has two voices in the
bass staff's first bar (voice 1 up-stem, voice 2 down-stem, six chords each);
the picture the app served was the 20:58 parse, one voice. That is the compare
view — the thing whose whole job is to show what the scan read — quietly showing
something else.

The fix is to move the numbered file whenever it exists, and a test that a
second reading of the same system is engraved again and leaves nothing behind.

I also cleared the stale cache under `songs/test/.pages/scan/` on the host, so
the live app is already showing the real parse for that song.

🤖 Generated with [Claude Code](https://claude.com/claude-code)