### PR TITLE
Carry notation state across imploded systems

### DIFF
--- a/src/clean_score/implode.py
+++ b/src/clean_score/implode.py
@@ -419,6 +419,17 @@ def _merge_measure(
     return measure
 
 
+def _first_kept_source(
+    sources: list[etree._Element], drop_when_resting: set[int]
+) -> int | None:
+    """Return the source member whose voice carries this printed staff's state."""
+    for position, source in enumerate(sources):
+        for voice in source.findall("voice"):
+            if position not in drop_when_resting or voice.find("Chord") is not None:
+                return position
+    return None
+
+
 def _rest_measure(source: etree._Element) -> etree._Element:
     """A full-bar rest carrying the source measure's staff-level state."""
     measure = etree.fromstring(etree.tostring(source))
@@ -449,19 +460,37 @@ def _source_states(
     return states
 
 
+def _measure_state(measure: etree._Element) -> dict[str, etree._Element]:
+    """Return explicit staff-level state written in one output measure."""
+    return {
+        element.tag: element
+        for element in measure.iter()
+        if element.tag in STAFF_LEVEL
+    }
+
+
 def _carry_source_state(
-    measure: etree._Element, state: dict[str, etree._Element]
+    measure: etree._Element,
+    source_state: dict[str, etree._Element],
+    output_state: dict[str, etree._Element],
 ) -> None:
-    """Write inherited source state when a fixed output position changes source."""
+    """Write changed inherited state when a fixed output position changes source."""
     voice = measure.find("voice")
     if voice is None:
-        voice = etree.SubElement(measure, "voice")
-    present = {element.tag for element in measure.iter() if element.tag in STAFF_LEVEL}
-    insert_at = 0
+        return
+    present = _measure_state(measure)
+    inherited = []
     for tag in STAFF_LEVEL:
-        if tag not in present and tag in state:
-            voice.insert(insert_at, etree.fromstring(etree.tostring(state[tag])))
-            insert_at += 1
+        incoming = source_state.get(tag)
+        previous = output_state.get(tag)
+        if (
+            tag not in present
+            and incoming is not None
+            and (previous is None or etree.tostring(incoming) != etree.tostring(previous))
+        ):
+            inherited.append(incoming)
+    for element in reversed(inherited):
+        voice.insert(0, etree.fromstring(etree.tostring(element)))
 
 
 def _merge_system_staves(
@@ -496,7 +525,8 @@ def _merge_system_staves(
         for element in template:
             if element.tag != "Measure" and not (position > 1 and element.tag == "VBox"):
                 staff.append(etree.fromstring(etree.tostring(element)))
-        previous_group: tuple[int, ...] | None = None
+        previous_owner: int | None = None
+        output_state: dict[str, etree._Element] = {}
         for index, base_measure in enumerate(base_bars):
             group = by_measure[index].printed.get(position)
             if group:
@@ -507,18 +537,22 @@ def _merge_system_staves(
                     if names.get(source, "") in set(drop_rests)
                 }
                 measure = _merge_measure(sources, silent)
-                current_group = tuple(group.staves)
-                if current_group != previous_group:
+                owner = _first_kept_source(sources, silent)
+                current_owner = group.staves[owner] if owner is not None else None
+                if current_owner is not None and current_owner != previous_owner:
                     _carry_source_state(
-                        measure, source_states[group.staves[0]][index]
+                        measure,
+                        source_states[current_owner][index],
+                        output_state,
                     )
             else:
                 measure = _rest_measure(base_measure)
-                current_group = None
+                current_owner = None
             for layout_break in measure.findall("LayoutBreak"):
                 measure.remove(layout_break)
             staff.append(measure)
-            previous_group = current_group
+            output_state.update(_measure_state(measure))
+            previous_owner = current_owner
         merged.append(staff)
 
     top = merged[0].findall("Measure") if merged else []

--- a/src/clean_score/tests/test_implode.py
+++ b/src/clean_score/tests/test_implode.py
@@ -113,6 +113,43 @@ def test_a_fixed_position_carries_the_new_source_clef_at_a_system_boundary() -> 
     assert output[1].findtext("voice/TimeSig/sigD") == "4"
 
 
+def test_a_boundary_uses_the_first_source_voice_that_is_actually_printed() -> None:
+    root = with_meta(
+        score([(1, "T1"), (2, "T2"), (3, "T3"), (4, "B")]),
+        "lyricsSystemMap",
+        '[{"start":1,"end":1,"map":{"1":[1],"2":[4]}},'
+        ' {"start":2,"end":2,"map":{"1":[1],"2":[2,3]}}]',
+    )
+    staves = root.find("Score").findall("Staff")
+    for staff, clef in zip(staves[1:], ("G", "C", "F")):
+        element = etree.SubElement(staff.find("Measure/voice"), "Clef")
+        etree.SubElement(element, "concertClefType").text = clef
+    staves[1].findall("Measure")[1].find("voice/Chord").tag = "Rest"
+
+    implode(root, drop_rests=["T2"])
+
+    boundary = root.find("Score").findall("Staff")[1].findall("Measure")[1]
+    assert boundary.findtext("voice/Clef/concertClefType") == "C"
+
+
+def test_a_boundary_does_not_repeat_unchanged_staff_state() -> None:
+    root = with_meta(
+        score([(1, "T1"), (2, "T2"), (3, "B")]),
+        "lyricsSystemMap",
+        '[{"start":1,"end":1,"map":{"1":[1],"2":[3]}},'
+        ' {"start":2,"end":2,"map":{"1":[1],"2":[2]}}]',
+    )
+    staves = root.find("Score").findall("Staff")
+    for staff in staves[1:]:
+        element = etree.SubElement(staff.find("Measure/voice"), "Clef")
+        etree.SubElement(element, "concertClefType").text = "G"
+
+    implode(root)
+
+    boundary = root.find("Score").findall("Staff")[1].findall("Measure")[1]
+    assert boundary.find("voice/Clef") is None
+
+
 def test_a_reviewed_grouping_beats_a_changing_per_system_map() -> None:
     root = with_meta(
         score([(1, "T1"), (2, "T2")]),

--- a/src/song_app/tests/test_clean_flow.py
+++ b/src/song_app/tests/test_clean_flow.py
@@ -97,11 +97,11 @@ def test_cleaned_system_map_implodes_divisi_and_later_split_staves(song_dir):
     assert [singing_voices(staff, 0) for staff in staves] == [2, 1, 0, 0]
     # m26 prints T1, T2 and B on three separate staves.
     assert [singing_voices(staff, 25) for staff in staves] == [1, 1, 1, 0]
-    # Printed position 2 was the bass staff in the earlier system. When T2
-    # takes that position at m26, its inherited tenor clef must take over too.
+    # Printed position 2 was the bass staff in the earlier systems. When T3
+    # takes that position at m20, its inherited tenor clef must take over too.
     assert (
         staves[1]
-        .findall("Measure")[25]
+        .findall("Measure")[19]
         .findtext("voice/Clef/concertClefType")
         == "G8vb"
     )


### PR DESCRIPTION
Completes the fixed-position staff handoff correction discovered after #138 merged.

When a printed position changes source staff, implosion now carries the first audible source voice's effective clef, key, and time signature into the boundary measure. It skips resting members and avoids emitting duplicate state when the incoming notation already matches the output position.

## Checked

- Focused implosion, reference-manifest, and real clean-flow tests: 33 passed

AgentDeck session link unavailable in this worker environment.

Closes #138
