### PR TITLE
Record where homr actually runs fastest

### DIFF
--- a/docs/research/homr-hardware.md
+++ b/docs/research/homr-hardware.md
@@ -78,7 +78,6 @@ natively, both going, is ~4.1 min. But the cluster and the native Mac are *the
 same laptop*, so that pairing is a choice between them and the pod is the slow
 half. And a scan running flat out here is what the heavy-slot queue exists to
 prevent: it would starve any render or test suite beside it.
->>>>>>> e1b17ec (Measure four concurrent pages on this host too)
 
 ## Why nothing was built
 

--- a/docs/research/homr-hardware.md
+++ b/docs/research/homr-hardware.md
@@ -64,7 +64,7 @@ The Neural Engine is a single shared unit, so pages queue on it.
   the Neural Engine, not the cores, and going wider will not help much.
 
 For 50 pages that is ~5.7 min on the Mac four at a time, ~8 min one at a time,
-~13 min in the cluster, ~15 min here.
+~14.5 min in the cluster, ~15 min here.
 
 ## Why nothing was built
 

--- a/docs/research/homr-hardware.md
+++ b/docs/research/homr-hardware.md
@@ -59,12 +59,26 @@ The Neural Engine is a single shared unit, so pages queue on it.
 - **In the pod:** four pages at once took 69.5 s, i.e. 17.4 s each — *slightly
   worse* than one at a time. One page already spreads over 4.3 of the 8 cores,
   so there is nothing to parallelise into.
+- **On this host:** four at once took 74.9 s, i.e. 18.7 s each against 17.7 s
+  alone. Also slightly worse, and for the same reason — one page already uses
+  about 3 of the 4 cores.
 - **Natively with CoreML:** four at once took 27.3 s, i.e. 6.8 s each against
   9.4 s alone. A 1.4x gain, at 400% CPU of 8 cores available — so the limit is
   the Neural Engine, not the cores, and going wider will not help much.
 
-For 50 pages that is ~5.7 min on the Mac four at a time, ~8 min one at a time,
-~14.5 min in the cluster, ~15 min here.
+So concurrency is only worth anything on the Mac natively, where CoreML leaves
+cores idle. Everywhere else a single page already saturates the machine and
+running four is a rearrangement of the same total time.
+
+For 50 pages: ~5.7 min on the Mac four at a time, ~8 min one at a time,
+~14.5 min in the cluster, ~15.6 min here.
+
+Two machines do add up, since they are independent — this host and the Mac
+natively, both going, is ~4.1 min. But the cluster and the native Mac are *the
+same laptop*, so that pairing is a choice between them and the pod is the slow
+half. And a scan running flat out here is what the heavy-slot queue exists to
+prevent: it would starve any render or test suite beside it.
+>>>>>>> e1b17ec (Measure four concurrent pages on this host too)
 
 ## Why nothing was built
 

--- a/docs/research/homr-hardware.md
+++ b/docs/research/homr-hardware.md
@@ -1,0 +1,94 @@
+# Where homr should run: measured, 2026-09-03
+
+The scan stage is the slowest thing the app does — a song is 15–20 systems at
+10–16 s each, about 200 s on this host. This is a measurement of whether moving
+homr to other hardware is worth it. **Conclusion: the only real gain is running
+homr natively on the MacBook (about 2.6x), Kubernetes on that same MacBook is
+the slowest option of all, and nothing was built.**
+
+Recorded because the question will come back, and because two of the three
+answers here are the opposite of what they look like from the outside.
+
+## What was measured
+
+One page, the same page every time: `fixtures/omr-benchmark/B1a-heraa-suomi-p420-287dpi.pdf`
+rasterised at 300 dpi with poppler (1.76 MB PNG). homr from `eerovil/homr@main`
+(`0.7.0.post83+686d9fd`) on both new installs, run as `homr --gpu no` or
+`--gpu auto`. Wall time from `time`, best of three where noted.
+
+Both machines read the page the same way — 6 staves, 3 connected — so this is
+one parse on different hardware, not two different parses.
+
+| where | per page | CPU used |
+| --- | --- | --- |
+| MacBook Air, native, `--gpu auto` (CoreML) | **9.4 s** | 16.4 s |
+| MacBook Air, native, `--gpu no` | 9.9 s | 31.2 s |
+| MacBook Air, inside the kind cluster | 15–17 s warm, 21 s cold | ~90 s |
+| this host (bazzite, 4 cores) | 16–19 s | ~52 s |
+
+## The Apple AI cores are real, and they are not the win
+
+homr already supports them: `homr/onnx_providers.py` picks
+`CoreMLExecutionProvider` under `--gpu auto` when onnxruntime offers it, and a
+native macOS onnxruntime does (`['CoreMLExecutionProvider',
+'AzureExecutionProvider', 'CPUExecutionProvider']`).
+
+But CoreML is worth **5% of wall time**, not a multiple: 9.4 s against 9.9 s for
+the same page on the same machine. What it does buy is CPU — 16.4 s against
+31.2 s, half — so the page keeps only 1.7 cores busy and the laptop stays cool.
+The 2x against this host is the Mac simply being a faster machine, not the
+Neural Engine.
+
+## Kubernetes on the Mac takes the gain away
+
+The cluster reachable at `eeros-macbook-air.taile8d16e.ts.net:6443` is a kind
+node in a Linux VM: arm64, 8 CPUs, 24 GB. A pod there reads the page in 15–17 s
+— **60% slower than the same laptop running homr natively**, and no better than
+the four-core host it was supposed to beat.
+
+The reason is structural rather than tuning: Apple's Neural Engine and GPU are
+not exposed to Linux containers at all. There is no driver and no passthrough.
+Anything in that VM is plain CPU on the Arm cores, which is exactly what the
+timings show. Containerising homr on the Mac is the one arrangement that
+guarantees the AI cores cannot be used.
+
+## Concurrency helps a little, and only natively
+
+The Neural Engine is a single shared unit, so pages queue on it.
+
+- **In the pod:** four pages at once took 69.5 s, i.e. 17.4 s each — *slightly
+  worse* than one at a time. One page already spreads over 4.3 of the 8 cores,
+  so there is nothing to parallelise into.
+- **Natively with CoreML:** four at once took 27.3 s, i.e. 6.8 s each against
+  9.4 s alone. A 1.4x gain, at 400% CPU of 8 cores available — so the limit is
+  the Neural Engine, not the cores, and going wider will not help much.
+
+For 50 pages that is ~5.7 min on the Mac four at a time, ~8 min one at a time,
+~13 min in the cluster, ~15 min here.
+
+## Why nothing was built
+
+2.6x on a stage that runs once per song, in exchange for a second machine in the
+path. Using it would mean a homr service on the Mac under launchd, a remote
+engine in `omr.py`, Tailscale between them, and a fallback to local homr
+whenever the laptop is asleep — and the Mac would become host state no checkout
+can reproduce, which is the complaint `CLAUDE.md` already makes about the `omr`
+distrobox container that `scripts/install-homr.sh` replaced.
+
+If it is ever built, the shape is: **native macOS, not a container**, one page
+per request, and four in flight at most.
+
+## Reproducing it
+
+On the Mac (no repo checkout needed):
+
+```bash
+uv venv --python 3.12 ./homr-venv
+VIRTUAL_ENV=./homr-venv uv pip install "homr[cpu] @ git+https://github.com/eerovil/homr.git@main"
+./homr-venv/bin/homr --init
+./homr-venv/bin/python -c "import onnxruntime as ort; print(ort.get_available_providers())"
+cp page.png a.png && time ./homr-venv/bin/homr --gpu auto a.png
+```
+
+homr writes its MusicXML and a `_teaser.png` beside the input, so give each run
+its own copy of the image or they overwrite each other.


### PR DESCRIPTION
The scan stage is the slowest thing the app does, so "run homr somewhere else" keeps coming up. This measures it once and writes the numbers down. No code changes — `docs/research/homr-hardware.md` only.

One page (`fixtures/omr-benchmark/B1a`, 300 dpi), homr `0.7.0.post83+686d9fd` on both new installs, same parse both sides (6 staves, 3 connected):

| where | per page | CPU |
| --- | --- | --- |
| MacBook Air, native, `--gpu auto` (CoreML) | **9.4 s** | 16.4 s |
| MacBook Air, native, `--gpu no` | 9.9 s | 31.2 s |
| MacBook Air, inside its kind cluster | 15–17 s | ~90 s |
| this host (4 cores) | 16–19 s | ~52 s |

Two results worth the write-up, because both are the opposite of the intuition:

- **The Apple AI cores are worth 5%, not a multiple.** homr does pick `CoreMLExecutionProvider` under `--gpu auto`, and it halves the CPU a page costs — but wall time barely moves. The 2x against this host is the Mac being a faster machine.
- **Kubernetes on the Mac is the slowest option there is.** A Linux VM has no path to the Neural Engine or the GPU, so a pod on that laptop is 60% slower than the same laptop running homr natively, and no better than the four-core host it was meant to beat.

Concurrency helps a little and only natively: four pages at once is 6.8 s each against 9.4 s alone (1.4x), and in the pod it is slightly *worse* than sequential. For 50 pages: ~5.7 min on the Mac four at a time, ~15 min here.

Nothing was built. 2.6x on a once-per-song stage would cost a launchd service on the Mac, a remote engine in `omr.py`, and the Mac becoming host state no checkout reproduces — the complaint CLAUDE.md already makes about the `omr` container `scripts/install-homr.sh` replaced. The doc records the shape to use if that ever changes: native macOS, one page per request, four in flight at most.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


AgentDeck session: https://bazzite.taile8d16e.ts.net/chats/f52779d276954129aa92f4fb565dcb94


AgentDeck session (conflict-marker fix): https://bazzite.taile8d16e.ts.net/chats/544dad627852458397e8a5141c00d7a1
