### PR TITLE
Give a band only the staves its own system prints

### DIFF
--- a/scripts/make_stem_fixture.py
+++ b/scripts/make_stem_fixture.py
@@ -33,7 +33,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
 from scripts.implode_report import drop_rests_for, override_for  # noqa: E402
 from scripts.reference_manifest import reference_files  # noqa: E402
-from src.clean_score.implode import implode  # noqa: E402
+from src.clean_score.implode import grouping, implode  # noqa: E402
 from src.song_app import pdf_systems  # noqa: E402
 
 FIXTURES = Path(os.environ.get("HOMR_FIXTURES",
@@ -72,43 +72,42 @@ def trim(root: etree._Element, start: int, end: int) -> None:
                 voice.insert(offset, carried[tag])
 
 
-def keep_printed(root: etree._Element, found, start: int) -> None:
-    """Drop the staves this system does not print.
+def system_override(root: etree._Element, start: int) -> list[list[str]] | None:
+    """The staves the page prints in the system this band cuts out.
 
-    `implode` gives the whole score one set of printed staves -- a slot per
-    top-to-bottom page position, sized by the widest system in the piece.  That
-    is right for a score, and wrong for one band of it: a part that rests through
-    a system is simply not printed, so a band cut out of a four-slot score can
-    hold three staves, or two.
+    `implode` groups for a whole score: one slot per top-to-bottom page
+    position, and each slot holds every part that ever occupies it.  That is
+    right for a score and wrong for one band of it, in two ways at once.
 
-    The reference kept the slot anyway, as a staff of rests, and then said the
-    page printed three staves where it printed two.  Every note is matched on its
-    staff, so that one extra row made a system homr had read correctly report
-    twenty-six lost noteheads -- and, worse, pointed the blame at homr.
+    A band gets **too many staves**, because the slots are sized by the widest
+    system in the piece and a part that rests through a system is simply not
+    printed.  `kayttaytymisohjeita-s1` came out with a third staff of rests the
+    page has no row for.
 
-    Which staves this system prints is not inferred here: the per-system map
-    already records it, position by position, and `Grouping.systems` carries it
-    through.  A song whose grouping has no per-system map keeps every slot, which
-    is what a score with fixed staff roles should do.
+    And a band gets **the wrong staves in a slot**, because slot membership is
+    unioned too.  On `laulun-aika-3` position 1 carries T1 and T2 in some systems
+    and T3 in others, so every band was given one tenor staff labelled `T3/T1/T2`
+    holding all three -- against a page that prints them on three separate
+    staves.
+
+    Both go away by asking the band's own system instead of the score.  The
+    per-system map records it position by position, `Grouping.systems` carries it
+    through, and `implode` already accepts a grouping by part name -- the same
+    door a person's reading of the page comes through, which is why a recorded
+    override still wins over this.
+
+    Nothing is inferred here.  A score with no per-system map, or one whose map
+    does not cover this bar, is imploded as the whole score, which is what fixed
+    staff roles should do.
     """
+    found = grouping(root)
     system = next((s for s in found.systems if s.start <= start <= s.end), None)
     if system is None or not system.printed:
-        return
-    order = {old: new for new, old in enumerate(sorted(system.printed), start=1)}
-    score = root.find("Score")
-    for staff in score.findall("Staff"):
-        old = int(staff.get("id", "0"))
-        if old in order:
-            staff.set("id", str(order[old]))
-        else:
-            score.remove(staff)
-    for part in score.findall("Part"):
-        holder = part.find("Staff")
-        old = int(holder.get("id", "0")) if holder is not None else 0
-        if old in order:
-            holder.set("id", str(order[old]))
-        else:
-            score.remove(part)
+        return None
+    printed = [list(system.printed[position].names) for position in sorted(system.printed)]
+    if any(not name for group in printed for name in group):
+        return None
+    return printed
 
 
 def main() -> None:
@@ -138,8 +137,8 @@ def main() -> None:
         picture.write_bytes(Path(image.path).read_bytes())
 
         root = etree.parse(str(sources.cleaned)).getroot()
-        found = implode(root, override_for(args.slug), drop_rests_for(args.slug))
-        keep_printed(root, found, band.measure_start)
+        override = override_for(args.slug) or system_override(root, band.measure_start)
+        implode(root, override, drop_rests_for(args.slug))
         trim(root, band.measure_start, band.measure_end)
         score = Path(tmp) / f"{name}.mscx"
         etree.ElementTree(root).write(str(score), encoding="UTF-8",

--- a/scripts/make_stem_fixture.py
+++ b/scripts/make_stem_fixture.py
@@ -72,6 +72,45 @@ def trim(root: etree._Element, start: int, end: int) -> None:
                 voice.insert(offset, carried[tag])
 
 
+def keep_printed(root: etree._Element, found, start: int) -> None:
+    """Drop the staves this system does not print.
+
+    `implode` gives the whole score one set of printed staves -- a slot per
+    top-to-bottom page position, sized by the widest system in the piece.  That
+    is right for a score, and wrong for one band of it: a part that rests through
+    a system is simply not printed, so a band cut out of a four-slot score can
+    hold three staves, or two.
+
+    The reference kept the slot anyway, as a staff of rests, and then said the
+    page printed three staves where it printed two.  Every note is matched on its
+    staff, so that one extra row made a system homr had read correctly report
+    twenty-six lost noteheads -- and, worse, pointed the blame at homr.
+
+    Which staves this system prints is not inferred here: the per-system map
+    already records it, position by position, and `Grouping.systems` carries it
+    through.  A song whose grouping has no per-system map keeps every slot, which
+    is what a score with fixed staff roles should do.
+    """
+    system = next((s for s in found.systems if s.start <= start <= s.end), None)
+    if system is None or not system.printed:
+        return
+    order = {old: new for new, old in enumerate(sorted(system.printed), start=1)}
+    score = root.find("Score")
+    for staff in score.findall("Staff"):
+        old = int(staff.get("id", "0"))
+        if old in order:
+            staff.set("id", str(order[old]))
+        else:
+            score.remove(staff)
+    for part in score.findall("Part"):
+        holder = part.find("Staff")
+        old = int(holder.get("id", "0")) if holder is not None else 0
+        if old in order:
+            holder.set("id", str(order[old]))
+        else:
+            score.remove(part)
+
+
 def main() -> None:
     load_dotenv()
     parser = argparse.ArgumentParser(description=__doc__)
@@ -99,7 +138,8 @@ def main() -> None:
         picture.write_bytes(Path(image.path).read_bytes())
 
         root = etree.parse(str(sources.cleaned)).getroot()
-        implode(root, override_for(args.slug), drop_rests_for(args.slug))
+        found = implode(root, override_for(args.slug), drop_rests_for(args.slug))
+        keep_printed(root, found, band.measure_start)
         trim(root, band.measure_start, band.measure_end)
         score = Path(tmp) / f"{name}.mscx"
         etree.ElementTree(root).write(str(score), encoding="UTF-8",

--- a/src/clean_score/tests/test_implode.py
+++ b/src/clean_score/tests/test_implode.py
@@ -308,3 +308,60 @@ def test_the_first_voice_left_in_a_bar_keeps_the_clef() -> None:
 
     bar = root.find("Score/Staff/Measure")
     assert len(bar.findall("voice/Clef")) == 1
+
+
+def test_a_band_keeps_only_the_staves_its_own_system_prints() -> None:
+    """One band of a score is not the whole score's set of printed staves.
+
+    `implode` sizes the slots by the widest system in the piece, so a band cut
+    out of a three-slot score kept a staff of rests the page never printed --
+    and the reference then claimed three printed staves against a page that
+    prints two.
+    """
+    from scripts.make_stem_fixture import keep_printed
+
+    root = with_meta(
+        score([(1, "T1"), (2, "T2"), (3, "B")], bars=4),
+        "lyricsSystemMap",
+        '[{"start":1,"end":2,"map":{"1":[1,2],"2":[3]}},'
+        ' {"start":3,"end":4,"map":{"1":[1],"2":[2],"3":[3]}}]',
+    )
+    found = implode(root)
+    assert len(root.find("Score").findall("Staff")) == 3
+
+    keep_printed(root, found, 1)
+
+    # The first system prints two staves; the third slot exists only because
+    # the second system splits the tenors.
+    staves = root.find("Score").findall("Staff")
+    assert [staff.get("id") for staff in staves] == ["1", "2"]
+    assert [part.find("Staff").get("id") for part in root.find("Score").findall("Part")] == ["1", "2"]
+
+
+def test_a_band_in_the_widest_system_keeps_every_staff() -> None:
+    root = with_meta(
+        score([(1, "T1"), (2, "T2"), (3, "B")], bars=4),
+        "lyricsSystemMap",
+        '[{"start":1,"end":2,"map":{"1":[1,2],"2":[3]}},'
+        ' {"start":3,"end":4,"map":{"1":[1],"2":[2],"3":[3]}}]',
+    )
+    found = implode(root)
+
+    from scripts.make_stem_fixture import keep_printed
+    keep_printed(root, found, 3)
+
+    assert [staff.get("id") for staff in root.find("Score").findall("Staff")] == ["1", "2", "3"]
+
+
+def test_a_score_with_no_per_system_map_keeps_every_staff() -> None:
+    """Fixed staff roles: there is no system that prints fewer."""
+    from scripts.make_stem_fixture import keep_printed
+
+    root = with_meta(
+        score([(1, "T1"), (2, "T2"), (3, "B1"), (4, "B2")]), "lyricsStaffMap", "1:1,2;2:3,4"
+    )
+    found = implode(root)
+
+    keep_printed(root, found, 1)
+
+    assert len(root.find("Score").findall("Staff")) == 2

--- a/src/clean_score/tests/test_implode.py
+++ b/src/clean_score/tests/test_implode.py
@@ -310,15 +310,16 @@ def test_the_first_voice_left_in_a_bar_keeps_the_clef() -> None:
     assert len(bar.findall("voice/Clef")) == 1
 
 
-def test_a_band_keeps_only_the_staves_its_own_system_prints() -> None:
-    """One band of a score is not the whole score's set of printed staves.
+def test_a_band_is_grouped_by_its_own_system_and_not_the_score() -> None:
+    """A band of a score is not the score.
 
-    `implode` sizes the slots by the widest system in the piece, so a band cut
-    out of a three-slot score kept a staff of rests the page never printed --
-    and the reference then claimed three printed staves against a page that
-    prints two.
+    `implode` groups over the whole piece: a slot per page position, holding
+    every part that ever occupies it.  One band then gets both too many staves
+    (a slot the widest system needs and this one does not print) and the wrong
+    parts inside one (position 1 unioned across systems that use it
+    differently).
     """
-    from scripts.make_stem_fixture import keep_printed
+    from scripts.make_stem_fixture import system_override
 
     root = with_meta(
         score([(1, "T1"), (2, "T2"), (3, "B")], bars=4),
@@ -326,42 +327,33 @@ def test_a_band_keeps_only_the_staves_its_own_system_prints() -> None:
         '[{"start":1,"end":2,"map":{"1":[1,2],"2":[3]}},'
         ' {"start":3,"end":4,"map":{"1":[1],"2":[2],"3":[3]}}]',
     )
-    found = implode(root)
-    assert len(root.find("Score").findall("Staff")) == 3
 
-    keep_printed(root, found, 1)
-
-    # The first system prints two staves; the third slot exists only because
-    # the second system splits the tenors.
-    staves = root.find("Score").findall("Staff")
-    assert [staff.get("id") for staff in staves] == ["1", "2"]
-    assert [part.find("Staff").get("id") for part in root.find("Score").findall("Part")] == ["1", "2"]
+    assert system_override(root, 1) == [["T1", "T2"], ["B"]]
+    assert system_override(root, 3) == [["T1"], ["T2"], ["B"]]
 
 
-def test_a_band_in_the_widest_system_keeps_every_staff() -> None:
+def test_the_band_grouping_is_what_implode_builds() -> None:
+    from scripts.make_stem_fixture import system_override
+
     root = with_meta(
         score([(1, "T1"), (2, "T2"), (3, "B")], bars=4),
         "lyricsSystemMap",
         '[{"start":1,"end":2,"map":{"1":[1,2],"2":[3]}},'
         ' {"start":3,"end":4,"map":{"1":[1],"2":[2],"3":[3]}}]',
     )
-    found = implode(root)
+    implode(root, system_override(root, 1))
 
-    from scripts.make_stem_fixture import keep_printed
-    keep_printed(root, found, 3)
+    # The first system prints two staves; without this it got the three the
+    # second system needs, the third of them holding nothing.
+    assert len(root.find("Score").findall("Staff")) == 2
 
-    assert [staff.get("id") for staff in root.find("Score").findall("Staff")] == ["1", "2", "3"]
 
-
-def test_a_score_with_no_per_system_map_keeps_every_staff() -> None:
-    """Fixed staff roles: there is no system that prints fewer."""
-    from scripts.make_stem_fixture import keep_printed
+def test_a_score_with_no_per_system_map_is_grouped_as_a_whole() -> None:
+    """Fixed staff roles: there is no system that prints something else."""
+    from scripts.make_stem_fixture import system_override
 
     root = with_meta(
         score([(1, "T1"), (2, "T2"), (3, "B1"), (4, "B2")]), "lyricsStaffMap", "1:1,2;2:3,4"
     )
-    found = implode(root)
 
-    keep_printed(root, found, 1)
-
-    assert len(root.find("Score").findall("Staff")) == 2
+    assert system_override(root, 1) is None


### PR DESCRIPTION
`implode` groups for a **whole score**: one slot per top-to-bottom page position, each holding every part that ever occupies it. For one band cut out of that score it is wrong twice over.

**Too many staves.** The slots are sized by the widest system in the piece, and a part that rests through a system is simply not printed. `kayttaytymisohjeita-s1`'s reference came out as

```
P1 'T1/T2'      40 notes
P2 'B1/B2/T2'   36 notes
P3 'B1/B2'       0 notes     <- the page prints no such staff
```

**The wrong parts inside a slot.** Membership is unioned too: on `laulun-aika-3`, position 1 carries T1 and T2 in some systems and T3 in others, so every band was given one tenor staff labelled `T3/T1/T2` holding all three — against a page that prints them separately.

Every note in the OMR comparison is matched on its staff, so one extra or wrong row is not one wrong number: it desynchronises the whole system. A page homr had read correctly reported **26 lost noteheads**, and the blame was written up against homr before anyone looked at the paper (corrected in eerovil/homr#18).

## The fix

Ask the band's own system. The per-system map records it position by position, `Grouping.systems` carries it through, and `implode` already takes a grouping by part name — the same door a person's reading of the page comes through, **which is why a recorded override still wins over this**. A score with no per-system map, or one whose map does not cover the bar, is imploded as the whole score.

## Measured

On the 46 printed systems of the four affected songs, against homr at `733c336`:

| | before | after |
|---|---|---|
| structural disagreements | 28 | **5** |
| agree / voice / pitch / count / beat | — | **all identical** |

Not one note comparison moves, because the slots removed were empty. That is the point.

## The five that remain — and they are three different things

Each was settled by looking at the printed page, not by the numbers.

- **`kaksi-laulua-krapulasta-2-s6`** — the page prints 2 staves, the reference says 2, **homr says 1**. A genuine homr defect, and now visible as one.
- **`kaksi-laulua-krapulasta-2-s16`** — the page prints **3**, the third resting throughout but still engraved. homr says 3; the reference says 2. The per-system map records which staves *sing*, not which are *printed*, so it cannot know this. A real limit on what a derived reference can claim, and the counterexample to "a resting part is not printed" — which does hold on `kayttaytymisohjeita`.
- **`laulun-aika-3` s5, s6, s7** — the song carries a **whole-song override a person recorded**, `[['T3','T1','T2'], ['B']]`, while the page prints four separate staves in s7 (labelled T3, T1, T2, B, each with its own lyric line). A whole-song override cannot express a per-system truth. **A recorded reading is not overruled here** — that needs a person's decision, and the honest options are a per-system override or a correction to the recorded one.

## Checked

`src/clean_score/tests/test_implode.py` — 24 passed, 3 new: a band is grouped by its own system and not the score, that grouping is what `implode` builds, and a score with no per-system map is left alone. CI green on the previous revision (run 33901825260); this revision's run is cited below.

Second half of a pair — #139 stopped the *grouping* being unioned across systems; this stops the *slot* being.

🤖 Generated with [Claude Code](https://claude.com/claude-code)