### PR TITLE
Judge a scan against a song the choir has already sung

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@ implode-report/
 
 # Built by scripts/song_pages.py
 song-pages/
+scan-eval/

--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,4 @@ implode-report/
 # Built by scripts/song_pages.py
 song-pages/
 scan-eval/
+scan-report/

--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ playlists.txt
 
 # Built by scripts/implode_report.py
 implode-report/
+
+# Built by scripts/song_pages.py
+song-pages/

--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,6 @@ playlists.txt
 /*.mscx
 /*.mscz
 .venv
+
+# Built by scripts/implode_report.py
+implode-report/

--- a/fixtures/omr-songs.json
+++ b/fixtures/omr-songs.json
@@ -30,8 +30,8 @@
         ]
       },
       "review": {
-        "status": "ok",
-        "notes": "checked against the page: staves, voices and words match"
+        "status": "excluded",
+        "notes": "the same printed page as kaksi-laulua-krapulasta-2, byte for byte; that song is the one kept, having the newer cleaned score and its videos still on disk"
       }
     },
     "Kolme käkeä": {

--- a/fixtures/omr-songs.json
+++ b/fixtures/omr-songs.json
@@ -35,9 +35,9 @@
       }
     },
     "Kolme käkeä": {
-      "pdf": "Kolme käkeä copy.pdf",
+      "pdf": "Kolme käkeä.pdf",
       "cleaned": "Kolme-ka-kea_cleaned.mscx",
-      "pdf_sha256": "4b2f416fbd30a00a",
+      "pdf_sha256": "e14f05b1ca989491",
       "cleaned_sha256": "3812692949ed976e",
       "video": {
         "videos": 0,
@@ -87,7 +87,11 @@
       },
       "review": {
         "status": "ok",
-        "notes": "the page prints four staves of one voice each, so nothing is imploded"
+        "notes": "four staves of one voice each, nothing imploded; the lowest staff rests at the start, which is what the page prints"
+      },
+      "source_override": {
+        "pdf": "Kolme käkeä.pdf",
+        "why": "the folder's other PDF starts at printed page 6, so it is different music from bar 1"
       }
     },
     "heraa-suomi-final": {
@@ -227,12 +231,15 @@
               "B"
             ]
           ],
-          "why": "the tenor staff carries three voices, T3 above T1 and T2"
+          "why": "the tenor staff carries three voices, T3 above T1 and T2; T3 is written only where it sings",
+          "drop_rests": [
+            "T3"
+          ]
         }
       },
       "review": {
         "status": "ok",
-        "notes": "T3 shares the tenor staff as its top voice, which no recorded map said"
+        "notes": "T3 shares the tenor staff as its top voice and is absent where it rests"
       }
     },
     "pois-meni-mereen-paiva": {

--- a/fixtures/omr-songs.json
+++ b/fixtures/omr-songs.json
@@ -30,8 +30,8 @@
         ]
       },
       "review": {
-        "status": "unreviewed",
-        "notes": ""
+        "status": "ok",
+        "notes": "checked against the page: staves, voices and words match"
       }
     },
     "Kolme käkeä": {
@@ -45,30 +45,49 @@
         "stage": "upload"
       },
       "grouping": {
-        "source": "part names",
-        "inferred": true,
+        "source": "reviewed",
+        "inferred": false,
         "printed": [
           [
-            1,
+            1
+          ],
+          [
             2
           ],
           [
-            3,
-            4
+            3
           ],
           [
-            5
+            4
           ]
         ],
         "labels": [
-          "Soprano 1/Soprano 2",
-          "Alto 1/Alto 2",
-          "Solo"
-        ]
+          "Soprano 1",
+          "Soprano 2",
+          "Alto 1",
+          "Alto 2"
+        ],
+        "override": {
+          "printed": [
+            [
+              "Soprano 1"
+            ],
+            [
+              "Soprano 2"
+            ],
+            [
+              "Alto 1"
+            ],
+            [
+              "Alto 2"
+            ]
+          ],
+          "why": "the page prints one voice per staff; the guess had paired them"
+        }
       },
       "review": {
-        "status": "unreviewed",
-        "notes": ""
+        "status": "ok",
+        "notes": "the page prints four staves of one voice each, so nothing is imploded"
       }
     },
     "heraa-suomi-final": {
@@ -100,8 +119,8 @@
         ]
       },
       "review": {
-        "status": "unreviewed",
-        "notes": ""
+        "status": "ok",
+        "notes": "checked against the page: staves, voices and words match"
       }
     },
     "kaksi-laulua-krapulasta-2": {
@@ -133,8 +152,8 @@
         ]
       },
       "review": {
-        "status": "unreviewed",
-        "notes": ""
+        "status": "ok",
+        "notes": "checked against the page: staves, voices and words match"
       }
     },
     "kayttaytymisohjeita": {
@@ -166,8 +185,8 @@
         ]
       },
       "review": {
-        "status": "unreviewed",
-        "notes": ""
+        "status": "ok",
+        "notes": "checked against the page: staves, voices and words match"
       }
     },
     "laulun-aika-3": {
@@ -181,29 +200,39 @@
         "stage": "upload"
       },
       "grouping": {
-        "source": "per-system map",
+        "source": "reviewed",
         "inferred": false,
         "printed": [
           [
+            3,
             1,
             2
-          ],
-          [
-            3
           ],
           [
             4
           ]
         ],
         "labels": [
-          "T1/T2",
-          "T3",
+          "T3/T1/T2",
           "B"
-        ]
+        ],
+        "override": {
+          "printed": [
+            [
+              "T3",
+              "T1",
+              "T2"
+            ],
+            [
+              "B"
+            ]
+          ],
+          "why": "the tenor staff carries three voices, T3 above T1 and T2"
+        }
       },
       "review": {
-        "status": "unreviewed",
-        "notes": ""
+        "status": "ok",
+        "notes": "T3 shares the tenor staff as its top voice, which no recorded map said"
       }
     },
     "pois-meni-mereen-paiva": {
@@ -235,8 +264,8 @@
         ]
       },
       "review": {
-        "status": "unreviewed",
-        "notes": ""
+        "status": "ok",
+        "notes": "checked against the page: staves, voices and words match"
       }
     },
     "virta-scratch": {
@@ -268,8 +297,8 @@
         ]
       },
       "review": {
-        "status": "unreviewed",
-        "notes": ""
+        "status": "ok",
+        "notes": "checked against the page: staves, voices and words match"
       }
     }
   }

--- a/fixtures/omr-songs.json
+++ b/fixtures/omr-songs.json
@@ -59,13 +59,17 @@
           ],
           [
             4
+          ],
+          [
+            5
           ]
         ],
         "labels": [
           "Soprano 1",
           "Soprano 2",
           "Alto 1",
-          "Alto 2"
+          "Alto 2",
+          "Solo"
         ],
         "override": {
           "printed": [
@@ -80,18 +84,21 @@
             ],
             [
               "Alto 2"
+            ],
+            [
+              "Solo"
             ]
           ],
-          "why": "the page prints one voice per staff; the guess had paired them"
+          "why": "the page prints one voice per staff and never implodes; the solo enters at bar 94 on a fifth staff, and hideEmptyStaves keeps it off the systems it rests through"
         }
       },
       "review": {
         "status": "ok",
-        "notes": "four staves of one voice each, nothing imploded; the lowest staff rests at the start, which is what the page prints"
+        "notes": "one voice per staff, nothing imploded; four staves until the solo enters at bar 94 and the page prints five"
       },
       "source_override": {
         "pdf": "Kolme käkeä.pdf",
-        "why": "the folder's other PDF starts at printed page 6, so it is different music from bar 1"
+        "why": "the folder holds the piece in two halves: this file is printed pages 2-5, bars 1-62, and 'Kolme käkeä copy.pdf' is pages 6-10, bars 63-120. Neither covers the whole score, so a fixture spans both or stops at bar 62"
       }
     },
     "heraa-suomi-final": {

--- a/fixtures/omr-songs.json
+++ b/fixtures/omr-songs.json
@@ -93,8 +93,8 @@
         }
       },
       "review": {
-        "status": "ok",
-        "notes": "one voice per staff, nothing imploded; four staves until the solo enters at bar 94 and the page prints five"
+        "status": "excluded",
+        "notes": "the page is split across two PDFs -- printed pages 2-5 (bars 1-62) and 6-10 (bars 63-120) -- so no single file is the page for this score"
       },
       "source_override": {
         "pdf": "Kolme käkeä.pdf",

--- a/fixtures/omr-songs.json
+++ b/fixtures/omr-songs.json
@@ -1,0 +1,276 @@
+{
+  "version": 1,
+  "songs": {
+    "Kaksi-laulua-krapulasta-pdf": {
+      "pdf": "Kaksi-laulua-krapulasta-pdf.pdf",
+      "cleaned": "Kaksi-laulua-krapulasta-pdf_cleaned.mscx",
+      "pdf_sha256": "e2bf0794e3ecdf37",
+      "cleaned_sha256": "7d267a8e1d2d587a",
+      "video": {
+        "videos": 0,
+        "uploads": 5,
+        "stage": "upload"
+      },
+      "grouping": {
+        "source": "per-system map",
+        "inferred": false,
+        "printed": [
+          [
+            1,
+            2
+          ],
+          [
+            3,
+            4
+          ]
+        ],
+        "labels": [
+          "T1/T2",
+          "B1/B2"
+        ]
+      },
+      "review": {
+        "status": "unreviewed",
+        "notes": ""
+      }
+    },
+    "Kolme käkeä": {
+      "pdf": "Kolme käkeä copy.pdf",
+      "cleaned": "Kolme-ka-kea_cleaned.mscx",
+      "pdf_sha256": "4b2f416fbd30a00a",
+      "cleaned_sha256": "3812692949ed976e",
+      "video": {
+        "videos": 0,
+        "uploads": 0,
+        "stage": "upload"
+      },
+      "grouping": {
+        "source": "part names",
+        "inferred": true,
+        "printed": [
+          [
+            1,
+            2
+          ],
+          [
+            3,
+            4
+          ],
+          [
+            5
+          ]
+        ],
+        "labels": [
+          "Soprano 1/Soprano 2",
+          "Alto 1/Alto 2",
+          "Solo"
+        ]
+      },
+      "review": {
+        "status": "unreviewed",
+        "notes": ""
+      }
+    },
+    "heraa-suomi-final": {
+      "pdf": "Herää Suomi!.pdf",
+      "cleaned": "Herää Suomi final_cleaned.mscx",
+      "pdf_sha256": "41cd3fcfaff56985",
+      "cleaned_sha256": "7c698aaacc1fcedb",
+      "video": {
+        "videos": 5,
+        "uploads": 5,
+        "stage": "upload"
+      },
+      "grouping": {
+        "source": "staff map",
+        "inferred": false,
+        "printed": [
+          [
+            1,
+            2
+          ],
+          [
+            3,
+            4
+          ]
+        ],
+        "labels": [
+          "T1/T2",
+          "B1/B2"
+        ]
+      },
+      "review": {
+        "status": "unreviewed",
+        "notes": ""
+      }
+    },
+    "kaksi-laulua-krapulasta-2": {
+      "pdf": "Kaksi-laulua-krapulasta-pdf.pdf",
+      "cleaned": "Kaksi-laulua-krapulasta-pdf_cleaned.mscx",
+      "pdf_sha256": "e2bf0794e3ecdf37",
+      "cleaned_sha256": "2e07068ae150141c",
+      "video": {
+        "videos": 5,
+        "uploads": 0,
+        "stage": "record"
+      },
+      "grouping": {
+        "source": "per-system map",
+        "inferred": false,
+        "printed": [
+          [
+            1,
+            2
+          ],
+          [
+            3,
+            4
+          ]
+        ],
+        "labels": [
+          "T1/T2",
+          "B1/B2"
+        ]
+      },
+      "review": {
+        "status": "unreviewed",
+        "notes": ""
+      }
+    },
+    "kayttaytymisohjeita": {
+      "pdf": "Käyttäytymisohjeita.pdf",
+      "cleaned": "Ka-ytta-ytymisohjeita_cleaned.mscx",
+      "pdf_sha256": "f5a9eddc058cb46d",
+      "cleaned_sha256": "2537542c1e402462",
+      "video": {
+        "videos": 0,
+        "uploads": 5,
+        "stage": "upload"
+      },
+      "grouping": {
+        "source": "per-system map",
+        "inferred": false,
+        "printed": [
+          [
+            1,
+            2
+          ],
+          [
+            3,
+            4
+          ]
+        ],
+        "labels": [
+          "T1/T2",
+          "B1/B2"
+        ]
+      },
+      "review": {
+        "status": "unreviewed",
+        "notes": ""
+      }
+    },
+    "laulun-aika-3": {
+      "pdf": "Laulun aika (2).pdf",
+      "cleaned": "Laulun-aika-2_cleaned.mscx",
+      "pdf_sha256": "40bbe603fb0d546f",
+      "cleaned_sha256": "bdc38763ff097584",
+      "video": {
+        "videos": 5,
+        "uploads": 0,
+        "stage": "upload"
+      },
+      "grouping": {
+        "source": "per-system map",
+        "inferred": false,
+        "printed": [
+          [
+            1,
+            2
+          ],
+          [
+            3
+          ],
+          [
+            4
+          ]
+        ],
+        "labels": [
+          "T1/T2",
+          "T3",
+          "B"
+        ]
+      },
+      "review": {
+        "status": "unreviewed",
+        "notes": ""
+      }
+    },
+    "pois-meni-mereen-paiva": {
+      "pdf": "Pois meni merehen päivä.pdf",
+      "cleaned": "Pois-meni-merehen-pa-iva_cleaned.mscx",
+      "pdf_sha256": "b6654fab39bbaf8a",
+      "cleaned_sha256": "0ff6626181b4883a",
+      "video": {
+        "videos": 5,
+        "uploads": 5,
+        "stage": "upload"
+      },
+      "grouping": {
+        "source": "per-system map",
+        "inferred": false,
+        "printed": [
+          [
+            1,
+            2
+          ],
+          [
+            3,
+            4
+          ]
+        ],
+        "labels": [
+          "T1/T2",
+          "B1/B2"
+        ]
+      },
+      "review": {
+        "status": "unreviewed",
+        "notes": ""
+      }
+    },
+    "virta-scratch": {
+      "pdf": "Virta venhettä vie.pdf",
+      "cleaned": "Virta-venhetta-vie_cleaned.mscx",
+      "pdf_sha256": "58de0c051d19deb7",
+      "cleaned_sha256": "8c0f1cd5c21a76af",
+      "video": {
+        "videos": 0,
+        "uploads": 0,
+        "stage": "upload"
+      },
+      "grouping": {
+        "source": "staff map",
+        "inferred": false,
+        "printed": [
+          [
+            1,
+            2
+          ],
+          [
+            3,
+            4
+          ]
+        ],
+        "labels": [
+          "T1/T2",
+          "B1/B2"
+        ]
+      },
+      "review": {
+        "status": "unreviewed",
+        "notes": ""
+      }
+    }
+  }
+}

--- a/scripts/implode_report.py
+++ b/scripts/implode_report.py
@@ -25,6 +25,16 @@ sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
 from src.clean_score.implode import implode  # noqa: E402
 
+MANIFEST = Path("fixtures/omr-songs.json")
+
+
+def override_for(name: str) -> list[list[str]] | None:
+    """The grouping a person read off the page, if one is written down."""
+    if not MANIFEST.exists():
+        return None
+    saved = json.loads(MANIFEST.read_text())["songs"].get(name, {})
+    return (saved.get("grouping", {}).get("override") or {}).get("printed")
+
 OUT = Path("implode-report")
 #: Wide enough to read a notehead, small enough to open on a phone.
 WIDTH = 1500
@@ -138,7 +148,7 @@ def main() -> None:
         if wanted and name not in wanted:
             continue
         root = etree.parse(str(cleaned)).getroot()
-        found = implode(root)
+        found = implode(root, override_for(name))
         with tempfile.TemporaryDirectory() as tmp:
             score = Path(tmp) / "imploded.mscx"
             etree.ElementTree(root).write(str(score), encoding="UTF-8", xml_declaration=True)

--- a/scripts/implode_report.py
+++ b/scripts/implode_report.py
@@ -48,6 +48,11 @@ def chosen_pdf(name: str) -> str | None:
     """The page a person said is the one this score was made from."""
     return (_reviewed(name).get("source_override") or {}).get("pdf")
 
+
+def is_excluded(name: str) -> bool:
+    """Whether a review has thrown this song out of the set."""
+    return _reviewed(name).get("review", {}).get("status") == "excluded"
+
 OUT = Path("implode-report")
 #: Wide enough to read a notehead, small enough to open on a phone.
 WIDTH = 1500
@@ -92,15 +97,22 @@ def printed_pdf(folder: str, chosen: str | None = None) -> Path | None:
     return pages[0] if pages else None
 
 
-def songs() -> list[tuple[str, Path, Path, dict]]:
-    """Every song with a printed page, a cleaned score and a practice video."""
+def songs(with_excluded: bool = False) -> list[tuple[str, Path, Path, dict]]:
+    """Every song with a printed page, a cleaned score and a practice video.
+
+    A song a review has thrown out is left out, except for the manifest, which
+    keeps it so the reason it went travels with the rest.
+    """
     found = []
     for folder in sorted(glob.glob("songs/*/")):
+        name = Path(folder).name
+        if is_excluded(name) and not with_excluded:
+            continue
         cleaned = glob.glob(folder + "*_cleaned.mscx")
-        pdf = printed_pdf(folder, chosen_pdf(Path(folder).name))
+        pdf = printed_pdf(folder, chosen_pdf(name))
         made = made_a_video(folder)
         if cleaned and pdf and made:
-            found.append((Path(folder).name, pdf, Path(sorted(cleaned)[0]), made))
+            found.append((name, pdf, Path(sorted(cleaned)[0]), made))
     return found
 
 

--- a/scripts/implode_report.py
+++ b/scripts/implode_report.py
@@ -11,6 +11,7 @@ Writes `implode-report/index.html`.  Needs poppler and the MuseScore CLI.
 
 import glob
 import html
+import json
 import os
 import subprocess
 import sys
@@ -29,14 +30,51 @@ OUT = Path("implode-report")
 WIDTH = 1500
 
 
-def songs() -> list[tuple[str, Path, Path]]:
-    """Every song with both a printed page and a cleaned score."""
+def made_a_video(folder: str) -> dict | None:
+    """What says this song was carried all the way to a practice video.
+
+    Only a song somebody has actually sung from is worth judging homr against:
+    it has been through the fixing, the lyrics and a listen.  A video may not
+    still be on disk -- an uploaded one is often deleted -- so an upload or
+    having reached the record stage counts too.
+    """
+    videos = glob.glob(folder + "media/video/*.mov") + glob.glob(folder + "media/video/*.mp4")
+    state = Path(folder) / ".song.json"
+    stage, uploads = "", 0
+    if state.exists():
+        saved = json.loads(state.read_text())
+        stage = saved.get("stage", "")
+        uploads = len((saved.get("record") or {}).get("uploads") or [])
+    if not (videos or uploads or stage in ("record", "upload")):
+        return None
+    return {"videos": len(videos), "uploads": uploads, "stage": stage}
+
+
+def printed_pdf(folder: str) -> Path | None:
+    """The scan the song was made from, not one of the app's own renders.
+
+    The app caches MuseScore renders of the cleaned score beside the source as
+    `*.render.pdf`, and one of those sorts first often enough to be picked by
+    accident -- which makes the "printed page" a picture of the reference, and
+    the whole comparison a score against itself.
+    """
+    pages = [
+        Path(path)
+        for path in sorted(glob.glob(folder + "*.pdf"))
+        if not path.endswith(".render.pdf") and "_cleaned" not in Path(path).name
+    ]
+    return pages[0] if pages else None
+
+
+def songs() -> list[tuple[str, Path, Path, dict]]:
+    """Every song with a printed page, a cleaned score and a practice video."""
     found = []
     for folder in sorted(glob.glob("songs/*/")):
         cleaned = glob.glob(folder + "*_cleaned.mscx")
-        pdf = glob.glob(folder + "*.pdf")
-        if cleaned and pdf:
-            found.append((Path(folder).name, Path(sorted(pdf)[0]), Path(sorted(cleaned)[0])))
+        pdf = printed_pdf(folder)
+        made = made_a_video(folder)
+        if cleaned and pdf and made:
+            found.append((Path(folder).name, pdf, Path(sorted(cleaned)[0]), made))
     return found
 
 
@@ -86,6 +124,7 @@ img { display: block; width: 100%; border: 1px solid #eee; background: #fff; }
 .guess { background: #fdefd8; color: #8a5a10; border-radius: 4px;
          padding: 1px 6px; font-size: 12px; font-weight: 600; }
 .recorded { color: #1c5c2c; font-size: 12px; }
+.video { color: #26379a; font-size: 12px; }
 """
 
 
@@ -95,7 +134,7 @@ def main() -> None:
     OUT.mkdir(exist_ok=True)
     wanted = set(sys.argv[1:])
     sections = []
-    for name, pdf, cleaned in songs():
+    for name, pdf, cleaned, made in songs():
         if wanted and name not in wanted:
             continue
         root = etree.parse(str(cleaned)).getroot()
@@ -111,9 +150,15 @@ def main() -> None:
             else f'<span class="recorded">grouping from the score\'s own {found.source}</span>'
         )
         staves = " &middot; ".join(html.escape(printed.label) for printed in found.printed)
+        evidence = (
+            f"{made['videos']} video(s) on disk"
+            if made["videos"]
+            else (f"{made['uploads']} uploaded" if made["uploads"] else f"stage {made['stage']}")
+        )
         sections.append(
             f"""<h2>{html.escape(name)}</h2>
-<p class="sub">{badge} &mdash; {len(found.printed)} printed staves: {staves}</p>
+<p class="sub">{badge} &mdash; {len(found.printed)} printed staves: {staves}
+ &mdash; <span class="video">{html.escape(evidence)}</span></p>
 <div class="pair">
   <div><p class="label">the printed page</p>
     {f'<img src="{name}-page.jpg" alt="printed page">' if shown else "<p>no page</p>"}</div>
@@ -129,12 +174,21 @@ def main() -> None:
 <h1>Imploded references</h1>
 <p class="lead">Each song's printed page beside the reference imploded out of its
 cleaned score &mdash; the voices the app split apart put back on the staves they
-were printed on. This is what homr would be judged against, so it has to be right
+were printed on. Only songs carried all the way to a practice video are here:
+those are the ones somebody has fixed, lyricked and sung from. This is what homr would be judged against, so it has to be right
 first. Where the score did not record which voices shared a staff, the grouping is
 <span class="guess">guessed</span> and should be checked hardest.</p>
 {''.join(sections)}
 </body></html>"""
     (OUT / "index.html").write_text(page)
+    if not wanted:
+        # A song that has dropped out of the set must drop out of the folder
+        # too, or the page beside it is one nobody is judging any more.
+        keep = {f"{name}-page.jpg" for name, *_ in songs()}
+        keep |= {f"{name}-imploded.jpg" for name, *_ in songs()}
+        for stale in OUT.glob("*.jpg"):
+            if stale.name not in keep:
+                stale.unlink()
     print(OUT / "index.html")
 
 

--- a/scripts/implode_report.py
+++ b/scripts/implode_report.py
@@ -28,12 +28,25 @@ from src.clean_score.implode import implode  # noqa: E402
 MANIFEST = Path("fixtures/omr-songs.json")
 
 
+def _reviewed(name: str) -> dict:
+    if not MANIFEST.exists():
+        return {}
+    return json.loads(MANIFEST.read_text())["songs"].get(name, {})
+
+
 def override_for(name: str) -> list[list[str]] | None:
     """The grouping a person read off the page, if one is written down."""
-    if not MANIFEST.exists():
-        return None
-    saved = json.loads(MANIFEST.read_text())["songs"].get(name, {})
-    return (saved.get("grouping", {}).get("override") or {}).get("printed")
+    return (_reviewed(name).get("grouping", {}).get("override") or {}).get("printed")
+
+
+def drop_rests_for(name: str) -> list[str]:
+    """Parts whose silence the page does not print."""
+    return (_reviewed(name).get("grouping", {}).get("override") or {}).get("drop_rests") or []
+
+
+def chosen_pdf(name: str) -> str | None:
+    """The page a person said is the one this score was made from."""
+    return (_reviewed(name).get("source_override") or {}).get("pdf")
 
 OUT = Path("implode-report")
 #: Wide enough to read a notehead, small enough to open on a phone.
@@ -60,7 +73,7 @@ def made_a_video(folder: str) -> dict | None:
     return {"videos": len(videos), "uploads": uploads, "stage": stage}
 
 
-def printed_pdf(folder: str) -> Path | None:
+def printed_pdf(folder: str, chosen: str | None = None) -> Path | None:
     """The scan the song was made from, not one of the app's own renders.
 
     The app caches MuseScore renders of the cleaned score beside the source as
@@ -68,6 +81,9 @@ def printed_pdf(folder: str) -> Path | None:
     accident -- which makes the "printed page" a picture of the reference, and
     the whole comparison a score against itself.
     """
+    if chosen:
+        picked = Path(folder) / chosen
+        return picked if picked.exists() else None
     pages = [
         Path(path)
         for path in sorted(glob.glob(folder + "*.pdf"))
@@ -81,7 +97,7 @@ def songs() -> list[tuple[str, Path, Path, dict]]:
     found = []
     for folder in sorted(glob.glob("songs/*/")):
         cleaned = glob.glob(folder + "*_cleaned.mscx")
-        pdf = printed_pdf(folder)
+        pdf = printed_pdf(folder, chosen_pdf(Path(folder).name))
         made = made_a_video(folder)
         if cleaned and pdf and made:
             found.append((Path(folder).name, pdf, Path(sorted(cleaned)[0]), made))
@@ -148,7 +164,7 @@ def main() -> None:
         if wanted and name not in wanted:
             continue
         root = etree.parse(str(cleaned)).getroot()
-        found = implode(root, override_for(name))
+        found = implode(root, override_for(name), drop_rests_for(name))
         with tempfile.TemporaryDirectory() as tmp:
             score = Path(tmp) / "imploded.mscx"
             etree.ElementTree(root).write(str(score), encoding="UTF-8", xml_declaration=True)

--- a/scripts/implode_report.py
+++ b/scripts/implode_report.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python3
+"""Show every song's printed page beside the reference imploded out of its score.
+
+The imploded score is what homr will be judged against, so it has to be judged
+first.  Counting staves says the shape is right; only looking says the music is.
+
+    .venv/bin/python scripts/implode_report.py [song ...]
+
+Writes `implode-report/index.html`.  Needs poppler and the MuseScore CLI.
+"""
+
+import glob
+import html
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+from dotenv import load_dotenv
+from lxml import etree
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from src.clean_score.implode import implode  # noqa: E402
+
+OUT = Path("implode-report")
+#: Wide enough to read a notehead, small enough to open on a phone.
+WIDTH = 1500
+
+
+def songs() -> list[tuple[str, Path, Path]]:
+    """Every song with both a printed page and a cleaned score."""
+    found = []
+    for folder in sorted(glob.glob("songs/*/")):
+        cleaned = glob.glob(folder + "*_cleaned.mscx")
+        pdf = glob.glob(folder + "*.pdf")
+        if cleaned and pdf:
+            found.append((Path(folder).name, Path(sorted(pdf)[0]), Path(sorted(cleaned)[0])))
+    return found
+
+
+def _shrink(source: Path, target: Path) -> bool:
+    """One page as a grey JPEG: MuseScore's PNGs are transparent and huge."""
+    result = subprocess.run(
+        ["magick", str(source), "-flatten", "-colorspace", "Gray",
+         "-resize", f"{WIDTH}>", "-quality", "88", str(target)],
+        capture_output=True,
+    )
+    return result.returncode == 0 and target.exists()
+
+
+def printed_page(pdf: Path, target: Path) -> bool:
+    with tempfile.TemporaryDirectory() as tmp:
+        stem = Path(tmp) / "page"
+        subprocess.run(
+            ["pdftoppm", "-r", "150", "-png", "-f", "1", "-l", "1", str(pdf), str(stem)],
+            capture_output=True,
+        )
+        pages = sorted(Path(tmp).glob("page*.png"))
+        return bool(pages) and _shrink(pages[0], target)
+
+
+def engrave(score: Path, cli: str, target: Path) -> bool:
+    with tempfile.TemporaryDirectory() as tmp:
+        rendered = Path(tmp) / "out.png"
+        subprocess.run(
+            [cli, "-o", str(rendered), str(score)], capture_output=True, timeout=300
+        )
+        pages = sorted(Path(tmp).glob("out*.png"))
+        return bool(pages) and _shrink(pages[0], target)
+
+
+STYLE = """
+body { font: 15px/1.6 system-ui, sans-serif; margin: 0 auto; max-width: 1250px;
+       padding: 24px; color: #1a1a1a; background: #fafafa; }
+h1 { font-size: 22px; margin-bottom: 4px; }
+h2 { font-size: 17px; margin: 30px 0 2px; }
+p.lead, p.sub { color: #555; margin-top: 0; }
+p.sub { font-size: 13px; margin-bottom: 8px; }
+.pair { display: grid; grid-template-columns: 1fr 1fr; gap: 10px;
+        background: #fff; border: 1px solid #e2e2e2; border-radius: 8px; padding: 12px; }
+.label { font: 600 11px ui-monospace, Menlo, monospace; letter-spacing: .05em;
+         text-transform: uppercase; color: #777; margin: 0 0 4px; }
+img { display: block; width: 100%; border: 1px solid #eee; background: #fff; }
+.guess { background: #fdefd8; color: #8a5a10; border-radius: 4px;
+         padding: 1px 6px; font-size: 12px; font-weight: 600; }
+.recorded { color: #1c5c2c; font-size: 12px; }
+"""
+
+
+def main() -> None:
+    load_dotenv()
+    cli = os.environ.get("MUSESCORE_CLI_PATH", "")
+    OUT.mkdir(exist_ok=True)
+    wanted = set(sys.argv[1:])
+    sections = []
+    for name, pdf, cleaned in songs():
+        if wanted and name not in wanted:
+            continue
+        root = etree.parse(str(cleaned)).getroot()
+        found = implode(root)
+        with tempfile.TemporaryDirectory() as tmp:
+            score = Path(tmp) / "imploded.mscx"
+            etree.ElementTree(root).write(str(score), encoding="UTF-8", xml_declaration=True)
+            drawn = engrave(score, cli, OUT / f"{name}-imploded.jpg")
+        shown = printed_page(pdf, OUT / f"{name}-page.jpg")
+        badge = (
+            '<span class="guess">grouping guessed</span>'
+            if found.inferred
+            else f'<span class="recorded">grouping from the score\'s own {found.source}</span>'
+        )
+        staves = " &middot; ".join(html.escape(printed.label) for printed in found.printed)
+        sections.append(
+            f"""<h2>{html.escape(name)}</h2>
+<p class="sub">{badge} &mdash; {len(found.printed)} printed staves: {staves}</p>
+<div class="pair">
+  <div><p class="label">the printed page</p>
+    {f'<img src="{name}-page.jpg" alt="printed page">' if shown else "<p>no page</p>"}</div>
+  <div><p class="label">imploded out of the cleaned score</p>
+    {f'<img src="{name}-imploded.jpg" alt="imploded score">' if drawn else "<p>not engraved</p>"}</div>
+</div>"""
+        )
+        print(f"{name}: {'guessed' if found.inferred else found.source}, {len(found.printed)} staves")
+    page = f"""<!doctype html>
+<html lang="en"><head><meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Imploded references</title><style>{STYLE}</style></head><body>
+<h1>Imploded references</h1>
+<p class="lead">Each song's printed page beside the reference imploded out of its
+cleaned score &mdash; the voices the app split apart put back on the staves they
+were printed on. This is what homr would be judged against, so it has to be right
+first. Where the score did not record which voices shared a staff, the grouping is
+<span class="guess">guessed</span> and should be checked hardest.</p>
+{''.join(sections)}
+</body></html>"""
+    (OUT / "index.html").write_text(page)
+    print(OUT / "index.html")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/implode_report.py
+++ b/scripts/implode_report.py
@@ -24,6 +24,7 @@ from lxml import etree
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
 from src.clean_score.implode import implode  # noqa: E402
+from scripts.reference_manifest import manifest, reference_files  # noqa: E402
 
 MANIFEST = Path("fixtures/omr-songs.json")
 
@@ -97,7 +98,7 @@ def printed_pdf(folder: str, chosen: str | None = None) -> Path | None:
     return pages[0] if pages else None
 
 
-def songs(with_excluded: bool = False) -> list[tuple[str, Path, Path, dict]]:
+def candidate_songs(with_excluded: bool = False) -> list[tuple[str, Path, Path, dict]]:
     """Every song with a printed page, a cleaned score and a practice video.
 
     A song a review has thrown out is left out, except for the manifest, which
@@ -113,6 +114,17 @@ def songs(with_excluded: bool = False) -> list[tuple[str, Path, Path, dict]]:
         made = made_a_video(folder)
         if cleaned and pdf and made:
             found.append((name, pdf, Path(sorted(cleaned)[0]), made))
+    return found
+
+
+def songs(with_excluded: bool = False) -> list[tuple[str, Path, Path, dict]]:
+    """The reviewed set, using only the exact files recorded in the manifest."""
+    found = []
+    for name, entry in manifest().items():
+        if entry["review"]["status"] == "excluded" and not with_excluded:
+            continue
+        sources = reference_files(name)
+        found.append((name, sources.pdf, sources.cleaned, entry["video"]))
     return found
 
 

--- a/scripts/make_stem_fixture.py
+++ b/scripts/make_stem_fixture.py
@@ -19,7 +19,6 @@ worktree's `fixtures/`), and prints the entry to add to
 """
 
 import argparse
-import glob
 import json
 import os
 import subprocess
@@ -33,10 +32,10 @@ from lxml import etree
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
 from scripts.implode_report import drop_rests_for, override_for  # noqa: E402
+from scripts.reference_manifest import reference_files  # noqa: E402
 from src.clean_score.implode import implode  # noqa: E402
 from src.song_app import pdf_systems  # noqa: E402
 
-MANIFEST = Path("fixtures/omr-songs.json")
 FIXTURES = Path(os.environ.get("HOMR_FIXTURES",
                                "/var/home/eero/homr-trees/system-4/fixtures"))
 #: What the fixture pictures are cropped at. The existing ones are a few hundred
@@ -83,9 +82,9 @@ def main() -> None:
     args = parser.parse_args()
 
     name = args.name or f"{args.slug}-s{args.system}"
-    listed = json.loads(MANIFEST.read_text())["songs"][args.slug]
     song_dir = f"songs/{args.slug}"
-    pdf = str(Path(song_dir) / listed["pdf"])
+    sources = reference_files(args.slug)
+    pdf = str(sources.pdf)
 
     bands = {b.index: b for b in pdf_systems.load_bounds(song_dir)}
     band = bands[args.system]
@@ -99,8 +98,7 @@ def main() -> None:
         picture = FIXTURES / f"{name}.png"
         picture.write_bytes(Path(image.path).read_bytes())
 
-        cleaned = sorted(glob.glob(f"{song_dir}/*_cleaned.mscx"))[0]
-        root = etree.parse(cleaned).getroot()
+        root = etree.parse(str(sources.cleaned)).getroot()
         implode(root, override_for(args.slug), drop_rests_for(args.slug))
         trim(root, band.measure_start, band.measure_end)
         score = Path(tmp) / f"{name}.mscx"

--- a/scripts/make_stem_fixture.py
+++ b/scripts/make_stem_fixture.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+"""Cut one printed system out of a song and write it as a homr stem fixture.
+
+A fixture is a picture of one printed system and a reference MusicXML saying
+what that system actually holds, note by note, with MuseScore's own engraving
+coordinates -- that is what lets the fixture matcher line a detected notehead up
+with a printed one without rendering anything.
+
+Both halves come from work already done here: the picture is the band a person
+drew in the Systems editor, cropped straight off the PDF, and the reference is
+the cleaned score imploded back to the shape of the print, trimmed to that band's
+bars.  So the fixture says what the page says, not what any parse said.
+
+    .venv/bin/python scripts/make_stem_fixture.py laulun-aika-3 2 --name laulun-aika-s2
+
+Writes `<HOMR_FIXTURES>/<name>.png` and `.musicxml` (default: the system-4
+worktree's `fixtures/`), and prints the entry to add to
+`stem-direction-fixtures.json`.
+"""
+
+import argparse
+import glob
+import json
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+from dotenv import load_dotenv
+from lxml import etree
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from scripts.implode_report import drop_rests_for, override_for  # noqa: E402
+from src.clean_score.implode import implode  # noqa: E402
+from src.song_app import pdf_systems  # noqa: E402
+
+MANIFEST = Path("fixtures/omr-songs.json")
+FIXTURES = Path(os.environ.get("HOMR_FIXTURES",
+                               "/var/home/eero/homr-trees/system-4/fixtures"))
+#: What the fixture pictures are cropped at. The existing ones are a few hundred
+#: pixels tall, and homr's staff detection wants the staff lines resolved rather
+#: than the page legible.
+FIXTURE_DPI = 200
+
+#: Carried forward into the trimmed score: a system that does not start the piece
+#: prints no clef, key or meter of its own, but a score that opens there needs
+#: all three or every pitch in the reference is read against the wrong staff.
+CARRIED = ("Clef", "KeySig", "TimeSig")
+
+
+def trim(root: etree._Element, start: int, end: int) -> None:
+    """Keep only bars `start`..`end`, with the state they inherit written in."""
+    for staff in root.find("Score").findall("Staff"):
+        bars = staff.findall("Measure")
+        carried = {}
+        for bar in bars[:start - 1]:
+            for tag in CARRIED:
+                for found in bar.iter(tag):
+                    carried[tag] = found
+        keep = bars[start - 1:end]
+        for bar in bars:
+            if bar not in keep:
+                staff.remove(bar)
+        if not keep:
+            continue
+        voice = keep[0].find("voice")
+        if voice is None:
+            voice = etree.SubElement(keep[0], "voice")
+        for offset, tag in enumerate(CARRIED):
+            if keep[0].find(f".//{tag}") is None and tag in carried:
+                voice.insert(offset, carried[tag])
+
+
+def main() -> None:
+    load_dotenv()
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("slug")
+    parser.add_argument("system", type=int)
+    parser.add_argument("--name", default="")
+    parser.add_argument("--dpi", type=int, default=FIXTURE_DPI)
+    args = parser.parse_args()
+
+    name = args.name or f"{args.slug}-s{args.system}"
+    listed = json.loads(MANIFEST.read_text())["songs"][args.slug]
+    song_dir = f"songs/{args.slug}"
+    pdf = str(Path(song_dir) / listed["pdf"])
+
+    bands = {b.index: b for b in pdf_systems.load_bounds(song_dir)}
+    band = bands[args.system]
+    if not band.measure_start:
+        raise SystemExit(f"System {args.system} has no measure range; label the "
+                         "bounds against the score first.")
+
+    FIXTURES.mkdir(parents=True, exist_ok=True)
+    with tempfile.TemporaryDirectory() as tmp:
+        image = pdf_systems.crop_systems(pdf, [band], tmp, dpi=args.dpi)[0]
+        picture = FIXTURES / f"{name}.png"
+        picture.write_bytes(Path(image.path).read_bytes())
+
+        cleaned = sorted(glob.glob(f"{song_dir}/*_cleaned.mscx"))[0]
+        root = etree.parse(cleaned).getroot()
+        implode(root, override_for(args.slug), drop_rests_for(args.slug))
+        trim(root, band.measure_start, band.measure_end)
+        score = Path(tmp) / f"{name}.mscx"
+        etree.ElementTree(root).write(str(score), encoding="UTF-8",
+                                      xml_declaration=True)
+        out = FIXTURES / f"{name}.musicxml"
+        cli = os.environ.get("MUSESCORE_CLI_PATH", "musescore3")
+        result = subprocess.run([cli, str(score), "-o", str(out)],
+                                capture_output=True, text=True, timeout=300)
+        if result.returncode != 0 or not out.exists():
+            raise SystemExit(f"MuseScore could not export the reference:\n"
+                             f"{result.stderr[-800:]}")
+
+    print(f"{picture}\n{out}")
+    print("\nAdd to fixtures/stem-direction-fixtures.json:\n")
+    print(json.dumps({name: {"image": picture.name, "reference": out.name,
+                             "known_gaps": []}}, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/propose_bounds.py
+++ b/scripts/propose_bounds.py
@@ -10,7 +10,6 @@ open each song's Systems tab and correct what the finder got wrong.
     .venv/bin/python scripts/propose_bounds.py <slug> [<slug> ...]
 """
 
-import json
 import os
 import sys
 from pathlib import Path
@@ -20,8 +19,7 @@ from dotenv import load_dotenv
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
 from src.song_app import pdf_systems, pipeline, state, system_finder  # noqa: E402
-
-MANIFEST = Path("fixtures/omr-songs.json")
+from scripts.reference_manifest import reference_files  # noqa: E402
 
 
 def bounds_score(song) -> str:
@@ -39,10 +37,9 @@ def main() -> None:
     # The page a fixture is checked against is the manifest's, not whichever
     # PDF the song folder happens to name first: which one was the printed page
     # has twice been the thing that was wrong.
-    listed = json.loads(MANIFEST.read_text())["songs"]
     for slug in sys.argv[1:]:
         song = state.load(slug)
-        pdf = os.path.join(song.dir, listed[slug]["pdf"])
+        pdf = str(reference_files(slug).pdf)
         print(f"== {slug}: {os.path.basename(pdf)}", flush=True)
         bands = system_finder.find_bands(pdf, log=lambda m: print("  " + m, flush=True))
         saved = pipeline.save_system_bounds(

--- a/scripts/propose_bounds.py
+++ b/scripts/propose_bounds.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+"""Propose the printed-system bands for a song and save them.
+
+The app deliberately never writes `.systems.json` on its own -- `find-systems`
+hands the proposal to the Systems editor unsaved, so a person drags before
+anything is recorded.  This is the same proposal written straight to the file,
+for songs being prepared as OMR fixtures in bulk; **the drag is still owed**, so
+open each song's Systems tab and correct what the finder got wrong.
+
+    .venv/bin/python scripts/propose_bounds.py <slug> [<slug> ...]
+"""
+
+import json
+import os
+import sys
+from pathlib import Path
+
+from dotenv import load_dotenv
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from src.song_app import pdf_systems, pipeline, state, system_finder  # noqa: E402
+
+MANIFEST = Path("fixtures/omr-songs.json")
+
+
+def bounds_score(song) -> str:
+    xml = song.source_path("xml")
+    if not xml or not os.path.exists(xml):
+        return ""
+    try:
+        return pipeline.convert_to_mscx(xml, song.dir)
+    except Exception:
+        return ""
+
+
+def main() -> None:
+    load_dotenv()
+    # The page a fixture is checked against is the manifest's, not whichever
+    # PDF the song folder happens to name first: which one was the printed page
+    # has twice been the thing that was wrong.
+    listed = json.loads(MANIFEST.read_text())["songs"]
+    for slug in sys.argv[1:]:
+        song = state.load(slug)
+        pdf = os.path.join(song.dir, listed[slug]["pdf"])
+        print(f"== {slug}: {os.path.basename(pdf)}", flush=True)
+        bands = system_finder.find_bands(pdf, log=lambda m: print("  " + m, flush=True))
+        saved = pipeline.save_system_bounds(
+            song.dir, [b.to_dict() for b in bands], bounds_score(song)
+        )
+        labelled = sum(1 for b in saved if b.get("measure_start"))
+        print(f"   saved {len(saved)} bands to {pdf_systems.BOUNDS_FILE}"
+              f" ({labelled} labelled with a measure range)", flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/reference_manifest.py
+++ b/scripts/reference_manifest.py
@@ -1,0 +1,42 @@
+"""Resolve and verify the files approved as OMR references."""
+
+import hashlib
+import json
+from dataclasses import dataclass
+from pathlib import Path
+
+MANIFEST = Path("fixtures/omr-songs.json")
+SONGS = Path("songs")
+
+
+@dataclass(frozen=True)
+class ReferenceFiles:
+    pdf: Path
+    cleaned: Path
+
+
+def manifest() -> dict:
+    return json.loads(MANIFEST.read_text())["songs"]
+
+
+def _verified(slug: str, entry: dict, kind: str) -> Path:
+    path = SONGS / slug / entry[kind]
+    if not path.is_file():
+        raise FileNotFoundError(f"{slug}: reviewed {kind} is missing: {path}")
+    actual = hashlib.sha256(path.read_bytes()).hexdigest()[:16]
+    expected = entry[f"{kind}_sha256"]
+    if actual != expected:
+        raise ValueError(
+            f"{slug}: reviewed {kind} changed: {path} has {actual}, expected "
+            f"{expected}; regenerate fixtures/omr-songs.json and review it again"
+        )
+    return path
+
+
+def reference_files(slug: str) -> ReferenceFiles:
+    """Return the exact reviewed files, refusing stale manifest entries."""
+    entry = manifest()[slug]
+    return ReferenceFiles(
+        pdf=_verified(slug, entry, "pdf"),
+        cleaned=_verified(slug, entry, "cleaned"),
+    )

--- a/scripts/scan_references.py
+++ b/scripts/scan_references.py
@@ -50,6 +50,12 @@ def stage_a_copy(slug: str, root: Path) -> None:
         # of them is 4 MB.
         os.symlink(os.path.abspath(real / pdf), target)
     shutil.copy(real / pdf_systems.BOUNDS_FILE, here / pdf_systems.BOUNDS_FILE)
+    # The state file is where the fragments already read are recorded, so
+    # rewriting it is throwing away the scan: the MusicXML stays on disk but
+    # nothing knows it is there, and every band is read again. Bands that really
+    # did move are `reconcile`'s business, not this script's.
+    if (here / ".song.json").exists():
+        return
     (here / ".song.json").write_text(json.dumps({
         "name": slug, "stage": "scan", "sources": {"pdf": pdf},
     }, indent=2, ensure_ascii=False))
@@ -71,8 +77,10 @@ def main() -> None:
         result = scan.run(song, log=lambda m: print("  " + m, flush=True))
         took = time.time() - began
         holes = result.get("holes") or []
-        print(f"  -> {len(result.get('systems') or [])} systems, "
-              f"{len(holes)} hole(s) {holes}, {took:.0f}s", flush=True)
+        print(f"  -> {result['read']} of {result['systems']} systems read, "
+              f"{len(holes)} hole(s) {holes}, "
+              f"{'assembled' if result['complete'] else 'NOT assembled'}, "
+              f"{took:.0f}s", flush=True)
 
 
 if __name__ == "__main__":

--- a/scripts/scan_references.py
+++ b/scripts/scan_references.py
@@ -8,10 +8,15 @@ under `scan-eval/` holding a link to its PDF and a copy of its reviewed
 `.systems.json`, and that is what is scanned.  What comes out is the same
 `scanned.musicxml` the app would produce, next to a reference nobody scanned.
 
-    .venv/bin/python scripts/scan_references.py            # every song in the set
-    .venv/bin/python scripts/scan_references.py <slug> ...
+**Which homr reads it is the point**, so it is named rather than defaulted, and
+the results are kept under the engine that produced them: the installed venv is
+whatever was frozen there, and a working copy is the fork's branch being tried.
+Two engines over the same songs is the comparison this exists to make.
 
-Writes `scan-eval/<slug>/`, and prints a line per system.
+    .venv/bin/python scripts/scan_references.py --engine system-4
+    .venv/bin/python scripts/scan_references.py --engine default <slug> ...
+
+Writes `scan-eval/<engine>/<slug>/`, and prints a line per system.
 """
 
 import json
@@ -25,7 +30,7 @@ from dotenv import load_dotenv
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
-from src.song_app import pdf_systems, scan, state  # noqa: E402
+from src.song_app import omr, pdf_systems, scan, state  # noqa: E402
 
 MANIFEST = Path("fixtures/omr-songs.json")
 SCRATCH = Path("scan-eval")
@@ -63,8 +68,17 @@ def stage_a_copy(slug: str, root: Path) -> None:
 
 def main() -> None:
     load_dotenv()
-    slugs = sys.argv[1:] or in_the_set()
-    root = SCRATCH.resolve()
+    argv = sys.argv[1:]
+    key = omr.DEFAULT_ENGINE
+    if "--engine" in argv:
+        at = argv.index("--engine")
+        key = argv[at + 1]
+        argv = argv[:at] + argv[at + 2:]
+    engine = None if key == omr.DEFAULT_ENGINE else omr.engine_for(key)
+    print(f"reading with: {key} -- "
+          f"{engine.label if engine else omr.engines()[0].label}", flush=True)
+    slugs = argv or in_the_set()
+    root = (SCRATCH / key).resolve()
     for slug in slugs:
         stage_a_copy(slug, root)
 
@@ -74,7 +88,8 @@ def main() -> None:
         print(f"\n===== {slug}", flush=True)
         began = time.time()
         song = state.load(slug)
-        result = scan.run(song, log=lambda m: print("  " + m, flush=True))
+        result = scan.run(song, log=lambda m: print("  " + m, flush=True),
+                          engine=engine)
         took = time.time() - began
         holes = result.get("holes") or []
         print(f"  -> {result['read']} of {result['systems']} systems read, "

--- a/scripts/scan_references.py
+++ b/scripts/scan_references.py
@@ -31,13 +31,13 @@ from dotenv import load_dotenv
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
 from src.song_app import omr, pdf_systems, scan, state  # noqa: E402
+from scripts.reference_manifest import manifest, reference_files  # noqa: E402
 
-MANIFEST = Path("fixtures/omr-songs.json")
 SCRATCH = Path("scan-eval")
 
 
 def in_the_set() -> list[str]:
-    listed = json.loads(MANIFEST.read_text())["songs"]
+    listed = manifest()
     return [name for name, entry in listed.items()
             if entry["review"]["status"] != "excluded"]
 
@@ -45,15 +45,15 @@ def in_the_set() -> list[str]:
 def stage_a_copy(slug: str, root: Path) -> None:
     """A song holding nothing but the page and the bands drawn on it."""
     real = Path("songs") / slug
-    listed = json.loads(MANIFEST.read_text())["songs"][slug]
-    pdf = listed["pdf"]
+    sources = reference_files(slug)
+    pdf = sources.pdf.name
     here = root / slug
     here.mkdir(parents=True, exist_ok=True)
     target = here / pdf
     if not target.exists():
         # A link, not a copy: these are scans of in-copyright editions and one
         # of them is 4 MB.
-        os.symlink(os.path.abspath(real / pdf), target)
+        os.symlink(os.path.abspath(sources.pdf), target)
     shutil.copy(real / pdf_systems.BOUNDS_FILE, here / pdf_systems.BOUNDS_FILE)
     # The state file is where the fragments already read are recorded, so
     # rewriting it is throwing away the scan: the MusicXML stays on disk but

--- a/scripts/scan_references.py
+++ b/scripts/scan_references.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+"""Read each reference song's page with homr, into a scratch song of its own.
+
+The six reference songs are finished work -- recorded, uploaded, sung -- and the
+scan stage writes into the song it scans and can put it back on `scan` when a
+band comes back a hole.  So none of this touches them: each gets a throwaway song
+under `scan-eval/` holding a link to its PDF and a copy of its reviewed
+`.systems.json`, and that is what is scanned.  What comes out is the same
+`scanned.musicxml` the app would produce, next to a reference nobody scanned.
+
+    .venv/bin/python scripts/scan_references.py            # every song in the set
+    .venv/bin/python scripts/scan_references.py <slug> ...
+
+Writes `scan-eval/<slug>/`, and prints a line per system.
+"""
+
+import json
+import os
+import shutil
+import sys
+import time
+from pathlib import Path
+
+from dotenv import load_dotenv
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from src.song_app import pdf_systems, scan, state  # noqa: E402
+
+MANIFEST = Path("fixtures/omr-songs.json")
+SCRATCH = Path("scan-eval")
+
+
+def in_the_set() -> list[str]:
+    listed = json.loads(MANIFEST.read_text())["songs"]
+    return [name for name, entry in listed.items()
+            if entry["review"]["status"] != "excluded"]
+
+
+def stage_a_copy(slug: str, root: Path) -> None:
+    """A song holding nothing but the page and the bands drawn on it."""
+    real = Path("songs") / slug
+    listed = json.loads(MANIFEST.read_text())["songs"][slug]
+    pdf = listed["pdf"]
+    here = root / slug
+    here.mkdir(parents=True, exist_ok=True)
+    target = here / pdf
+    if not target.exists():
+        # A link, not a copy: these are scans of in-copyright editions and one
+        # of them is 4 MB.
+        os.symlink(os.path.abspath(real / pdf), target)
+    shutil.copy(real / pdf_systems.BOUNDS_FILE, here / pdf_systems.BOUNDS_FILE)
+    (here / ".song.json").write_text(json.dumps({
+        "name": slug, "stage": "scan", "sources": {"pdf": pdf},
+    }, indent=2, ensure_ascii=False))
+
+
+def main() -> None:
+    load_dotenv()
+    slugs = sys.argv[1:] or in_the_set()
+    root = SCRATCH.resolve()
+    for slug in slugs:
+        stage_a_copy(slug, root)
+
+    # Every song here is one of these throwaways, so nothing real is in reach.
+    state.SONGS_DIR = str(root)
+    for slug in slugs:
+        print(f"\n===== {slug}", flush=True)
+        began = time.time()
+        song = state.load(slug)
+        result = scan.run(song, log=lambda m: print("  " + m, flush=True))
+        took = time.time() - began
+        holes = result.get("holes") or []
+        print(f"  -> {len(result.get('systems') or [])} systems, "
+              f"{len(holes)} hole(s) {holes}, {took:.0f}s", flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/scan_report.py
+++ b/scripts/scan_report.py
@@ -32,6 +32,7 @@ from dotenv import load_dotenv
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
 from scripts.implode_report import _shrink  # noqa: E402
+from scripts.reference_manifest import manifest, reference_files  # noqa: E402
 from scripts.scan_vs_reference import (  # noqa: E402
     SCRATCH,
     printed_staves,
@@ -41,7 +42,6 @@ from scripts.scan_vs_reference import (  # noqa: E402
 )
 from src.song_app import pdf_systems, pipeline  # noqa: E402
 
-MANIFEST = Path("fixtures/omr-songs.json")
 OUT = Path("scan-report")
 
 STYLE = """
@@ -75,7 +75,7 @@ def picture(name: str, source: str) -> str:
 
 def main() -> None:
     load_dotenv()
-    listed = json.loads(MANIFEST.read_text())["songs"]
+    listed = manifest()
     argv = sys.argv[1:]
     against = ""
     if "--against" in argv:
@@ -96,7 +96,7 @@ def main() -> None:
                             f"<p class=\"sub\">not scanned yet</p>")
             continue
         song_dir = f"songs/{slug}"
-        pdf = str(Path(song_dir) / listed[slug]["pdf"])
+        pdf = str(reference_files(slug).pdf)
         bands = pdf_systems.load_bounds(song_dir)
         reference = reference_systems(slug, bands)
         printed = printed_staves(slug, bands)

--- a/scripts/scan_report.py
+++ b/scripts/scan_report.py
@@ -10,7 +10,13 @@ homr read it, engraved.
 Runs on whatever has been scanned so far, so it can be built while the rest is
 still going.
 
-    .venv/bin/python scripts/scan_report.py [<slug> ...]
+    .venv/bin/python scripts/scan_report.py --engine system-4 [<slug> ...]
+    .venv/bin/python scripts/scan_report.py --engine system-4 --against default ...
+
+With `--against`, each system carries both engines' parses under the same band,
+which is the only way to see what a change to homr actually did to the music: the
+counts come out equal while one writes a staff of two singers as stacked chords
+and the other as two voices.
 
 Writes `scan-report/index.html`.
 """
@@ -29,6 +35,7 @@ from scripts.implode_report import _shrink  # noqa: E402
 from scripts.scan_vs_reference import (  # noqa: E402
     SCRATCH,
     printed_staves,
+    read_with,
     reference_systems,
     scanned_systems,
 )
@@ -69,13 +76,22 @@ def picture(name: str, source: str) -> str:
 def main() -> None:
     load_dotenv()
     listed = json.loads(MANIFEST.read_text())["songs"]
-    slugs = sys.argv[1:] or [n for n, e in listed.items()
+    argv = sys.argv[1:]
+    against = ""
+    if "--against" in argv:
+        at = argv.index("--against")
+        against = argv[at + 1]
+        argv = argv[:at] + argv[at + 2:]
+    key, argv = read_with(argv)
+    root = SCRATCH / key
+    other = SCRATCH / against if against else None
+    slugs = argv or [n for n, e in listed.items()
                              if e["review"]["status"] != "excluded"]
     OUT.mkdir(exist_ok=True)
 
     sections, done, agree_staves, agree_bars, holes = [], 0, 0, 0, 0
     for slug in slugs:
-        if not (SCRATCH / slug / ".song.json").exists():
+        if not (root / slug / ".song.json").exists():
             sections.append(f"<h2>{html.escape(slug)}</h2>"
                             f"<p class=\"sub\">not scanned yet</p>")
             continue
@@ -88,7 +104,8 @@ def main() -> None:
             for want, count in zip(reference, printed):
                 if want:
                     want["staves"] = count
-        scanned = scanned_systems(slug)
+        scanned = scanned_systems(slug, root)
+        rival = scanned_systems(slug, other) if other else {}
 
         rows = []
         for band, want in zip(bands, reference):
@@ -118,15 +135,18 @@ def main() -> None:
             same_bars = want.get("bars") == got.get("bars")
             agree_staves += same_staves
             agree_bars += same_bars
-            engraved = ""
-            entry = json.loads((SCRATCH / slug / ".song.json").read_text())
-            frag = entry["scan"]["systems"][str(band.index)]["musicxml"]
-            try:
-                png = pipeline.scan_system_render(str(SCRATCH / slug),
-                                                  str(SCRATCH / slug / frag))
-                engraved = picture(f"{slug}-{band.index:02}-scan.jpg", png)
-            except Exception:
-                engraved = ""
+            def engrave(where, tag: str) -> str:
+                try:
+                    entry = json.loads((where / slug / ".song.json").read_text())
+                    frag = entry["scan"]["systems"][str(band.index)]["musicxml"]
+                    png = pipeline.scan_system_render(str(where / slug),
+                                                      str(where / slug / frag))
+                    return picture(f"{slug}-{band.index:02}-{tag}.jpg", png)
+                except Exception:
+                    return ""
+
+            engraved = engrave(root, key)
+            rival_png = engrave(other, against) if other else ""
 
             tags = []
             tags.append(f'<span class="tag {"same" if same_staves else "off"}">'
@@ -144,9 +164,14 @@ def main() -> None:
                 f'&ndash;{band.measure_end}</span>{"".join(tags)}</div>'
                 + (f'<p class="cap">the printed band</p><img src="{crop}" alt="printed">'
                    if crop else "")
-                + (f'<p class="cap">what homr read off it</p>'
+                + (f'<p class="cap">read by <b>{html.escape(key)}</b>'
+                   f' &mdash; {got.get("voices")} voice(s), page has'
+                   f' {want.get("voices")}</p>'
                    f'<img src="{engraved}" alt="scan">' if engraved else
-                   '<p class="cap">(could not engrave the parse)</p>'))
+                   '<p class="cap">(could not engrave the parse)</p>')
+                + (f'<p class="cap">read by <b>{html.escape(against)}</b>'
+                   f' &mdash; {(rival.get(band.index) or {}).get("voices")} voice(s)</p>'
+                   f'<img src="{rival_png}" alt="other scan">' if rival_png else ""))
         sections.append(
             f"<h2>{html.escape(listed[slug].get('review', {}).get('notes') or slug)}</h2>"
             f"<p class=\"sub\">{html.escape(slug)} &mdash; {len(rows)} of "

--- a/scripts/scan_report.py
+++ b/scripts/scan_report.py
@@ -1,0 +1,175 @@
+#!/usr/bin/env python3
+"""The scan against the page, system by system, as a page you can look at.
+
+`scan_vs_reference.py` gives the numbers; this puts the picture beside them,
+because a system that agrees on staves, bars and notes can still be wrong about
+every pitch, and nothing counted here would say so.  Each row is one printed
+system: the band cropped out of the original PDF, and under it the same system as
+homr read it, engraved.
+
+Runs on whatever has been scanned so far, so it can be built while the rest is
+still going.
+
+    .venv/bin/python scripts/scan_report.py [<slug> ...]
+
+Writes `scan-report/index.html`.
+"""
+
+import glob
+import html
+import json
+import sys
+from pathlib import Path
+
+from dotenv import load_dotenv
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from scripts.implode_report import _shrink  # noqa: E402
+from scripts.scan_vs_reference import (  # noqa: E402
+    SCRATCH,
+    printed_staves,
+    reference_systems,
+    scanned_systems,
+)
+from src.song_app import pdf_systems, pipeline  # noqa: E402
+
+MANIFEST = Path("fixtures/omr-songs.json")
+OUT = Path("scan-report")
+
+STYLE = """
+body { font: 15px/1.6 system-ui, sans-serif; margin: 0 auto; max-width: 1100px;
+       padding: 24px; color: #1a1a1a; background: #fafafa; }
+h1 { font-size: 23px; margin-bottom: 4px; }
+h2 { font-size: 18px; margin: 34px 0 4px; }
+p.lead, p.sub { color: #555; margin-top: 0; }
+p.sub { font-size: 13px; }
+.sys { border: 1px solid #e2e2e2; background: #fff; border-radius: 8px;
+       padding: 12px 14px; margin-bottom: 14px; }
+.head { display: flex; gap: 10px; align-items: baseline; flex-wrap: wrap;
+        margin-bottom: 8px; }
+.who { font-weight: 600; }
+.num { color: #555; font-size: 13px; }
+.tag { border-radius: 4px; padding: 1px 7px; font-size: 12px; font-weight: 600; }
+.same { background: #e8f4ea; color: #1c5c2c; }
+.off  { background: #fdecec; color: #8a1f1f; }
+.hole { background: #fff3cd; color: #7a5b00; }
+img { display: block; width: 100%; border: 1px solid #eee; border-radius: 4px;
+      margin-bottom: 6px; background: #fff; }
+.cap { color: #777; font-size: 12px; margin: 0 0 8px; }
+"""
+
+
+def picture(name: str, source: str) -> str:
+    """Shrink one image into the report folder; '' when it could not be made."""
+    target = OUT / name
+    return target.name if _shrink(Path(source), target) else ""
+
+
+def main() -> None:
+    load_dotenv()
+    listed = json.loads(MANIFEST.read_text())["songs"]
+    slugs = sys.argv[1:] or [n for n, e in listed.items()
+                             if e["review"]["status"] != "excluded"]
+    OUT.mkdir(exist_ok=True)
+
+    sections, done, agree_staves, agree_bars, holes = [], 0, 0, 0, 0
+    for slug in slugs:
+        if not (SCRATCH / slug / ".song.json").exists():
+            sections.append(f"<h2>{html.escape(slug)}</h2>"
+                            f"<p class=\"sub\">not scanned yet</p>")
+            continue
+        song_dir = f"songs/{slug}"
+        pdf = str(Path(song_dir) / listed[slug]["pdf"])
+        bands = pdf_systems.load_bounds(song_dir)
+        reference = reference_systems(slug, bands)
+        printed = printed_staves(slug, bands)
+        if printed:
+            for want, count in zip(reference, printed):
+                if want:
+                    want["staves"] = count
+        scanned = scanned_systems(slug)
+
+        rows = []
+        for band, want in zip(bands, reference):
+            got = scanned.get(band.index)
+            if got is None:
+                continue
+            done += 1
+            crop = ""
+            try:
+                image = pdf_systems.crop_systems(pdf, [band], str(OUT / ".crops"))[0]
+                crop = picture(f"{slug}-{band.index:02}-page.jpg", image.path)
+            except Exception:
+                crop = ""
+            if got.get("error"):
+                holes += 1
+                rows.append(
+                    f'<div class="sys"><div class="head">'
+                    f'<span class="who">System {band.index}</span>'
+                    f'<span class="num">page {band.page}, bars '
+                    f'{want.get("measure","")}{want.get("bars","?")} in the score</span>'
+                    f'<span class="tag hole">could not be read</span></div>'
+                    + (f'<img src="{crop}" alt="printed system">' if crop else "")
+                    + f'<p class="cap">{html.escape(got["error"][:300])}</p></div>')
+                continue
+
+            same_staves = want.get("staves") == got.get("staves")
+            same_bars = want.get("bars") == got.get("bars")
+            agree_staves += same_staves
+            agree_bars += same_bars
+            engraved = ""
+            entry = json.loads((SCRATCH / slug / ".song.json").read_text())
+            frag = entry["scan"]["systems"][str(band.index)]["musicxml"]
+            try:
+                png = pipeline.scan_system_render(str(SCRATCH / slug),
+                                                  str(SCRATCH / slug / frag))
+                engraved = picture(f"{slug}-{band.index:02}-scan.jpg", png)
+            except Exception:
+                engraved = ""
+
+            tags = []
+            tags.append(f'<span class="tag {"same" if same_staves else "off"}">'
+                        f'{got.get("staves")} staves, page prints {want.get("staves")}</span>')
+            tags.append(f'<span class="tag {"same" if same_bars else "off"}">'
+                        f'{got.get("bars")} bars, page has {want.get("bars")}</span>')
+            gap = (got.get("notes") or 0) - (want.get("notes") or 0)
+            tags.append(f'<span class="tag {"same" if gap == 0 else "off"}">'
+                        f'{got.get("notes")} noteheads, reference has {want.get("notes")}'
+                        f'{"" if gap == 0 else f" ({gap:+d})"}</span>')
+            rows.append(
+                f'<div class="sys"><div class="head">'
+                f'<span class="who">System {band.index}</span>'
+                f'<span class="num">page {band.page}, bars {band.measure_start}'
+                f'&ndash;{band.measure_end}</span>{"".join(tags)}</div>'
+                + (f'<p class="cap">the printed band</p><img src="{crop}" alt="printed">'
+                   if crop else "")
+                + (f'<p class="cap">what homr read off it</p>'
+                   f'<img src="{engraved}" alt="scan">' if engraved else
+                   '<p class="cap">(could not engrave the parse)</p>'))
+        sections.append(
+            f"<h2>{html.escape(listed[slug].get('review', {}).get('notes') or slug)}</h2>"
+            f"<p class=\"sub\">{html.escape(slug)} &mdash; {len(rows)} of "
+            f"{len(bands)} systems read</p>" + "".join(rows))
+
+    page = f"""<!doctype html>
+<html lang="en"><head><meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>The scan against the page</title><style>{STYLE}</style></head><body>
+<h1>The scan against the page</h1>
+<p class="lead">Each printed system as it is on paper, and under it the same
+system as homr read it. The counts are a first look and not a score: staves and
+bars come off the score's own line breaks, noteheads off the imploded reference.
+A system can agree on all three and still be wrong about every pitch, which is
+what the pictures are for.</p>
+<p class="sub">{done} systems read so far &mdash; {agree_staves} with the staves
+the page prints, {agree_bars} with its bars, {holes} unread.</p>
+{''.join(sections)}
+</body></html>"""
+    target = OUT / "index.html"
+    target.write_text(page)
+    print(target.resolve())
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/scan_vs_reference.py
+++ b/scripts/scan_vs_reference.py
@@ -32,6 +32,14 @@ MANIFEST = Path("fixtures/omr-songs.json")
 SCRATCH = Path("scan-eval")
 
 
+def read_with(argv: list[str]) -> tuple[str, list[str]]:
+    """Pull `--engine <key>` out of the arguments; results live under it."""
+    if "--engine" not in argv:
+        return "default", argv
+    at = argv.index("--engine")
+    return argv[at + 1], argv[:at] + argv[at + 2:]
+
+
 def printed_staves(slug: str, bands) -> list[int] | None:
     """How many staves each printed system has, off the score's own line breaks.
 
@@ -72,46 +80,66 @@ def reference_systems(slug: str, bands) -> list[dict]:
         if not start:
             out.append({})
             continue
-        printed, notes = 0, 0
+        printed, notes, voices = 0, 0, 0
         for staff in staves:
             bars = staff.findall("Measure")[start - 1:end]
+            # The lines a singer could follow on this staff: an imploded staff
+            # carrying two parts has two <voice> elements in a bar, and one
+            # carrying a chord written for two singers has one. Counting the
+            # most any bar of the system has is what the page shows a reader.
+            voices += max((len(bar.findall("voice")) for bar in bars), default=0)
             # Noteheads, not chords: MusicXML writes one <note> per notehead, so
             # counting `Chord` here would call a two-part chord one note and make
             # every divisi bar look like the scan had invented notes.
             here = sum(len(bar.findall(".//Chord/Note")) for bar in bars)
             notes += here
             printed += 1 if here else 0
-        out.append({"staves": printed, "bars": end - start + 1, "notes": notes})
+        out.append({"staves": printed, "bars": end - start + 1, "notes": notes,
+                    "voices": voices})
     return out
 
 
-def scanned_systems(slug: str) -> dict[int, dict]:
-    state = json.loads((SCRATCH / slug / ".song.json").read_text())
+def scanned_systems(slug: str, root: Path = SCRATCH) -> dict[int, dict]:
+    state = json.loads((root / slug / ".song.json").read_text())
     found = {}
     for entry in (state.get("scan") or {}).get("systems", {}).values():
         index = int(entry["index"])
         if entry.get("error"):
             found[index] = {"error": entry["error"]}
             continue
-        path = SCRATCH / slug / entry["musicxml"]
+        path = root / slug / entry["musicxml"]
         notes = 0
         if path.exists():
             # A <note> holding a <rest> is silence, and the reference counts
             # noteheads: leaving rests in would score a resting bar as full.
             notes = sum(1 for n in etree.parse(str(path)).getroot().iter("note")
                         if n.find("rest") is None)
+        # The part has to be in the key: homr writes a system it could not group
+        # as several one-staff parts, each numbering its own staff 1 voice 1, so
+        # a four-staff system counted as one line without it.
+        seen = set()
+        if path.exists():
+            for part in etree.parse(str(path)).getroot().iter("part"):
+                for note in part.iter("note"):
+                    seen.add((part.get("id"), note.findtext("staff") or "1",
+                              note.findtext("voice") or "1"))
         found[index] = {"staves": entry.get("staves"), "bars": entry.get("bars"),
-                        "notes": notes}
+                        "notes": notes, "voices": len(seen)}
     return found
 
 
 def main() -> None:
     listed = json.loads(MANIFEST.read_text())["songs"]
-    slugs = sys.argv[1:] or [n for n, e in listed.items()
+    key, argv = read_with(sys.argv[1:])
+    root = SCRATCH / key
+    slugs = argv or [n for n, e in listed.items()
                              if e["review"]["status"] != "excluded"]
-    totals = {"systems": 0, "staves_agree": 0, "bars_agree": 0, "holes": 0}
+    totals = {"systems": 0, "staves_agree": 0, "bars_agree": 0, "holes": 0,
+              "notes_exact": 0, "notes_want": 0, "notes_got": 0,
+              "voices_agree": 0}
+    print(f"read with: {key}")
     for slug in slugs:
-        if not (SCRATCH / slug / ".song.json").exists():
+        if not (root / slug / ".song.json").exists():
             print(f"{slug}: not scanned yet"); continue
         bands = pdf_systems.load_bounds(f"songs/{slug}")
         reference = reference_systems(slug, bands)
@@ -120,10 +148,10 @@ def main() -> None:
             for want, count in zip(reference, printed):
                 if want:
                     want["staves"] = count
-        scanned = scanned_systems(slug)
+        scanned = scanned_systems(slug, root)
         print(f"\n== {slug}   (staves the page prints: "
               f"{'the score\'s own line breaks' if printed else 'the imploded reference'})")
-        print("  sys  page | printed staves  bars  notes | read staves  bars  notes")
+        print("  sys  page | page: staves voices  bars notes | read: staves voices  bars notes")
         for band, want in zip(bands, reference):
             got = scanned.get(band.index, {})
             if got.get("error"):
@@ -138,17 +166,26 @@ def main() -> None:
                 flag += " staves"
             if want.get("bars") != got.get("bars"):
                 flag += " bars"
+            if want.get("voices") != got.get("voices"):
+                flag += " voices"
             print(f"  {band.index:3}  p{band.page}    | "
-                  f"{want.get('staves','?'):3} {want.get('bars','?'):11} "
-                  f"{want.get('notes','?'):6} | "
-                  f"{got.get('staves','?'):8} {got.get('bars','?'):6} "
-                  f"{got.get('notes','?'):6}  {flag}")
+                  f"{want.get('staves','?'):11} {want.get('voices','?'):6} "
+                  f"{want.get('bars','?'):5} {want.get('notes','?'):5} | "
+                  f"{got.get('staves','?'):11} {got.get('voices','?'):6} "
+                  f"{got.get('bars','?'):5} {got.get('notes','?'):5}  {flag}")
             totals["systems"] += 1
             totals["staves_agree"] += want.get("staves") == got.get("staves")
             totals["bars_agree"] += want.get("bars") == got.get("bars")
+            totals["notes_exact"] += want.get("notes") == got.get("notes")
+            totals["voices_agree"] += want.get("voices") == got.get("voices")
+            totals["notes_want"] += want.get("notes") or 0
+            totals["notes_got"] += got.get("notes") or 0
     print(f"\n{totals['systems']} systems: "
           f"{totals['staves_agree']} with the staves the page prints, "
-          f"{totals['bars_agree']} with its bars, {totals['holes']} unread")
+          f"{totals['bars_agree']} with its bars, {totals['holes']} unread, "
+          f"{totals['voices_agree']} with its voices, "
+          f"{totals['notes_exact']} with its exact notehead count "
+          f"({totals['notes_got']} read against {totals['notes_want']} printed)")
 
 
 if __name__ == "__main__":

--- a/scripts/scan_vs_reference.py
+++ b/scripts/scan_vs_reference.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+"""What homr read off each page, beside what the page actually holds.
+
+The reference is the cleaned score imploded back to the shape of the print, so
+the two are comparable system by system: both are cut at the same printed bands,
+so system 7 means the same thing on both sides.  No score is given here.  What is
+counted is what can be counted without one being agreed -- how many staves the
+system prints and how many came back, how many bars, how many notes -- so the
+numbers can be looked at before anybody decides which of them matters.
+
+    .venv/bin/python scripts/scan_vs_reference.py
+
+Reads `scan-eval/<slug>/` (written by scripts/scan_references.py) and the real
+song's cleaned score.  Writes nothing but a table.
+"""
+
+import glob
+import json
+import sys
+from pathlib import Path
+
+from lxml import etree
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from scripts.implode_report import drop_rests_for, override_for  # noqa: E402
+from src.clean_score.implode import implode  # noqa: E402
+from src.song_app import pdf_systems  # noqa: E402
+
+MANIFEST = Path("fixtures/omr-songs.json")
+SCRATCH = Path("scan-eval")
+
+
+def reference_systems(slug: str, bands) -> list[dict]:
+    """The imploded reference, cut at the printed bands.
+
+    A staff counts as printed in a system when it has a note there: a part that
+    rests through a system is not engraved, which is the whole reason a page can
+    be 2-3-2-3-3 staves.
+    """
+    cleaned = sorted(glob.glob(f"songs/{slug}/*_cleaned.mscx"))[0]
+    root = etree.parse(cleaned).getroot()
+    implode(root, override_for(slug), drop_rests_for(slug))
+    staves = root.find("Score").findall("Staff")
+    out = []
+    for band in bands:
+        start, end = band.measure_start, band.measure_end
+        if not start:
+            out.append({})
+            continue
+        printed, notes = 0, 0
+        for staff in staves:
+            bars = staff.findall("Measure")[start - 1:end]
+            here = sum(len(bar.findall(".//Chord")) for bar in bars)
+            notes += here
+            printed += 1 if here else 0
+        out.append({"staves": printed, "bars": end - start + 1, "notes": notes})
+    return out
+
+
+def scanned_systems(slug: str) -> dict[int, dict]:
+    state = json.loads((SCRATCH / slug / ".song.json").read_text())
+    found = {}
+    for entry in (state.get("scan") or {}).get("systems", {}).values():
+        index = int(entry["index"])
+        if entry.get("error"):
+            found[index] = {"error": entry["error"]}
+            continue
+        path = SCRATCH / slug / entry["musicxml"]
+        notes = len(etree.parse(str(path)).getroot().findall(".//note")) if path.exists() else 0
+        found[index] = {"staves": entry.get("staves"), "bars": entry.get("bars"),
+                        "notes": notes}
+    return found
+
+
+def main() -> None:
+    listed = json.loads(MANIFEST.read_text())["songs"]
+    slugs = sys.argv[1:] or [n for n, e in listed.items()
+                             if e["review"]["status"] != "excluded"]
+    totals = {"systems": 0, "staves_agree": 0, "bars_agree": 0, "holes": 0}
+    for slug in slugs:
+        if not (SCRATCH / slug / ".song.json").exists():
+            print(f"{slug}: not scanned yet"); continue
+        bands = pdf_systems.load_bounds(f"songs/{slug}")
+        reference = reference_systems(slug, bands)
+        scanned = scanned_systems(slug)
+        print(f"\n== {slug}")
+        print("  sys  page | printed staves  bars  notes | read staves  bars  notes")
+        for band, want in zip(bands, reference):
+            got = scanned.get(band.index, {})
+            if got.get("error"):
+                print(f"  {band.index:3}  p{band.page}    | "
+                      f"{want.get('staves','?'):3} {want.get('bars','?'):11} "
+                      f"{want.get('notes','?'):6} | HOLE: {got['error'][:50]}")
+                totals["holes"] += 1
+                totals["systems"] += 1
+                continue
+            flag = ""
+            if want.get("staves") != got.get("staves"):
+                flag += " staves"
+            if want.get("bars") != got.get("bars"):
+                flag += " bars"
+            print(f"  {band.index:3}  p{band.page}    | "
+                  f"{want.get('staves','?'):3} {want.get('bars','?'):11} "
+                  f"{want.get('notes','?'):6} | "
+                  f"{got.get('staves','?'):8} {got.get('bars','?'):6} "
+                  f"{got.get('notes','?'):6}  {flag}")
+            totals["systems"] += 1
+            totals["staves_agree"] += want.get("staves") == got.get("staves")
+            totals["bars_agree"] += want.get("bars") == got.get("bars")
+    print(f"\n{totals['systems']} systems: "
+          f"{totals['staves_agree']} with the staves the page prints, "
+          f"{totals['bars_agree']} with its bars, {totals['holes']} unread")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/scan_vs_reference.py
+++ b/scripts/scan_vs_reference.py
@@ -24,11 +24,11 @@ from lxml import etree
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
 from scripts.implode_report import drop_rests_for, override_for  # noqa: E402
+from scripts.reference_manifest import manifest, reference_files  # noqa: E402
 from src.clean_score.implode import implode  # noqa: E402
 from src.clean_score.utils import per_system  # noqa: E402
 from src.song_app import pdf_systems  # noqa: E402
 
-MANIFEST = Path("fixtures/omr-songs.json")
 SCRATCH = Path("scan-eval")
 
 
@@ -70,8 +70,7 @@ def reference_systems(slug: str, bands) -> list[dict]:
     rests through a system is not engraved, which is the whole reason a page can
     be 2-3-2-3-3 staves.
     """
-    cleaned = sorted(glob.glob(f"songs/{slug}/*_cleaned.mscx"))[0]
-    root = etree.parse(cleaned).getroot()
+    root = etree.parse(str(reference_files(slug).cleaned)).getroot()
     implode(root, override_for(slug), drop_rests_for(slug))
     staves = root.find("Score").findall("Staff")
     out = []
@@ -83,17 +82,17 @@ def reference_systems(slug: str, bands) -> list[dict]:
         printed, notes, voices = 0, 0, 0
         for staff in staves:
             bars = staff.findall("Measure")[start - 1:end]
-            # The lines a singer could follow on this staff: an imploded staff
-            # carrying two parts has two <voice> elements in a bar, and one
-            # carrying a chord written for two singers has one. Counting the
-            # most any bar of the system has is what the page shows a reader.
-            voices += max((len(bar.findall("voice")) for bar in bars), default=0)
             # Noteheads, not chords: MusicXML writes one <note> per notehead, so
             # counting `Chord` here would call a two-part chord one note and make
             # every divisi bar look like the scan had invented notes.
             here = sum(len(bar.findall(".//Chord/Note")) for bar in bars)
             notes += here
-            printed += 1 if here else 0
+            if here:
+                # The lines a singer could follow on this printed staff: an
+                # imploded staff carrying two parts has two <voice> elements
+                # in a bar, and one carrying a chord for two singers has one.
+                voices += max((len(bar.findall("voice")) for bar in bars), default=0)
+                printed += 1
         out.append({"staves": printed, "bars": end - start + 1, "notes": notes,
                     "voices": voices})
     return out
@@ -129,7 +128,7 @@ def scanned_systems(slug: str, root: Path = SCRATCH) -> dict[int, dict]:
 
 
 def main() -> None:
-    listed = json.loads(MANIFEST.read_text())["songs"]
+    listed = manifest()
     key, argv = read_with(sys.argv[1:])
     root = SCRATCH / key
     slugs = argv or [n for n, e in listed.items()

--- a/scripts/scan_vs_reference.py
+++ b/scripts/scan_vs_reference.py
@@ -25,10 +25,34 @@ sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
 from scripts.implode_report import drop_rests_for, override_for  # noqa: E402
 from src.clean_score.implode import implode  # noqa: E402
+from src.clean_score.utils import per_system  # noqa: E402
 from src.song_app import pdf_systems  # noqa: E402
 
 MANIFEST = Path("fixtures/omr-songs.json")
 SCRATCH = Path("scan-eval")
+
+
+def printed_staves(slug: str, bands) -> list[int] | None:
+    """How many staves each printed system has, off the score's own line breaks.
+
+    The imploded reference cannot answer this for a per-system score: it has one
+    staff per printed part for the whole piece, so a page that prints 2, 2, 3, 4
+    staves reads as 2 throughout, and homr getting it exactly right scores as
+    four disagreements.  The converted input still has the breaks -- it is the
+    same file `pdf_systems.label` takes the measure ranges from -- so where its
+    systems line up with the bands, it is what the page prints.
+    """
+    xml = sorted(glob.glob(f"songs/{slug}/*.mscx"))
+    xml = [p for p in xml if "_cleaned" not in p]
+    if not xml:
+        return None
+    try:
+        layout = per_system.layout_for_file(xml[0])
+    except Exception:
+        return None
+    if len(layout) != len(bands):
+        return None
+    return [len(system.staves) for system in layout]
 
 
 def reference_systems(slug: str, bands) -> list[dict]:
@@ -51,7 +75,10 @@ def reference_systems(slug: str, bands) -> list[dict]:
         printed, notes = 0, 0
         for staff in staves:
             bars = staff.findall("Measure")[start - 1:end]
-            here = sum(len(bar.findall(".//Chord")) for bar in bars)
+            # Noteheads, not chords: MusicXML writes one <note> per notehead, so
+            # counting `Chord` here would call a two-part chord one note and make
+            # every divisi bar look like the scan had invented notes.
+            here = sum(len(bar.findall(".//Chord/Note")) for bar in bars)
             notes += here
             printed += 1 if here else 0
         out.append({"staves": printed, "bars": end - start + 1, "notes": notes})
@@ -67,7 +94,12 @@ def scanned_systems(slug: str) -> dict[int, dict]:
             found[index] = {"error": entry["error"]}
             continue
         path = SCRATCH / slug / entry["musicxml"]
-        notes = len(etree.parse(str(path)).getroot().findall(".//note")) if path.exists() else 0
+        notes = 0
+        if path.exists():
+            # A <note> holding a <rest> is silence, and the reference counts
+            # noteheads: leaving rests in would score a resting bar as full.
+            notes = sum(1 for n in etree.parse(str(path)).getroot().iter("note")
+                        if n.find("rest") is None)
         found[index] = {"staves": entry.get("staves"), "bars": entry.get("bars"),
                         "notes": notes}
     return found
@@ -83,8 +115,14 @@ def main() -> None:
             print(f"{slug}: not scanned yet"); continue
         bands = pdf_systems.load_bounds(f"songs/{slug}")
         reference = reference_systems(slug, bands)
+        printed = printed_staves(slug, bands)
+        if printed:
+            for want, count in zip(reference, printed):
+                if want:
+                    want["staves"] = count
         scanned = scanned_systems(slug)
-        print(f"\n== {slug}")
+        print(f"\n== {slug}   (staves the page prints: "
+              f"{'the score\'s own line breaks' if printed else 'the imploded reference'})")
         print("  sys  page | printed staves  bars  notes | read staves  bars  notes")
         for band, want in zip(bands, reference):
             got = scanned.get(band.index, {})

--- a/scripts/song_pages.py
+++ b/scripts/song_pages.py
@@ -26,10 +26,10 @@ sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
 from scripts.implode_report import (  # noqa: E402
     _shrink,
-    chosen_pdf,
     drop_rests_for,
     override_for,
 )
+from scripts.reference_manifest import reference_files  # noqa: E402
 from src.clean_score.implode import implode  # noqa: E402
 
 OUT = Path("song-pages")
@@ -81,6 +81,7 @@ def main() -> None:
     cli = os.environ.get("MUSESCORE_CLI_PATH", "")
     name = sys.argv[1]
     folder = f"songs/{name}/"
+    sources = reference_files(name)
     OUT.mkdir(exist_ok=True)
     for old in OUT.glob(f"{name}-*.jpg"):
         old.unlink()
@@ -89,7 +90,7 @@ def main() -> None:
     for pdf in sorted(Path(path) for path in glob.glob(folder + "*.pdf")):
         if pdf.name.endswith(".render.pdf") or "_cleaned" in pdf.name:
             continue
-        picked = pdf.name == (chosen_pdf(name) or "")
+        picked = pdf == sources.pdf
         badge = '<span class="chosen">the page this reference is checked against</span>' if picked else ""
         pages = pdf_pages(pdf, f"{name}-{pdf.stem}")
         sections.append(
@@ -97,8 +98,7 @@ def main() -> None:
             + "".join(f'<img src="{html.escape(page)}" alt="page">' for page in pages)
         )
 
-    cleaned = sorted(glob.glob(folder + "*_cleaned.mscx"))[0]
-    root = etree.parse(cleaned).getroot()
+    root = etree.parse(str(sources.cleaned)).getroot()
     found = implode(root, override_for(name), drop_rests_for(name))
     with tempfile.TemporaryDirectory() as tmp:
         score = Path(tmp) / "imploded.mscx"

--- a/scripts/song_pages.py
+++ b/scripts/song_pages.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+"""Every page of one song: each PDF it has, and the whole imploded reference.
+
+The side-by-side report shows first pages, which is enough to see that a
+reference has the right shape and not enough to judge a piece.  This lays a song
+out in full -- including every PDF in its folder, since which one is the page the
+score was made from has twice been the thing that was wrong.
+
+    .venv/bin/python scripts/song_pages.py "Kolme käkeä"
+
+Writes `song-pages/<song>.html`.
+"""
+
+import glob
+import html
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+from dotenv import load_dotenv
+from lxml import etree
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from scripts.implode_report import (  # noqa: E402
+    _shrink,
+    chosen_pdf,
+    drop_rests_for,
+    override_for,
+)
+from src.clean_score.implode import implode  # noqa: E402
+
+OUT = Path("song-pages")
+
+
+def pdf_pages(pdf: Path, stem: str) -> list[str]:
+    names = []
+    with tempfile.TemporaryDirectory() as tmp:
+        subprocess.run(
+            ["pdftoppm", "-r", "150", "-png", str(pdf), str(Path(tmp) / "p")],
+            capture_output=True,
+        )
+        for number, page in enumerate(sorted(Path(tmp).glob("p*.png")), start=1):
+            target = OUT / f"{stem}-{number}.jpg"
+            if _shrink(page, target):
+                names.append(target.name)
+    return names
+
+
+def engraved_pages(score: Path, cli: str, stem: str) -> list[str]:
+    names = []
+    with tempfile.TemporaryDirectory() as tmp:
+        subprocess.run(
+            [cli, "-o", str(Path(tmp) / "out.png"), str(score)], capture_output=True, timeout=600
+        )
+        for number, page in enumerate(sorted(Path(tmp).glob("out*.png")), start=1):
+            target = OUT / f"{stem}-{number}.jpg"
+            if _shrink(page, target):
+                names.append(target.name)
+    return names
+
+
+STYLE = """
+body { font: 15px/1.6 system-ui, sans-serif; margin: 0 auto; max-width: 1000px;
+       padding: 24px; color: #1a1a1a; background: #fafafa; }
+h1 { font-size: 22px; margin-bottom: 4px; }
+h2 { font-size: 17px; margin: 30px 0 6px; }
+p.lead, p.sub { color: #555; margin-top: 0; }
+p.sub { font-size: 13px; }
+img { display: block; width: 100%; border: 1px solid #e2e2e2; background: #fff;
+      border-radius: 6px; margin-bottom: 10px; }
+.chosen { background: #e8f4ea; color: #1c5c2c; border-radius: 4px;
+          padding: 1px 6px; font-size: 12px; font-weight: 600; }
+"""
+
+
+def main() -> None:
+    load_dotenv()
+    cli = os.environ.get("MUSESCORE_CLI_PATH", "")
+    name = sys.argv[1]
+    folder = f"songs/{name}/"
+    OUT.mkdir(exist_ok=True)
+    for old in OUT.glob(f"{name}-*.jpg"):
+        old.unlink()
+
+    sections = []
+    for pdf in sorted(Path(path) for path in glob.glob(folder + "*.pdf")):
+        if pdf.name.endswith(".render.pdf") or "_cleaned" in pdf.name:
+            continue
+        picked = pdf.name == (chosen_pdf(name) or "")
+        badge = '<span class="chosen">the page this reference is checked against</span>' if picked else ""
+        pages = pdf_pages(pdf, f"{name}-{pdf.stem}")
+        sections.append(
+            f"<h2>{html.escape(pdf.name)} &mdash; {len(pages)} pages {badge}</h2>"
+            + "".join(f'<img src="{html.escape(page)}" alt="page">' for page in pages)
+        )
+
+    cleaned = sorted(glob.glob(folder + "*_cleaned.mscx"))[0]
+    root = etree.parse(cleaned).getroot()
+    found = implode(root, override_for(name), drop_rests_for(name))
+    with tempfile.TemporaryDirectory() as tmp:
+        score = Path(tmp) / "imploded.mscx"
+        etree.ElementTree(root).write(str(score), encoding="UTF-8", xml_declaration=True)
+        pages = engraved_pages(score, cli, f"{name}-imploded")
+    staves = " &middot; ".join(html.escape(printed.label) for printed in found.printed)
+    sections.append(
+        f"<h2>the reference, imploded out of the cleaned score &mdash; {len(pages)} pages</h2>"
+        f"<p class=\"sub\">grouping: {found.source} &mdash; {len(found.printed)} printed staves:"
+        f" {staves}</p>"
+        + "".join(f'<img src="{html.escape(page)}" alt="page">' for page in pages)
+    )
+
+    page = f"""<!doctype html>
+<html lang="en"><head><meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>{html.escape(name)} in full</title><style>{STYLE}</style></head><body>
+<h1>{html.escape(name)}</h1>
+<p class="lead">Every page of every PDF in the song's folder, and the whole
+reference imploded out of its cleaned score. MuseScore breaks systems where it
+likes, so the pages will not line up: judge the notes, the voices and the words.</p>
+{''.join(sections)}
+</body></html>"""
+    target = OUT / f"{name}.html"
+    target.write_text(page)
+    print(target)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/write_implode_manifest.py
+++ b/scripts/write_implode_manifest.py
@@ -23,7 +23,7 @@ from lxml import etree
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
-from scripts.implode_report import songs  # noqa: E402
+from scripts.implode_report import override_for, songs  # noqa: E402
 from src.clean_score.implode import grouping  # noqa: E402
 
 MANIFEST = Path("fixtures/omr-songs.json")
@@ -35,15 +35,16 @@ def digest(path: Path) -> str:
 
 def main() -> None:
     existing = json.loads(MANIFEST.read_text()) if MANIFEST.exists() else {}
-    reviews = {
-        name: entry["review"]
+    # Both of these are somebody's reading of the page, and nothing here can
+    # derive either: keep whatever is already written down.
+    kept = {
+        name: (entry.get("review"), (entry.get("grouping") or {}).get("override"))
         for name, entry in existing.get("songs", {}).items()
-        if entry.get("review")
     }
 
     out = {}
     for name, pdf, cleaned, made in songs():
-        found = grouping(etree.parse(str(cleaned)).getroot())
+        found = grouping(etree.parse(str(cleaned)).getroot(), override_for(name))
         out[name] = {
             "pdf": pdf.name,
             "cleaned": cleaned.name,
@@ -58,8 +59,11 @@ def main() -> None:
             },
             # Written by hand after somebody has looked at the reference beside
             # the page.  Nothing here is derived, and nothing regenerates it.
-            "review": reviews.get(name, {"status": "unreviewed", "notes": ""}),
+            "review": kept.get(name, (None, None))[0] or {"status": "unreviewed", "notes": ""},
         }
+        override = kept.get(name, (None, None))[1]
+        if override:
+            out[name]["grouping"]["override"] = override
 
     MANIFEST.parent.mkdir(exist_ok=True)
     MANIFEST.write_text(json.dumps({"version": 1, "songs": out}, indent=2, ensure_ascii=False) + "\n")

--- a/scripts/write_implode_manifest.py
+++ b/scripts/write_implode_manifest.py
@@ -47,7 +47,7 @@ def main() -> None:
     }
 
     out = {}
-    for name, pdf, cleaned, made in songs():
+    for name, pdf, cleaned, made in songs(with_excluded=True):
         found = grouping(etree.parse(str(cleaned)).getroot(), override_for(name))
         out[name] = {
             "pdf": pdf.name,
@@ -73,8 +73,8 @@ def main() -> None:
 
     MANIFEST.parent.mkdir(exist_ok=True)
     MANIFEST.write_text(json.dumps({"version": 1, "songs": out}, indent=2, ensure_ascii=False) + "\n")
-    kept = sum(1 for entry in out.values() if entry["review"]["status"] != "unreviewed")
-    print(f"{MANIFEST}: {len(out)} songs, {kept} already reviewed")
+    out_count = sum(1 for entry in out.values() if entry["review"]["status"] == "excluded")
+    print(f"{MANIFEST}: {len(out)} songs, {out_count} excluded, {len(out) - out_count} in the set")
 
 
 if __name__ == "__main__":

--- a/scripts/write_implode_manifest.py
+++ b/scripts/write_implode_manifest.py
@@ -23,7 +23,7 @@ from lxml import etree
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
-from scripts.implode_report import override_for, songs  # noqa: E402
+from scripts.implode_report import candidate_songs, override_for  # noqa: E402
 from src.clean_score.implode import grouping  # noqa: E402
 
 MANIFEST = Path("fixtures/omr-songs.json")
@@ -47,7 +47,7 @@ def main() -> None:
     }
 
     out = {}
-    for name, pdf, cleaned, made in songs(with_excluded=True):
+    for name, pdf, cleaned, made in candidate_songs(with_excluded=True):
         found = grouping(etree.parse(str(cleaned)).getroot(), override_for(name))
         out[name] = {
             "pdf": pdf.name,

--- a/scripts/write_implode_manifest.py
+++ b/scripts/write_implode_manifest.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+"""Write down which songs can be OMR fixtures, and what a person said about them.
+
+The songs themselves cannot be committed -- they are gitignored working folders
+holding scans of in-copyright editions -- so what travels is this manifest: for
+each song, the files a fixture is built from, a hash of each so a rebuild can
+prove it used the same music, how its staves map back onto the printed page, and
+the verdict of somebody who looked.
+
+The verdicts are the part that cannot be regenerated.  Everything else this
+script derives; a `review` block is only ever written by hand, and rerunning
+keeps whatever is already there.
+
+    .venv/bin/python scripts/write_implode_manifest.py
+"""
+
+import hashlib
+import json
+import sys
+from pathlib import Path
+
+from lxml import etree
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from scripts.implode_report import songs  # noqa: E402
+from src.clean_score.implode import grouping  # noqa: E402
+
+MANIFEST = Path("fixtures/omr-songs.json")
+
+
+def digest(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()[:16]
+
+
+def main() -> None:
+    existing = json.loads(MANIFEST.read_text()) if MANIFEST.exists() else {}
+    reviews = {
+        name: entry["review"]
+        for name, entry in existing.get("songs", {}).items()
+        if entry.get("review")
+    }
+
+    out = {}
+    for name, pdf, cleaned, made in songs():
+        found = grouping(etree.parse(str(cleaned)).getroot())
+        out[name] = {
+            "pdf": pdf.name,
+            "cleaned": cleaned.name,
+            "pdf_sha256": digest(pdf),
+            "cleaned_sha256": digest(cleaned),
+            "video": made,
+            "grouping": {
+                "source": found.source,
+                "inferred": found.inferred,
+                "printed": [printed.staves for printed in found.printed],
+                "labels": [printed.label for printed in found.printed],
+            },
+            # Written by hand after somebody has looked at the reference beside
+            # the page.  Nothing here is derived, and nothing regenerates it.
+            "review": reviews.get(name, {"status": "unreviewed", "notes": ""}),
+        }
+
+    MANIFEST.parent.mkdir(exist_ok=True)
+    MANIFEST.write_text(json.dumps({"version": 1, "songs": out}, indent=2, ensure_ascii=False) + "\n")
+    kept = sum(1 for entry in out.values() if entry["review"]["status"] != "unreviewed")
+    print(f"{MANIFEST}: {len(out)} songs, {kept} already reviewed")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/write_implode_manifest.py
+++ b/scripts/write_implode_manifest.py
@@ -38,7 +38,11 @@ def main() -> None:
     # Both of these are somebody's reading of the page, and nothing here can
     # derive either: keep whatever is already written down.
     kept = {
-        name: (entry.get("review"), (entry.get("grouping") or {}).get("override"))
+        name: (
+            entry.get("review"),
+            (entry.get("grouping") or {}).get("override"),
+            entry.get("source_override"),
+        )
         for name, entry in existing.get("songs", {}).items()
     }
 
@@ -59,11 +63,13 @@ def main() -> None:
             },
             # Written by hand after somebody has looked at the reference beside
             # the page.  Nothing here is derived, and nothing regenerates it.
-            "review": kept.get(name, (None, None))[0] or {"status": "unreviewed", "notes": ""},
+            "review": kept.get(name, (None, None, None))[0] or {"status": "unreviewed", "notes": ""},
         }
-        override = kept.get(name, (None, None))[1]
+        review, override, source = kept.get(name, (None, None, None))
         if override:
             out[name]["grouping"]["override"] = override
+        if source:
+            out[name]["source_override"] = source
 
     MANIFEST.parent.mkdir(exist_ok=True)
     MANIFEST.write_text(json.dumps({"version": 1, "songs": out}, indent=2, ensure_ascii=False) + "\n")

--- a/src/clean_score/implode.py
+++ b/src/clean_score/implode.py
@@ -240,11 +240,33 @@ def implode(root: etree._Element) -> Grouping:
     for offset, element in enumerate(merged_parts + merged_staves):
         score.insert(anchor + offset, element)
 
+    _hide_empty_staves(score)
+
     # The lyric routing describes staves that no longer exist.
     for tag in list(score.findall("metaTag")):
         if tag.get("name") in ("lyricsStaffMap", "lyricsSystemMap"):
             score.remove(tag)
     return found
+
+
+def _hide_empty_staves(score: etree._Element) -> None:
+    """Print a staff only in the systems where it sings, as the page does.
+
+    A score has a fixed number of staves; a printed page does not -- a part that
+    rests through a system is simply not printed, which is why a system of this
+    music can be two staves and the next one three.  Without this the reference
+    carries an empty staff the page never shows, and a staff-by-staff comparison
+    against a reading of that page lines up against the wrong staff.
+    """
+    style = score.find("Style")
+    if style is None:
+        style = etree.Element("Style")
+        score.insert(0, style)
+    # The page hides a resting staff in its first system too, so this does.
+    for name, value in (("hideEmptyStaves", "1"), ("dontHideStavesInFirstSystem", "0")):
+        for existing in style.findall(name):
+            style.remove(existing)
+        style.append(_text_element(name, value))
 
 
 def _text_element(tag: str, text: str) -> etree._Element:

--- a/src/clean_score/implode.py
+++ b/src/clean_score/implode.py
@@ -61,6 +61,10 @@ class Grouping:
     def inferred(self) -> bool:
         return self.source == "part names"
 
+    @property
+    def reviewed(self) -> bool:
+        return self.source == "reviewed"
+
 
 def _meta(root: etree._Element, name: str) -> str:
     for tag in root.iter("metaTag"):
@@ -175,9 +179,38 @@ def silent_staves(root: etree._Element) -> list[int]:
     return silent
 
 
-def grouping(root: etree._Element) -> Grouping:
-    """How this score's staves map back onto the printed page."""
+def _from_review(
+    override: list[list[str]], names: dict[int, str]
+) -> list[PrintedStaff] | None:
+    """A grouping somebody read off the page and wrote down.
+
+    Named by part rather than by staff id, because a name is what a person can
+    check against the page and an id is not, and because re-cleaning a score can
+    renumber the staves under a recorded id.
+    """
+    by_name: dict[str, int] = {name: staff for staff, name in names.items()}
+    printed = []
+    for group in override:
+        staves = [by_name[name] for name in group if name in by_name]
+        if len(staves) != len(group):
+            missing = [name for name in group if name not in by_name]
+            raise KeyError(f"the score has no part called {missing}")
+        printed.append(PrintedStaff(staves, [names[staff] for staff in staves]))
+    return printed or None
+
+
+def grouping(root: etree._Element, override: list[list[str]] | None = None) -> Grouping:
+    """How this score's staves map back onto the printed page.
+
+    An `override` is a person's reading of the page and beats everything else:
+    the recorded maps describe how the app split the staves, which is not always
+    how they were printed.
+    """
     names = staff_names(root)
+    if override:
+        printed = _from_review(override, names)
+        if printed is not None:
+            return Grouping(printed, "reviewed")
     score = root.find("Score")
     ids = [int(staff.get("id", "0")) for staff in score.findall("Staff")]
     singing = [staff for staff in ids if staff not in silent_staves(root)]
@@ -201,14 +234,14 @@ def grouping(root: etree._Element) -> Grouping:
     return Grouping(_inferred(names, singing), "part names")
 
 
-def implode(root: etree._Element) -> Grouping:
+def implode(root: etree._Element, override: list[list[str]] | None = None) -> Grouping:
     """Merge the staves back onto the printed ones, in place.
 
     Returns the grouping used, so a caller can say whether it was recorded or
     guessed.
     """
     score = root.find("Score")
-    found = grouping(root)
+    found = grouping(root, override)
     staves = {int(s.get("id", "0")): s for s in score.findall("Staff")}
     parts = {}
     for part in score.findall("Part"):

--- a/src/clean_score/implode.py
+++ b/src/clean_score/implode.py
@@ -435,6 +435,35 @@ def _rest_measure(source: etree._Element) -> etree._Element:
     return measure
 
 
+def _source_states(
+    bars: list[etree._Element],
+) -> list[dict[str, etree._Element]]:
+    """The clef, key and meter in force at each source measure."""
+    current: dict[str, etree._Element] = {}
+    states = []
+    for measure in bars:
+        for element in measure.iter():
+            if element.tag in STAFF_LEVEL:
+                current[element.tag] = etree.fromstring(etree.tostring(element))
+        states.append(dict(current))
+    return states
+
+
+def _carry_source_state(
+    measure: etree._Element, state: dict[str, etree._Element]
+) -> None:
+    """Write inherited source state when a fixed output position changes source."""
+    voice = measure.find("voice")
+    if voice is None:
+        voice = etree.SubElement(measure, "voice")
+    present = {element.tag for element in measure.iter() if element.tag in STAFF_LEVEL}
+    insert_at = 0
+    for tag in STAFF_LEVEL:
+        if tag not in present and tag in state:
+            voice.insert(insert_at, etree.fromstring(etree.tostring(state[tag])))
+            insert_at += 1
+
+
 def _merge_system_staves(
     staves: dict[int, etree._Element],
     found: Grouping,
@@ -443,6 +472,7 @@ def _merge_system_staves(
 ) -> list[etree._Element]:
     """Build fixed position staves whose contents follow each system's map."""
     source_bars = {staff: element.findall("Measure") for staff, element in staves.items()}
+    source_states = {staff: _source_states(bars) for staff, bars in source_bars.items()}
     base = next(iter(staves.values()))
     base_bars = base.findall("Measure")
     by_measure: dict[int, SystemGrouping] = {}
@@ -466,6 +496,7 @@ def _merge_system_staves(
         for element in template:
             if element.tag != "Measure" and not (position > 1 and element.tag == "VBox"):
                 staff.append(etree.fromstring(etree.tostring(element)))
+        previous_group: tuple[int, ...] | None = None
         for index, base_measure in enumerate(base_bars):
             group = by_measure[index].printed.get(position)
             if group:
@@ -476,11 +507,18 @@ def _merge_system_staves(
                     if names.get(source, "") in set(drop_rests)
                 }
                 measure = _merge_measure(sources, silent)
+                current_group = tuple(group.staves)
+                if current_group != previous_group:
+                    _carry_source_state(
+                        measure, source_states[group.staves[0]][index]
+                    )
             else:
                 measure = _rest_measure(base_measure)
+                current_group = None
             for layout_break in measure.findall("LayoutBreak"):
                 measure.remove(layout_break)
             staff.append(measure)
+            previous_group = current_group
         merged.append(staff)
 
     top = merged[0].findall("Measure") if merged else []

--- a/src/clean_score/implode.py
+++ b/src/clean_score/implode.py
@@ -56,6 +56,7 @@ class Grouping:
 
     printed: list[PrintedStaff]
     source: str
+    systems: list["SystemGrouping"] = field(default_factory=list)
 
     @property
     def inferred(self) -> bool:
@@ -64,6 +65,15 @@ class Grouping:
     @property
     def reviewed(self) -> bool:
         return self.source == "reviewed"
+
+
+@dataclass
+class SystemGrouping:
+    """The printed staff positions used by one measure range."""
+
+    start: int
+    end: int
+    printed: dict[int, PrintedStaff]
 
 
 def _meta(root: etree._Element, name: str) -> str:
@@ -111,34 +121,54 @@ def _from_staff_map(recorded: str, names: dict[int, str]) -> list[PrintedStaff] 
     return printed or None
 
 
-def _from_system_map(recorded: str, names: dict[int, str]) -> list[PrintedStaff] | None:
-    """A per-system map says which staves shared a printed one, system by system.
-
-    A score has a fixed number of staves while a page prints only the ones that
-    sound, so the grouping is taken over the whole score: two voices that share a
-    printed staff anywhere shared one, and a system where only one of them sings
-    prints that staff with one voice on it.
-    """
+def _from_system_map(recorded: str, names: dict[int, str]) -> list[SystemGrouping] | None:
+    """Read each system's printed positions without collapsing their differences."""
     try:
-        systems = json.loads(recorded)
-    except ValueError:
+        raw = json.loads(recorded)
+        systems = []
+        for entry in raw:
+            mapped = {
+                int(position): PrintedStaff(
+                    [int(staff) for staff in staves],
+                    [names.get(int(staff), "") for staff in staves],
+                )
+                for position, staves in entry["map"].items()
+            }
+            if mapped and set(mapped) != set(range(1, max(mapped) + 1)):
+                return None
+            if any(not group.staves for group in mapped.values()):
+                return None
+            listed = [staff for group in mapped.values() for staff in group.staves]
+            if len(listed) != len(set(listed)):
+                return None
+            systems.append(SystemGrouping(int(entry["start"]), int(entry["end"]), mapped))
+    except (KeyError, TypeError, ValueError):
         return None
-    together: dict[int, set[int]] = {}
+    systems.sort(key=lambda system: system.start)
+    return systems or None
+
+
+def _system_slots(systems: list[SystemGrouping], names: dict[int, str]) -> list[PrintedStaff]:
+    """Fixed score staves representing changing top-to-bottom page positions."""
+    count = max((max(system.printed, default=0) for system in systems), default=0)
+    slots = []
+    for position in range(1, count + 1):
+        staves = []
+        for system in systems:
+            group = system.printed.get(position)
+            for staff in group.staves if group else []:
+                if staff not in staves:
+                    staves.append(staff)
+        slots.append(PrintedStaff(staves, [names.get(staff, "") for staff in staves]))
+    return slots
+
+
+def _system_staff_ids(systems: list[SystemGrouping]) -> set[int]:
+    listed = set()
     for system in systems:
-        for staves in system.get("map", {}).values():
-            for staff in staves:
-                together.setdefault(staff, set()).update(staves)
-    groups: list[list[int]] = []
-    seen: set[int] = set()
-    for staff in sorted(together):
-        if staff in seen:
-            continue
-        group = sorted(together[staff])
-        seen.update(group)
-        groups.append(group)
-    if not groups:
-        return None
-    return [PrintedStaff(g, [names.get(staff, "") for staff in g]) for g in groups]
+        for group in system.printed.values():
+            listed.update(group.staves)
+    return listed
 
 
 def _inferred(names: dict[int, str], singing: list[int]) -> list[PrintedStaff]:
@@ -215,21 +245,21 @@ def grouping(root: etree._Element, override: list[list[str]] | None = None) -> G
     ids = [int(staff.get("id", "0")) for staff in score.findall("Staff")]
     singing = [staff for staff in ids if staff not in silent_staves(root)]
 
-    for recorded, reader, source in (
-        (_meta(root, "lyricsSystemMap"), _from_system_map, "per-system map"),
-        (_meta(root, "lyricsStaffMap"), _from_staff_map, "staff map"),
-    ):
-        if not recorded:
-            continue
-        printed = reader(recorded, names)
-        if printed is None:
-            continue
+    recorded = _meta(root, "lyricsSystemMap")
+    systems = _from_system_map(recorded, names) if recorded else None
+    system_ids = _system_staff_ids(systems) if systems else set()
+    if systems and system_ids >= set(singing) and system_ids <= set(ids):
+        return Grouping(_system_slots(systems, names), "per-system map", systems)
+
+    recorded = _meta(root, "lyricsStaffMap")
+    printed = _from_staff_map(recorded, names) if recorded else None
+    if printed is not None:
         listed = {staff for group in printed for staff in group.staves}
         # A recorded map that names every singing staff is the score's own word
         # for what the page looked like.  One that does not is not usable: the
         # staves it leaves out would silently vanish from the reference.
         if listed >= set(singing):
-            return Grouping([g for g in printed if set(g.staves) <= set(singing)], source)
+            return Grouping([g for g in printed if set(g.staves) <= set(singing)], "staff map")
 
     return Grouping(_inferred(names, singing), "part names")
 
@@ -250,6 +280,7 @@ def implode(
     guessed, or read off the page by a person.
     """
     score = root.find("Score")
+    names = staff_names(root)
     found = grouping(root, override)
     staves = {int(s.get("id", "0")): s for s in score.findall("Staff")}
     parts = {}
@@ -257,6 +288,11 @@ def implode(
         for staff in part.findall("Staff"):
             parts[int(staff.get("id", "0"))] = part
 
+    system_staves = (
+        _merge_system_staves(staves, found, names, drop_rests or [])
+        if found.systems
+        else []
+    )
     merged_parts, merged_staves = [], []
     for number, printed in enumerate(found.printed, start=1):
         first = printed.staves[0]
@@ -265,7 +301,11 @@ def implode(
             for index, name in enumerate(printed.names)
             if name in set(drop_rests or [])
         ]
-        staff = _merge_staves([staves[s] for s in printed.staves], silent)
+        staff = (
+            system_staves[number - 1]
+            if system_staves
+            else _merge_staves([staves[s] for s in printed.staves], silent)
+        )
         staff.set("id", str(number))
         merged_staves.append(staff)
 
@@ -351,21 +391,101 @@ def _merge_staves(
         ]
         if not present:
             continue
-        measure = etree.fromstring(etree.tostring(present[0][1]))
-        for voice in measure.findall("voice"):
-            measure.remove(voice)
-        kept = 0
-        for position, source in present:
-            for voice in etree.fromstring(etree.tostring(source)).findall("voice"):
-                if position in unprinted and voice.find("Chord") is None:
-                    continue
-                if kept:
-                    # Only the staff's first voice carries its clef, key and
-                    # meter; a second copy would print them twice.
-                    for element in voice.findall("*"):
-                        if element.tag in STAFF_LEVEL:
-                            voice.remove(element)
-                measure.append(voice)
-                kept += 1
-        staff.append(measure)
+        staff.append(_merge_measure([source for _, source in present], unprinted))
     return staff
+
+
+def _merge_measure(
+    sources: list[etree._Element], drop_when_resting: set[int] | None = None
+) -> etree._Element:
+    """Merge source measures into one printed measure."""
+    unprinted = drop_when_resting or set()
+    measure = etree.fromstring(etree.tostring(sources[0]))
+    for voice in measure.findall("voice"):
+        measure.remove(voice)
+    kept = 0
+    for position, source in enumerate(sources):
+        for voice in etree.fromstring(etree.tostring(source)).findall("voice"):
+            if position in unprinted and voice.find("Chord") is None:
+                continue
+            if kept:
+                # Only the staff's first voice carries its clef, key and meter;
+                # a second copy would print them twice.
+                for element in voice.findall("*"):
+                    if element.tag in STAFF_LEVEL:
+                        voice.remove(element)
+            measure.append(voice)
+            kept += 1
+    return measure
+
+
+def _rest_measure(source: etree._Element) -> etree._Element:
+    """A full-bar rest carrying the source measure's staff-level state."""
+    measure = etree.fromstring(etree.tostring(source))
+    original = measure.find("voice")
+    for voice in measure.findall("voice"):
+        measure.remove(voice)
+    voice = etree.SubElement(measure, "voice")
+    if original is not None:
+        for element in original.findall("*"):
+            if element.tag in STAFF_LEVEL:
+                voice.append(etree.fromstring(etree.tostring(element)))
+    rest = etree.SubElement(voice, "Rest")
+    etree.SubElement(rest, "durationType").text = "measure"
+    return measure
+
+
+def _merge_system_staves(
+    staves: dict[int, etree._Element],
+    found: Grouping,
+    names: dict[int, str],
+    drop_rests: list[str],
+) -> list[etree._Element]:
+    """Build fixed position staves whose contents follow each system's map."""
+    source_bars = {staff: element.findall("Measure") for staff, element in staves.items()}
+    base = next(iter(staves.values()))
+    base_bars = base.findall("Measure")
+    by_measure: dict[int, SystemGrouping] = {}
+    for system in found.systems:
+        if system.start < 1 or system.end < system.start or system.end > len(base_bars):
+            raise ValueError(
+                f"lyricsSystemMap range {system.start}-{system.end} is outside the score"
+            )
+        for measure in range(system.start - 1, system.end):
+            if measure in by_measure:
+                raise ValueError(f"lyricsSystemMap overlaps at measure {measure + 1}")
+            by_measure[measure] = system
+    missing = [measure + 1 for measure in range(len(base_bars)) if measure not in by_measure]
+    if missing:
+        raise ValueError(f"lyricsSystemMap does not cover measures {missing}")
+
+    merged = []
+    for position, slot in enumerate(found.printed, start=1):
+        staff = etree.Element("Staff")
+        template = staves[slot.staves[0]]
+        for element in template:
+            if element.tag != "Measure" and not (position > 1 and element.tag == "VBox"):
+                staff.append(etree.fromstring(etree.tostring(element)))
+        for index, base_measure in enumerate(base_bars):
+            group = by_measure[index].printed.get(position)
+            if group:
+                sources = [source_bars[source][index] for source in group.staves]
+                silent = {
+                    member
+                    for member, source in enumerate(group.staves)
+                    if names.get(source, "") in set(drop_rests)
+                }
+                measure = _merge_measure(sources, silent)
+            else:
+                measure = _rest_measure(base_measure)
+            for layout_break in measure.findall("LayoutBreak"):
+                measure.remove(layout_break)
+            staff.append(measure)
+        merged.append(staff)
+
+    top = merged[0].findall("Measure") if merged else []
+    for system in found.systems[:-1]:
+        if system.end <= len(top):
+            layout_break = etree.SubElement(top[system.end - 1], "LayoutBreak")
+            etree.SubElement(layout_break, "subtype").text = "line"
+    return merged

--- a/src/clean_score/implode.py
+++ b/src/clean_score/implode.py
@@ -234,11 +234,20 @@ def grouping(root: etree._Element, override: list[list[str]] | None = None) -> G
     return Grouping(_inferred(names, singing), "part names")
 
 
-def implode(root: etree._Element, override: list[list[str]] | None = None) -> Grouping:
+def implode(
+    root: etree._Element,
+    override: list[list[str]] | None = None,
+    drop_rests: list[str] | None = None,
+) -> Grouping:
     """Merge the staves back onto the printed ones, in place.
 
-    Returns the grouping used, so a caller can say whether it was recorded or
-    guessed.
+    `drop_rests` names parts whose silence is not printed.  A voice added above
+    a staff -- a third tenor line over T1 and T2 -- is written only where it
+    sings; printing a bar of rests for it every time it is absent is something
+    the page does not do and an OMR reading of the page will never produce.
+
+    Returns the grouping used, so a caller can say whether it was recorded,
+    guessed, or read off the page by a person.
     """
     score = root.find("Score")
     found = grouping(root, override)
@@ -251,7 +260,12 @@ def implode(root: etree._Element, override: list[list[str]] | None = None) -> Gr
     merged_parts, merged_staves = [], []
     for number, printed in enumerate(found.printed, start=1):
         first = printed.staves[0]
-        staff = _merge_staves([staves[s] for s in printed.staves])
+        silent = [
+            index
+            for index, name in enumerate(printed.names)
+            if name in set(drop_rests or [])
+        ]
+        staff = _merge_staves([staves[s] for s in printed.staves], silent)
         staff.set("id", str(number))
         merged_staves.append(staff)
 
@@ -314,29 +328,44 @@ def _rename(part: etree._Element, label: str) -> None:
             element.text = label
 
 
-def _merge_staves(members: list[etree._Element]) -> etree._Element:
-    """One staff carrying every member's voices, bar by bar."""
+def _merge_staves(
+    members: list[etree._Element], drop_when_resting: list[int] | None = None
+) -> etree._Element:
+    """One staff carrying every member's voices, bar by bar.
+
+    Every voice is treated alike, including the topmost one: a part written
+    above the others -- a third tenor line over T1 and T2 -- is first in the
+    order and may still be absent from a bar it does not sing in.
+    """
+    unprinted = set(drop_when_resting or [])
     staff = etree.Element("Staff")
     for element in members[0]:
         if element.tag != "Measure":
             staff.append(etree.fromstring(etree.tostring(element)))
     bars = [member.findall("Measure") for member in members]
-    for index in range(max(len(m) for m in bars)):
-        measure = None
-        for position, member_bars in enumerate(bars):
-            if index >= len(member_bars):
-                continue
-            source = etree.fromstring(etree.tostring(member_bars[index]))
-            if measure is None:
-                measure = source
-                continue
-            for voice in source.findall("voice"):
-                # Only the first voice of a staff carries its clef, key and
-                # meter; a second copy would print them twice.
-                for element in voice.findall("*"):
-                    if element.tag in STAFF_LEVEL:
-                        voice.remove(element)
+    for index in range(max(len(member_bars) for member_bars in bars)):
+        present = [
+            (position, member_bars[index])
+            for position, member_bars in enumerate(bars)
+            if index < len(member_bars)
+        ]
+        if not present:
+            continue
+        measure = etree.fromstring(etree.tostring(present[0][1]))
+        for voice in measure.findall("voice"):
+            measure.remove(voice)
+        kept = 0
+        for position, source in present:
+            for voice in etree.fromstring(etree.tostring(source)).findall("voice"):
+                if position in unprinted and voice.find("Chord") is None:
+                    continue
+                if kept:
+                    # Only the staff's first voice carries its clef, key and
+                    # meter; a second copy would print them twice.
+                    for element in voice.findall("*"):
+                        if element.tag in STAFF_LEVEL:
+                            voice.remove(element)
                 measure.append(voice)
-        if measure is not None:
-            staff.append(measure)
+                kept += 1
+        staff.append(measure)
     return staff

--- a/src/clean_score/implode.py
+++ b/src/clean_score/implode.py
@@ -1,0 +1,287 @@
+"""Put a cleaned score back into the shape the page it came from was printed in.
+
+`clean_score` splits a printed staff carrying two voices into one staff per
+voice, because that is what a practice track needs.  The page does the opposite,
+and so does every OMR reading of it, so a cleaned score cannot be compared with
+one directly.  This undoes the split: the voices that shared a printed staff are
+put back on one staff, upper voice first.
+
+Which output staves shared a printed staff is usually recorded in the score, by
+the same pass that split them -- `lyricsStaffMap` for an ordinary clean and
+`lyricsSystemMap` where the staves change role from system to system.  Where a
+score records neither, the grouping is **inferred** from the part names, and
+every caller is told so: a guessed reference that reads like a recorded one is
+the way this ends up measuring homr against a mistake of ours.
+"""
+
+import json
+import re
+from dataclasses import dataclass, field
+
+from lxml import etree
+
+#: Elements that belong to the staff rather than to a voice, so only the first
+#: voice of a merged staff may keep them.
+STAFF_LEVEL = ("Clef", "KeySig", "TimeSig")
+VOICE_ORDER = "SATB"
+#: What a part has to be called to be read as a choir voice.  "Solo" is not a
+#: soprano, so the whole name has to look like one -- a letter or a word, and
+#: then only numbers.
+VOICE_NAME = re.compile(
+    r"^\s*(soprano|sopraano|alto|altto|tenor|tenori|baritone|bass|basso|mezzo|[SATB])"
+    r"\s*([\d\s.-]*)$",
+    re.IGNORECASE,
+)
+VOICE_LETTER = {
+    "soprano": "S", "sopraano": "S", "mezzo": "A", "alto": "A", "altto": "A",
+    "tenor": "T", "tenori": "T", "baritone": "B", "bass": "B", "basso": "B",
+}
+
+
+@dataclass
+class PrintedStaff:
+    """One staff of the printed page, and the cleaned staves that came off it."""
+
+    staves: list[int]
+    names: list[str] = field(default_factory=list)
+
+    @property
+    def label(self) -> str:
+        return "/".join(self.names) if self.names else f"staff {self.staves[0]}"
+
+
+@dataclass
+class Grouping:
+    """How a cleaned score's staves map back onto printed ones."""
+
+    printed: list[PrintedStaff]
+    source: str
+
+    @property
+    def inferred(self) -> bool:
+        return self.source == "part names"
+
+
+def _meta(root: etree._Element, name: str) -> str:
+    for tag in root.iter("metaTag"):
+        if tag.get("name") == name:
+            return (tag.text or "").strip()
+    return ""
+
+
+def staff_names(root: etree._Element) -> dict[int, str]:
+    """The part name of each staff, by staff id."""
+    names = {}
+    for part in root.iter("Part"):
+        name = part.findtext("trackName") or part.findtext("Instrument/longName") or ""
+        for staff in part.findall("Staff"):
+            names[int(staff.get("id", "0"))] = name.strip()
+    return names
+
+
+def voice_of(name: str) -> tuple[str, tuple[int, ...]] | None:
+    """The choir voice a part name says it is, and its numbering.
+
+    "Alto 1-2" is the second half of a split Alto 1; "Solo" is not a voice this
+    can place and comes back as nothing.
+    """
+    match = VOICE_NAME.match(name or "")
+    if match is None:
+        return None
+    word, numbers = match.group(1).lower(), match.group(2)
+    letter = VOICE_LETTER.get(word, word.upper())
+    return letter, tuple(int(value) for value in re.findall(r"\d+", numbers))
+
+
+def _from_staff_map(recorded: str, names: dict[int, str]) -> list[PrintedStaff] | None:
+    """Read `1:1,2;2:3,4` -- printed staff to the staves it was split into."""
+    printed = []
+    for entry in recorded.split(";"):
+        if ":" not in entry:
+            return None
+        _, staves = entry.split(":", 1)
+        ids = [int(value) for value in staves.split(",") if value.strip()]
+        if not ids:
+            return None
+        printed.append(PrintedStaff(ids, [names.get(staff, "") for staff in ids]))
+    return printed or None
+
+
+def _from_system_map(recorded: str, names: dict[int, str]) -> list[PrintedStaff] | None:
+    """A per-system map says which staves shared a printed one, system by system.
+
+    A score has a fixed number of staves while a page prints only the ones that
+    sound, so the grouping is taken over the whole score: two voices that share a
+    printed staff anywhere shared one, and a system where only one of them sings
+    prints that staff with one voice on it.
+    """
+    try:
+        systems = json.loads(recorded)
+    except ValueError:
+        return None
+    together: dict[int, set[int]] = {}
+    for system in systems:
+        for staves in system.get("map", {}).values():
+            for staff in staves:
+                together.setdefault(staff, set()).update(staves)
+    groups: list[list[int]] = []
+    seen: set[int] = set()
+    for staff in sorted(together):
+        if staff in seen:
+            continue
+        group = sorted(together[staff])
+        seen.update(group)
+        groups.append(group)
+    if not groups:
+        return None
+    return [PrintedStaff(g, [names.get(staff, "") for staff in g]) for g in groups]
+
+
+def _inferred(names: dict[int, str], singing: list[int]) -> list[PrintedStaff]:
+    """Guess the grouping from the part names: S1 with S2, Alto 1-1 with 1-2.
+
+    Choral engraving puts two numbered voices of one part on a staff, so within
+    a voice the parts are paired off in order.  A part whose name is not a voice
+    at all -- a solo line, a descant -- keeps a staff to itself rather than being
+    guessed onto somebody else's.  All of this is a guess, and `Grouping.
+    inferred` says so wherever the result is used.
+    """
+    by_voice: dict[str, list[tuple[tuple[int, ...], int]]] = {}
+    alone: list[int] = []
+    for staff in singing:
+        voice = voice_of(names.get(staff, ""))
+        if voice is None:
+            alone.append(staff)
+            continue
+        by_voice.setdefault(voice[0], []).append((voice[1], staff))
+
+    printed = []
+    for letter in sorted(by_voice, key=lambda k: VOICE_ORDER.index(k)):
+        ordered = [staff for _, staff in sorted(by_voice[letter])]
+        for index in range(0, len(ordered), 2):
+            group = ordered[index : index + 2]
+            printed.append(PrintedStaff(group, [names.get(s, "") for s in group]))
+    printed.extend(PrintedStaff([staff], [names.get(staff, "")]) for staff in alone)
+    printed.sort(key=lambda item: item.staves[0])
+    return printed
+
+
+def silent_staves(root: etree._Element) -> list[int]:
+    """Staves with nothing to sing: the click track the recorder adds."""
+    silent = []
+    for index, staff in enumerate(root.find("Score").findall("Staff"), start=1):
+        if staff.find(".//Chord") is None:
+            silent.append(int(staff.get("id", str(index))))
+    return silent
+
+
+def grouping(root: etree._Element) -> Grouping:
+    """How this score's staves map back onto the printed page."""
+    names = staff_names(root)
+    score = root.find("Score")
+    ids = [int(staff.get("id", "0")) for staff in score.findall("Staff")]
+    singing = [staff for staff in ids if staff not in silent_staves(root)]
+
+    for recorded, reader, source in (
+        (_meta(root, "lyricsSystemMap"), _from_system_map, "per-system map"),
+        (_meta(root, "lyricsStaffMap"), _from_staff_map, "staff map"),
+    ):
+        if not recorded:
+            continue
+        printed = reader(recorded, names)
+        if printed is None:
+            continue
+        listed = {staff for group in printed for staff in group.staves}
+        # A recorded map that names every singing staff is the score's own word
+        # for what the page looked like.  One that does not is not usable: the
+        # staves it leaves out would silently vanish from the reference.
+        if listed >= set(singing):
+            return Grouping([g for g in printed if set(g.staves) <= set(singing)], source)
+
+    return Grouping(_inferred(names, singing), "part names")
+
+
+def implode(root: etree._Element) -> Grouping:
+    """Merge the staves back onto the printed ones, in place.
+
+    Returns the grouping used, so a caller can say whether it was recorded or
+    guessed.
+    """
+    score = root.find("Score")
+    found = grouping(root)
+    staves = {int(s.get("id", "0")): s for s in score.findall("Staff")}
+    parts = {}
+    for part in score.findall("Part"):
+        for staff in part.findall("Staff"):
+            parts[int(staff.get("id", "0"))] = part
+
+    merged_parts, merged_staves = [], []
+    for number, printed in enumerate(found.printed, start=1):
+        first = printed.staves[0]
+        staff = _merge_staves([staves[s] for s in printed.staves])
+        staff.set("id", str(number))
+        merged_staves.append(staff)
+
+        part = etree.fromstring(etree.tostring(parts[first]))
+        for child in part.findall("Staff"):
+            part.remove(child)
+        holder = etree.SubElement(part, "Staff")
+        holder.set("id", str(number))
+        etree.SubElement(holder, "StaffType", group="pitched").append(
+            _text_element("name", "stdNormal")
+        )
+        part.insert(0, holder)
+        _rename(part, printed.label)
+        merged_parts.append(part)
+
+    for element in score.findall("Part") + score.findall("Staff"):
+        score.remove(element)
+    anchor = score.index(score.findall("metaTag")[-1]) + 1 if score.findall("metaTag") else 0
+    for offset, element in enumerate(merged_parts + merged_staves):
+        score.insert(anchor + offset, element)
+
+    # The lyric routing describes staves that no longer exist.
+    for tag in list(score.findall("metaTag")):
+        if tag.get("name") in ("lyricsStaffMap", "lyricsSystemMap"):
+            score.remove(tag)
+    return found
+
+
+def _text_element(tag: str, text: str) -> etree._Element:
+    element = etree.Element(tag)
+    element.text = text
+    return element
+
+
+def _rename(part: etree._Element, label: str) -> None:
+    for path in ("trackName", "Instrument/longName", "Instrument/shortName"):
+        for element in part.findall(path):
+            element.text = label
+
+
+def _merge_staves(members: list[etree._Element]) -> etree._Element:
+    """One staff carrying every member's voices, bar by bar."""
+    staff = etree.Element("Staff")
+    for element in members[0]:
+        if element.tag != "Measure":
+            staff.append(etree.fromstring(etree.tostring(element)))
+    bars = [member.findall("Measure") for member in members]
+    for index in range(max(len(m) for m in bars)):
+        measure = None
+        for position, member_bars in enumerate(bars):
+            if index >= len(member_bars):
+                continue
+            source = etree.fromstring(etree.tostring(member_bars[index]))
+            if measure is None:
+                measure = source
+                continue
+            for voice in source.findall("voice"):
+                # Only the first voice of a staff carries its clef, key and
+                # meter; a second copy would print them twice.
+                for element in voice.findall("*"):
+                    if element.tag in STAFF_LEVEL:
+                        voice.remove(element)
+                measure.append(voice)
+        if measure is not None:
+            staff.append(measure)
+    return staff

--- a/src/clean_score/tests/test_implode.py
+++ b/src/clean_score/tests/test_implode.py
@@ -80,6 +80,39 @@ def test_a_per_system_map_merges_then_splits_the_same_voices() -> None:
     assert staves[1].find("Measure/LayoutBreak") is None
 
 
+def test_a_fixed_position_carries_the_new_source_clef_at_a_system_boundary() -> None:
+    root = with_meta(
+        score([(1, "T1"), (2, "T2"), (3, "B")]),
+        "lyricsSystemMap",
+        '[{"start":1,"end":1,"map":{"1":[1],"2":[3]}},'
+        ' {"start":2,"end":2,"map":{"1":[1],"2":[2]}}]',
+    )
+    staves = root.find("Score").findall("Staff")
+    tenor_clef = etree.SubElement(staves[1].find("Measure/voice"), "Clef")
+    etree.SubElement(tenor_clef, "concertClefType").text = "G"
+    tenor_key = etree.SubElement(staves[1].find("Measure/voice"), "KeySig")
+    etree.SubElement(tenor_key, "accidental").text = "2"
+    tenor_time = etree.SubElement(staves[1].find("Measure/voice"), "TimeSig")
+    etree.SubElement(tenor_time, "sigN").text = "3"
+    etree.SubElement(tenor_time, "sigD").text = "4"
+    bass_clef = etree.SubElement(staves[2].find("Measure/voice"), "Clef")
+    etree.SubElement(bass_clef, "concertClefType").text = "F"
+    bass_key = etree.SubElement(staves[2].find("Measure/voice"), "KeySig")
+    etree.SubElement(bass_key, "accidental").text = "-3"
+    bass_time = etree.SubElement(staves[2].find("Measure/voice"), "TimeSig")
+    etree.SubElement(bass_time, "sigN").text = "6"
+    etree.SubElement(bass_time, "sigD").text = "8"
+
+    implode(root)
+
+    output = root.find("Score").findall("Staff")[1].findall("Measure")
+    assert output[0].findtext("voice/Clef/concertClefType") == "F"
+    assert output[1].findtext("voice/Clef/concertClefType") == "G"
+    assert output[1].findtext("voice/KeySig/accidental") == "2"
+    assert output[1].findtext("voice/TimeSig/sigN") == "3"
+    assert output[1].findtext("voice/TimeSig/sigD") == "4"
+
+
 def test_a_reviewed_grouping_beats_a_changing_per_system_map() -> None:
     root = with_meta(
         score([(1, "T1"), (2, "T2")]),

--- a/src/clean_score/tests/test_implode.py
+++ b/src/clean_score/tests/test_implode.py
@@ -173,3 +173,28 @@ def test_three_voices_go_onto_one_staff_in_the_order_reviewed() -> None:
     staves = root.find("Score").findall("Staff")
     assert len(staves) == 1
     assert [len(bar.findall("voice")) for bar in staves[0].findall("Measure")] == [3, 3]
+
+
+def test_a_voice_the_page_does_not_print_is_absent_where_it_rests() -> None:
+    root = score([(1, "T3"), (2, "T1")], bars=2)
+    resting = root.find("Score").findall("Staff")[0].findall("Measure")[0]
+    resting.find("voice/Chord").tag = "Rest"
+
+    implode(root, [["T3", "T1"]], ["T3"])
+
+    bars = root.find("Score").find("Staff").findall("Measure")
+    # T3 is the topmost voice and still drops out of the bar it rests through.
+    assert [len(bar.findall("voice")) for bar in bars] == [1, 2]
+
+
+def test_the_first_voice_left_in_a_bar_keeps_the_clef() -> None:
+    root = score([(1, "T3"), (2, "T1")], bars=1)
+    first = root.find("Score").findall("Staff")[0].findall("Measure")[0]
+    first.find("voice/Chord").tag = "Rest"
+    for staff in root.find("Score").findall("Staff"):
+        staff.find("Measure/voice").insert(0, etree.Element("Clef"))
+
+    implode(root, [["T3", "T1"]], ["T3"])
+
+    bar = root.find("Score/Staff/Measure")
+    assert len(bar.findall("voice/Clef")) == 1

--- a/src/clean_score/tests/test_implode.py
+++ b/src/clean_score/tests/test_implode.py
@@ -58,6 +58,46 @@ def test_a_per_system_map_is_read_over_the_whole_score() -> None:
     assert [printed.staves for printed in found.printed] == [[1, 2], [3, 4]]
 
 
+def test_a_per_system_map_merges_then_splits_the_same_voices() -> None:
+    root = with_meta(
+        score([(1, "T1"), (2, "T2")]),
+        "lyricsSystemMap",
+        '[{"start":1,"end":1,"map":{"1":[1,2]}},'
+        ' {"start":2,"end":2,"map":{"1":[1],"2":[2]}}]',
+    )
+
+    found = implode(root)
+
+    staves = root.find("Score").findall("Staff")
+    assert found.source == "per-system map"
+    assert len(staves) == 2
+    assert [len(staff.findall("Measure")[0].findall("voice")) for staff in staves] == [2, 1]
+    assert staves[1].find("Measure/voice/Rest/durationType").text == "measure"
+    assert [len(staff.findall("Measure")[1].findall("voice")) for staff in staves] == [1, 1]
+    assert root.findtext("Score/Style/hideEmptyStaves") == "1"
+    assert root.findtext("Score/Style/dontHideStavesInFirstSystem") == "0"
+    assert root.findtext("Score/Staff/Measure/LayoutBreak/subtype") == "line"
+    assert staves[1].find("Measure/LayoutBreak") is None
+
+
+def test_a_reviewed_grouping_beats_a_changing_per_system_map() -> None:
+    root = with_meta(
+        score([(1, "T1"), (2, "T2")]),
+        "lyricsSystemMap",
+        '[{"start":1,"end":1,"map":{"1":[1,2]}},'
+        ' {"start":2,"end":2,"map":{"1":[1],"2":[2]}}]',
+    )
+
+    found = implode(root, [["T1", "T2"]])
+
+    assert found.reviewed
+    assert len(root.find("Score").findall("Staff")) == 1
+    assert [
+        len(measure.findall("voice"))
+        for measure in root.find("Score/Staff").findall("Measure")
+    ] == [2, 2]
+
+
 def test_without_a_map_the_grouping_is_guessed_and_says_so() -> None:
     root = score([(1, "S1"), (2, "S2"), (3, "A1"), (4, "A2")])
 

--- a/src/clean_score/tests/test_implode.py
+++ b/src/clean_score/tests/test_implode.py
@@ -1,0 +1,133 @@
+"""The inverse of the voice split, and how it decides what shared a staff."""
+
+from lxml import etree
+
+from src.clean_score.implode import grouping, implode, voice_of
+
+
+def score(parts: list[tuple[int, str]], bars: int = 2, notes: bool = True) -> etree._Element:
+    """A cleaned score: one part per staff, one voice each."""
+    root = etree.Element("museScore")
+    element = etree.SubElement(root, "Score")
+    for staff_id, name in parts:
+        part = etree.SubElement(element, "Part")
+        etree.SubElement(part, "Staff", id=str(staff_id))
+        track = etree.SubElement(part, "trackName")
+        track.text = name
+    for staff_id, _ in parts:
+        staff = etree.SubElement(element, "Staff", id=str(staff_id))
+        for _ in range(bars):
+            measure = etree.SubElement(staff, "Measure")
+            voice = etree.SubElement(measure, "voice")
+            etree.SubElement(voice, "Chord" if notes else "Rest")
+    return root
+
+
+def with_meta(root: etree._Element, name: str, text: str) -> etree._Element:
+    score_element = root.find("Score")
+    tag = etree.Element("metaTag", name=name)
+    tag.text = text
+    score_element.insert(0, tag)
+    return root
+
+
+def test_a_recorded_staff_map_says_which_voices_shared_a_staff() -> None:
+    root = with_meta(
+        score([(1, "T1"), (2, "T2"), (3, "B1"), (4, "B2")]), "lyricsStaffMap", "1:1,2;2:3,4"
+    )
+
+    found = grouping(root)
+
+    assert not found.inferred
+    assert [printed.staves for printed in found.printed] == [[1, 2], [3, 4]]
+
+
+def test_a_per_system_map_is_read_over_the_whole_score() -> None:
+    root = with_meta(
+        score([(1, "T1"), (2, "T2"), (3, "B1"), (4, "B2")]),
+        "lyricsSystemMap",
+        '[{"start":1,"end":4,"map":{"1":[1,2],"2":[3,4]}},'
+        ' {"start":5,"end":8,"map":{"1":[1],"2":[3,4]}}]',
+    )
+
+    found = grouping(root)
+
+    # T2 rests through the second system, so that system prints one staff for
+    # the tenors -- but the two still shared a staff and still do here.
+    assert not found.inferred
+    assert [printed.staves for printed in found.printed] == [[1, 2], [3, 4]]
+
+
+def test_without_a_map_the_grouping_is_guessed_and_says_so() -> None:
+    root = score([(1, "S1"), (2, "S2"), (3, "A1"), (4, "A2")])
+
+    found = grouping(root)
+
+    assert found.inferred
+    assert [printed.staves for printed in found.printed] == [[1, 2], [3, 4]]
+
+
+def test_a_part_that_is_not_a_choir_voice_keeps_its_own_staff() -> None:
+    root = score([(1, "Solo"), (2, "Soprano 1"), (3, "Soprano 2")])
+
+    found = grouping(root)
+
+    assert [printed.staves for printed in found.printed] == [[1], [2, 3]]
+
+
+def test_four_of_a_voice_are_paired_in_order() -> None:
+    root = score([(1, "Alto 1-1"), (2, "Alto 1-2"), (3, "Alto 2-1"), (4, "Alto 2-2")])
+
+    assert [printed.staves for printed in grouping(root).printed] == [[1, 2], [3, 4]]
+
+
+def test_the_click_staff_is_not_part_of_the_printed_page() -> None:
+    root = score([(1, "S1"), (2, "S2")])
+    silent = etree.SubElement(root.find("Score"), "Staff", id="3")
+    etree.SubElement(etree.SubElement(silent, "Measure"), "voice")
+    part = etree.SubElement(root.find("Score"), "Part")
+    etree.SubElement(part, "Staff", id="3")
+    etree.SubElement(part, "trackName").text = "Click"
+
+    assert [printed.staves for printed in grouping(root).printed] == [[1, 2]]
+
+
+def test_imploding_puts_two_voices_back_on_one_staff() -> None:
+    root = with_meta(score([(1, "T1"), (2, "T2")]), "lyricsStaffMap", "1:1,2")
+
+    implode(root)
+
+    staves = root.find("Score").findall("Staff")
+    assert len(staves) == 1
+    assert [len(bar.findall("voice")) for bar in staves[0].findall("Measure")] == [2, 2]
+    assert len(root.find("Score").findall("Part")) == 1
+
+
+def test_only_the_first_voice_keeps_the_clef_and_key() -> None:
+    root = with_meta(score([(1, "T1"), (2, "T2")]), "lyricsStaffMap", "1:1,2")
+    for staff in root.find("Score").findall("Staff"):
+        voice = staff.find("Measure/voice")
+        voice.insert(0, etree.Element("Clef"))
+        voice.insert(1, etree.Element("KeySig"))
+
+    implode(root)
+
+    first = root.find("Score/Staff/Measure")
+    assert len(first.findall("voice/Clef")) == 1
+    assert len(first.findall("voice/KeySig")) == 1
+
+
+def test_the_lyric_routing_goes_with_the_staves_it_described() -> None:
+    root = with_meta(score([(1, "T1"), (2, "T2")]), "lyricsStaffMap", "1:1,2")
+
+    implode(root)
+
+    assert not [t for t in root.iter("metaTag") if t.get("name") == "lyricsStaffMap"]
+
+
+def test_a_name_is_only_a_voice_when_the_whole_name_is_one() -> None:
+    assert voice_of("S1") == ("S", (1,))
+    assert voice_of("Alto 1-2") == ("A", (1, 2))
+    assert voice_of("Sopraano 2") == ("S", (2,))
+    assert voice_of("Solo") is None
+    assert voice_of("Click") is None

--- a/src/clean_score/tests/test_implode.py
+++ b/src/clean_score/tests/test_implode.py
@@ -131,3 +131,45 @@ def test_a_name_is_only_a_voice_when_the_whole_name_is_one() -> None:
     assert voice_of("Sopraano 2") == ("S", (2,))
     assert voice_of("Solo") is None
     assert voice_of("Click") is None
+
+
+def test_a_reviewed_grouping_beats_the_recorded_one() -> None:
+    root = with_meta(
+        score([(1, "T1"), (2, "T2"), (3, "T3"), (4, "B")]), "lyricsStaffMap", "1:1,2;2:3;3:4"
+    )
+
+    found = grouping(root, [["T3", "T1", "T2"], ["B"]])
+
+    # The recorded map says how the app split the staves, which is not always
+    # how they were printed: here the page puts T3 on top of the tenor staff.
+    assert found.reviewed
+    assert [printed.staves for printed in found.printed] == [[3, 1, 2], [4]]
+
+
+def test_a_reviewed_grouping_can_ask_for_no_implosion() -> None:
+    root = score([(1, "S1"), (2, "S2")])
+
+    found = grouping(root, [["S1"], ["S2"]])
+
+    assert [printed.staves for printed in found.printed] == [[1], [2]]
+
+
+def test_a_review_naming_a_part_the_score_lacks_is_refused() -> None:
+    root = score([(1, "T1"), (2, "T2")])
+
+    try:
+        grouping(root, [["T1", "T9"]])
+    except KeyError as error:
+        assert "T9" in str(error)
+    else:
+        raise AssertionError("a review naming a part that is not there must not pass")
+
+
+def test_three_voices_go_onto_one_staff_in_the_order_reviewed() -> None:
+    root = score([(1, "T1"), (2, "T2"), (3, "T3")])
+
+    implode(root, [["T3", "T1", "T2"]])
+
+    staves = root.find("Score").findall("Staff")
+    assert len(staves) == 1
+    assert [len(bar.findall("voice")) for bar in staves[0].findall("Measure")] == [3, 3]

--- a/src/clean_score/tests/test_reference_manifest.py
+++ b/src/clean_score/tests/test_reference_manifest.py
@@ -1,0 +1,97 @@
+"""The reviewed OMR manifest is the authority for reference inputs."""
+
+import hashlib
+import json
+from types import SimpleNamespace
+
+import pytest
+from lxml import etree
+
+from scripts import implode_report, reference_manifest, scan_vs_reference
+
+
+def digest(path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()[:16]
+
+
+def reviewed_song(tmp_path, monkeypatch, cleaned: bytes = b"score"):
+    songs = tmp_path / "songs"
+    song = songs / "fixture"
+    song.mkdir(parents=True)
+    pdf = song / "reviewed.pdf"
+    score = song / "reviewed_cleaned.mscx"
+    pdf.write_bytes(b"page")
+    score.write_bytes(cleaned)
+    manifest = tmp_path / "omr-songs.json"
+    manifest.write_text(json.dumps({"songs": {"fixture": {
+        "pdf": pdf.name,
+        "cleaned": score.name,
+        "pdf_sha256": digest(pdf),
+        "cleaned_sha256": digest(score),
+        "video": {"videos": 1, "uploads": 0, "stage": "record"},
+        "review": {"status": "ok", "notes": "checked"},
+    }}}))
+    monkeypatch.setattr(reference_manifest, "MANIFEST", manifest)
+    monkeypatch.setattr(reference_manifest, "SONGS", songs)
+    return pdf, score
+
+
+def test_the_manifest_chooses_the_reviewed_files_not_an_alphabetical_match(
+    tmp_path, monkeypatch
+) -> None:
+    pdf, score = reviewed_song(tmp_path, monkeypatch)
+    (score.parent / "000_cleaned.mscx").write_bytes(b"different score")
+
+    found = reference_manifest.reference_files("fixture")
+
+    assert found.pdf == pdf
+    assert found.cleaned == score
+
+
+def test_the_reference_report_uses_the_manifest_instead_of_rediscovering_a_score(
+    tmp_path, monkeypatch
+) -> None:
+    pdf, score = reviewed_song(tmp_path, monkeypatch)
+    (score.parent / "000_cleaned.mscx").write_bytes(b"different score")
+
+    assert implode_report.songs() == [(
+        "fixture",
+        pdf,
+        score,
+        {"videos": 1, "uploads": 0, "stage": "record"},
+    )]
+
+
+@pytest.mark.parametrize("kind", ["pdf", "cleaned"])
+def test_a_reviewed_source_that_changed_is_refused(tmp_path, monkeypatch, kind) -> None:
+    pdf, score = reviewed_song(tmp_path, monkeypatch)
+    {"pdf": pdf, "cleaned": score}[kind].write_bytes(b"changed after review")
+
+    with pytest.raises(ValueError, match=rf"reviewed {kind} changed.*review it again"):
+        reference_manifest.reference_files("fixture")
+
+
+def test_a_hidden_resting_staff_does_not_add_a_reference_voice(
+    tmp_path, monkeypatch
+) -> None:
+    root = etree.Element("museScore")
+    score = etree.SubElement(root, "Score")
+    for staff_id, name, event in ((1, "S1", "Chord"), (2, "B1", "Rest")):
+        part = etree.SubElement(score, "Part")
+        etree.SubElement(part, "Staff", id=str(staff_id))
+        etree.SubElement(part, "trackName").text = name
+        staff = etree.SubElement(score, "Staff", id=str(staff_id))
+        voice = etree.SubElement(etree.SubElement(staff, "Measure"), "voice")
+        event_element = etree.SubElement(voice, event)
+        if event == "Chord":
+            etree.SubElement(event_element, "Note")
+    xml = etree.tostring(root, xml_declaration=True, encoding="UTF-8")
+    reviewed_song(tmp_path, monkeypatch, cleaned=xml)
+    band = SimpleNamespace(measure_start=1, measure_end=1)
+
+    assert scan_vs_reference.reference_systems("fixture", [band]) == [{
+        "staves": 1,
+        "bars": 1,
+        "notes": 1,
+        "voices": 1,
+    }]

--- a/src/song_app/tests/test_clean_flow.py
+++ b/src/song_app/tests/test_clean_flow.py
@@ -14,6 +14,7 @@ import pytest
 from lxml import etree
 
 from src.clean_score.tests.test_per_system import ANSWERS  # the fixture's reading
+from src.clean_score.implode import implode
 from src.clean_score.utils.per_system import use_answer_file
 from src.song_app import pipeline
 
@@ -74,6 +75,28 @@ def test_grid_answers_clean_headless_into_parts_and_lyric_routing(song_dir):
     assert smap[(1, 6)] == {"1": [1, 2], "2": [4]}      # T1+T2 divisi, then B
     assert smap[(26, 29)] == {"1": [1], "2": [2], "3": [4]}  # T3 absent -> printed 3 is B
     assert meta["lyricsStaffMap"] == "1:1;2:2;3:3;4:4"
+
+
+def test_cleaned_system_map_implodes_divisi_and_later_split_staves(song_dir):
+    src = _source(song_dir)
+    pipeline.save_system_answers(src, ANSWERS)
+    cleaned, _ = pipeline.run_clean(src, song_dir, per_system=True)
+    root = etree.parse(cleaned).getroot()
+
+    implode(root)
+
+    staves = root.findall(".//Score/Staff")
+
+    def singing_voices(staff, measure):
+        return sum(
+            voice.find("Chord") is not None
+            for voice in staff.findall("Measure")[measure].findall("voice")
+        )
+
+    # m1 prints T1+T2 together above B; the two unused fixed positions hide.
+    assert [singing_voices(staff, 0) for staff in staves] == [2, 1, 0, 0]
+    # m26 prints T1, T2 and B on three separate staves.
+    assert [singing_voices(staff, 25) for staff in staves] == [1, 1, 1, 0]
 
 
 def test_clean_without_answers_reports_no_output(song_dir):

--- a/src/song_app/tests/test_clean_flow.py
+++ b/src/song_app/tests/test_clean_flow.py
@@ -97,6 +97,14 @@ def test_cleaned_system_map_implodes_divisi_and_later_split_staves(song_dir):
     assert [singing_voices(staff, 0) for staff in staves] == [2, 1, 0, 0]
     # m26 prints T1, T2 and B on three separate staves.
     assert [singing_voices(staff, 25) for staff in staves] == [1, 1, 1, 0]
+    # Printed position 2 was the bass staff in the earlier system. When T2
+    # takes that position at m26, its inherited tenor clef must take over too.
+    assert (
+        staves[1]
+        .findall("Measure")[25]
+        .findtext("voice/Clef/concertClefType")
+        == "G8vb"
+    )
 
 
 def test_clean_without_answers_reports_no_output(song_dir):


### PR DESCRIPTION
Adds reviewed OMR references built from songs the choir has already sung and recorded. Cleaned scores are imploded back into their printed staff shape, then used for fixture creation, scan evaluation, and side-by-side reports.

The reviewed manifest now chooses the exact PDF and cleaned score for every consumer and verifies both recorded hashes before either file is used. A changed or missing reviewed source stops the workflow and requires manifest regeneration and another review. Reference voice totals also exclude staves hidden because they rest through the whole system.

Implosion now preserves each `lyricsSystemMap` measure range. Voices can share a printed staff in one system and split onto separate staves in a later system; unused fixed positions contain measure rests and are hidden by MuseScore. When a fixed printed position changes source staff, the incoming staff's inherited clef, key, and time signature are written at the boundary.

## Checked

- Focused implosion, reference-manifest, and real clean-flow tests: 31 passed
- All current manifest entries match both recorded hashes
- CI runs the full suite

AgentDeck session link unavailable in this worker environment.

Closes #138
