### PR TITLE
Repair the five references the sweep proved wrong

### DIFF
--- a/fixtures/omr-songs.json
+++ b/fixtures/omr-songs.json
@@ -160,18 +160,39 @@
         "labels": [
           "T1/T2",
           "B1/B2"
-        ]
+        ],
+        "override": {
+          "systems": [
+            {
+              "start": 58,
+              "end": 60,
+              "printed": [
+                [
+                  "T1",
+                  "T2"
+                ],
+                [
+                  "B1"
+                ],
+                [
+                  "B2"
+                ]
+              ],
+              "why": "s16: treble, then two bass staves. B2 rests through the whole system and the page prints its staff anyway, so the score's per-system map -- which records only the staves that sing -- is a staff short here."
+            }
+          ]
+        }
       },
       "review": {
         "status": "ok",
-        "notes": "checked against the page: staves, voices and words match"
+        "notes": "checked against the page: staves, voices and words match, except s16, where the page prints a third staff for a bass that rests through it; `grouping.override.systems` records that"
       }
     },
     "kayttaytymisohjeita": {
       "pdf": "Käyttäytymisohjeita.pdf",
       "cleaned": "Ka-ytta-ytymisohjeita_cleaned.mscx",
       "pdf_sha256": "f5a9eddc058cb46d",
-      "cleaned_sha256": "2537542c1e402462",
+      "cleaned_sha256": "9d3460c8766040f4",
       "video": {
         "videos": 0,
         "uploads": 5,
@@ -197,7 +218,7 @@
       },
       "review": {
         "status": "ok",
-        "notes": "checked against the page: staves, voices and words match"
+        "notes": "checked against the page: staves, voices and words match. Bars 26-32 carried an extra eighth rest in bar 26 that put every barline down to 32 an eighth early; repaired by hand on issue #161 against the printed page and recorded in the song's fixes.json"
       }
     },
     "laulun-aika-3": {
@@ -215,8 +236,12 @@
         "inferred": false,
         "printed": [
           [
-            3,
-            1,
+            3
+          ],
+          [
+            1
+          ],
+          [
             2
           ],
           [
@@ -224,29 +249,70 @@
           ]
         ],
         "labels": [
-          "T3/T1/T2",
+          "T3",
+          "T1",
+          "T2",
           "B"
         ],
         "override": {
           "printed": [
             [
-              "T3",
-              "T1",
+              "T3"
+            ],
+            [
+              "T1"
+            ],
+            [
               "T2"
             ],
             [
               "B"
             ]
           ],
-          "why": "the tenor staff carries three voices, T3 above T1 and T2; T3 is written only where it sings",
-          "drop_rests": [
-            "T3"
+          "why": "the page prints up to four staves, T3 over T1 over T2 over B, and prints T3 only where it sings. The earlier reading here said T3 shares the tenor staff as its top voice, which is not what the page does: T3 has a staff of its own in both systems it appears in. That reading was one grouping for a song whose systems print two, three and four staves, so it was applied to five bands it does not describe -- see `systems` below, and issue #161.",
+          "systems": [
+            {
+              "start": 20,
+              "end": 25,
+              "printed": [
+                [
+                  "T3"
+                ],
+                [
+                  "T1",
+                  "T2"
+                ],
+                [
+                  "B"
+                ]
+              ],
+              "why": "s5: T3 alone at the top, then T1 and T2 sharing a staff, then B. The score's own map has the same three staves and puts T3 second, because it numbers positions by musical rank and T3 ranks below T1 and T2."
+            },
+            {
+              "start": 30,
+              "end": 35,
+              "printed": [
+                [
+                  "T3"
+                ],
+                [
+                  "T1"
+                ],
+                [
+                  "T2"
+                ],
+                [
+                  "B"
+                ]
+              ],
+              "why": "s7: four staves, T3 T1 T2 B down the page, each labelled and each with its own lyric line. Same correction as s5 -- the map has the four staves and ranks T3 third."
+            }
           ]
         }
       },
       "review": {
         "status": "ok",
-        "notes": "T3 shares the tenor staff as its top voice and is absent where it rests"
+        "notes": "checked against the page system by system: s1-s4 print two staves (T1/T2, B) and s6 prints three (T1, T2, B), all as the score's per-system map says; s5 and s7 print T3 on a staff of its own above the rest, which the map has in the wrong place and `grouping.override.systems` corrects"
       }
     },
     "pois-meni-mereen-paiva": {

--- a/scripts/implode_report.py
+++ b/scripts/implode_report.py
@@ -40,6 +40,24 @@ def override_for(name: str) -> list[list[str]] | None:
     return (_reviewed(name).get("grouping", {}).get("override") or {}).get("printed")
 
 
+def system_override_for(name: str, start: int) -> list[list[str]] | None:
+    """The staves a person read off one printed system, if that one was read.
+
+    A whole-song reading cannot describe a page whose systems differ, and this
+    repertoire's do: `laulun-aika-3` prints two staves for four systems, three
+    for two of them and four for the last.  One reading for the song therefore
+    has to be wrong about most of it, which is what it was.
+
+    Recorded per measure range rather than per band index, because a band index
+    moves the moment somebody inserts a boundary in the Systems editor and a bar
+    number does not.
+    """
+    for system in (_reviewed(name).get("grouping", {}).get("override") or {}).get("systems") or []:
+        if system["start"] <= start <= system["end"]:
+            return [list(group) for group in system["printed"]]
+    return None
+
+
 def drop_rests_for(name: str) -> list[str]:
     """Parts whose silence the page does not print."""
     return (_reviewed(name).get("grouping", {}).get("override") or {}).get("drop_rests") or []

--- a/scripts/make_stem_fixture.py
+++ b/scripts/make_stem_fixture.py
@@ -31,7 +31,11 @@ from lxml import etree
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
-from scripts.implode_report import drop_rests_for, override_for  # noqa: E402
+from scripts.implode_report import (  # noqa: E402
+    drop_rests_for,
+    override_for,
+    system_override_for,
+)
 from scripts.reference_manifest import reference_files  # noqa: E402
 from src.clean_score.implode import grouping, implode  # noqa: E402
 from src.song_app import pdf_systems  # noqa: E402
@@ -93,12 +97,16 @@ def system_override(root: etree._Element, start: int) -> list[list[str]] | None:
     Both go away by asking the band's own system instead of the score.  The
     per-system map records it position by position, `Grouping.systems` carries it
     through, and `implode` already accepts a grouping by part name -- the same
-    door a person's reading of the page comes through, which is why a recorded
-    override still wins over this.
+    door a person's reading of the page comes through.
+
+    The positions are numbered by musical rank, so this can still be **wrong
+    about the order** where the page is: a voice printed above the parts it
+    ranks below -- `laulun-aika-3`'s T3 over T1 and T2 -- comes back underneath
+    them.  `system_override_for` is where that is corrected, and `band_grouping`
+    is the order the three answers are asked in.
 
     Nothing is inferred here.  A score with no per-system map, or one whose map
-    does not cover this bar, is imploded as the whole score, which is what fixed
-    staff roles should do.
+    does not cover this bar, falls back to whatever `band_grouping` has left.
     """
     found = grouping(root)
     system = next((s for s in found.systems if s.start <= start <= s.end), None)
@@ -108,6 +116,34 @@ def system_override(root: etree._Element, start: int) -> list[list[str]] | None:
     if any(not name for group in printed for name in group):
         return None
     return printed
+
+
+def band_grouping(
+    slug: str, root: etree._Element, start: int
+) -> list[list[str]] | None:
+    """The staves this band's own system prints, best evidence first.
+
+    A reading of **this system** beats the score's own map, which beats a
+    reading of the **whole song** -- and that last step is a correction.  A
+    whole-song reading used to beat everything, on the principle that a person
+    who looked at the page outranks a map the app wrote.  It does, about the
+    same thing: `laulun-aika-3`'s recorded reading is one grouping for a song
+    that prints two staves in four systems, three in two of them and four in the
+    last, so it was applied to five bands it does not describe and made three of
+    the worst six references in the corpus.  Specificity, not authority, is what
+    orders these -- so a per-system reading is added and sits at the top.
+
+    The map is right about which staves a system prints and can be wrong about
+    their **order**: it numbers positions by musical rank (S<A<T<B), and an
+    extra voice printed above the others -- `laulun-aika-3`'s T3 -- is then
+    ranked below the parts it sits over.  That is what a per-system reading is
+    for here; where the two agree there is nothing to record.
+    """
+    return (
+        system_override_for(slug, start)
+        or system_override(root, start)
+        or override_for(slug)
+    )
 
 
 def main() -> None:
@@ -137,7 +173,7 @@ def main() -> None:
         picture.write_bytes(Path(image.path).read_bytes())
 
         root = etree.parse(str(sources.cleaned)).getroot()
-        override = override_for(args.slug) or system_override(root, band.measure_start)
+        override = band_grouping(args.slug, root, band.measure_start)
         implode(root, override, drop_rests_for(args.slug))
         trim(root, band.measure_start, band.measure_end)
         score = Path(tmp) / f"{name}.mscx"

--- a/src/clean_score/tests/test_band_grouping.py
+++ b/src/clean_score/tests/test_band_grouping.py
@@ -1,0 +1,94 @@
+"""Which staves one printed band is given, and which reading of the page wins.
+
+A band gets its staves from three places, and until #161 they were asked in the
+wrong order: a reading of the whole song beat everything, including the score's
+own per-system map.  A whole-song reading cannot describe a page whose systems
+differ, and `laulun-aika-3`'s do -- two staves for four systems, three for one,
+four for the last -- so one reading was applied to five bands it does not
+describe and produced three of the worst six references in the corpus.
+
+What these pin is the ordering: **specificity, not authority.**  A reading of
+this system, then the score's map, then a reading of the song.
+"""
+
+import json
+
+import pytest
+
+from scripts import implode_report, make_stem_fixture
+from src.clean_score.tests.test_implode import score, with_meta
+
+PARTS = [(1, "T1"), (2, "T2"), (3, "T3"), (4, "B")]
+#: One system of two staves and one of three, the shape this all exists for.
+SYSTEM_MAP = json.dumps(
+    [
+        {"start": 1, "end": 4, "map": {"1": [1, 2], "2": [4]}},
+        {"start": 5, "end": 8, "map": {"1": [1, 2], "2": [3], "3": [4]}},
+    ]
+)
+
+
+@pytest.fixture
+def manifest(tmp_path, monkeypatch):
+    """A manifest this test owns, in the shape `fixtures/omr-songs.json` has."""
+
+    def write(grouping: dict) -> None:
+        path = tmp_path / "omr-songs.json"
+        path.write_text(json.dumps({"songs": {"a-song": {"grouping": grouping}}}))
+        monkeypatch.setattr(implode_report, "MANIFEST", path)
+
+    return write
+
+
+def test_a_reading_of_this_system_beats_the_score_and_the_song(manifest) -> None:
+    manifest(
+        {
+            "override": {
+                "printed": [["T3", "T1", "T2"], ["B"]],
+                "systems": [{"start": 5, "end": 8, "printed": [["T3"], ["T1", "T2"], ["B"]]}],
+            }
+        }
+    )
+    root = with_meta(score(PARTS, bars=8), "lyricsSystemMap", SYSTEM_MAP)
+
+    # The map has these three staves too, and puts T3 second: it numbers
+    # positions by musical rank, and T3 ranks below the parts it is printed over.
+    assert make_stem_fixture.system_override(root, 5) == [["T1", "T2"], ["T3"], ["B"]]
+    assert make_stem_fixture.band_grouping("a-song", root, 5) == [["T3"], ["T1", "T2"], ["B"]]
+
+
+def test_a_reading_covers_only_the_bars_it_names(manifest) -> None:
+    manifest(
+        {"override": {"systems": [{"start": 5, "end": 8, "printed": [["T3"], ["T1", "T2"], ["B"]]}]}}
+    )
+    root = with_meta(score(PARTS, bars=8), "lyricsSystemMap", SYSTEM_MAP)
+
+    # Inclusive at both ends, and the other system falls through to the map.
+    assert implode_report.system_override_for("a-song", 5) is not None
+    assert implode_report.system_override_for("a-song", 8) is not None
+    assert implode_report.system_override_for("a-song", 4) is None
+    assert make_stem_fixture.band_grouping("a-song", root, 1) == [["T1", "T2"], ["B"]]
+
+
+def test_the_score_s_own_map_beats_a_reading_of_the_whole_song(manifest) -> None:
+    manifest({"override": {"printed": [["T3", "T1", "T2"], ["B"]]}})
+    root = with_meta(score(PARTS, bars=8), "lyricsSystemMap", SYSTEM_MAP)
+
+    # This is the correction. The whole-song reading says two staves for every
+    # system of the piece; the map knows the second one prints three.
+    assert make_stem_fixture.band_grouping("a-song", root, 5) == [["T1", "T2"], ["T3"], ["B"]]
+
+
+def test_a_score_with_no_map_still_takes_the_reading_of_the_song(manifest) -> None:
+    manifest({"override": {"printed": [["T3", "T1", "T2"], ["B"]]}})
+    root = score(PARTS, bars=8)
+
+    assert make_stem_fixture.band_grouping("a-song", root, 5) == [["T3", "T1", "T2"], ["B"]]
+
+
+def test_a_song_nobody_has_read_is_left_to_its_map(manifest) -> None:
+    manifest({})
+    root = with_meta(score(PARTS, bars=8), "lyricsSystemMap", SYSTEM_MAP)
+
+    assert implode_report.system_override_for("a-song", 5) is None
+    assert make_stem_fixture.band_grouping("a-song", root, 5) == [["T1", "T2"], ["T3"], ["B"]]


### PR DESCRIPTION
Closes #161

Five references were wrong and they were five of the worst six systems in the corpus. Each was
checked against the printed band before anything was changed, and three of them turned out not to
be cleaned-score faults at all.

**Laulun aika s5, s6 and s7 came from a file in this repository.** The song's own per-system map
already had the right staves — s5 prints `T3 · T1/T2 · B`, s6 prints `T1 · T2 · B`, s7 prints
`T3 · T1 · T2 · B` — but `fixtures/omr-songs.json` carried a whole-song reading saying two staves
for every system, and a band asked that first. One reading cannot describe a page that prints two,
three and four staves, so it was applied to five bands it does not describe. `band_grouping` now
asks a reading of **this system**, then the score's map, then a reading of the song: specificity
rather than authority.

The map is right about *which* staves a system prints and can be wrong about their **order** — it
numbers positions by musical rank, so T3, printed above T1 and T2, comes back underneath them.
That is what `grouping.override.systems` is for, and it carries only the two systems where the two
disagree. All seven were checked against the page; the review notes say so.

**Kaksi laulua krapulasta s16** gets one such reading too: the page prints a third staff for a bass
that rests through the whole system, which a map recording only the staves that sing cannot know.

**`kayttaytymisohjeita-s8` was a real score fault.** Bar 26 of the cleaned score has one eighth rest
too many — the page rests an eighth and then a fermata quarter — so "Jos" starts an eighth late and
every barline down to bar 32 sits an eighth early, with five notes written as pairs tied across
them. Bar 32 is then an eighth short of the printed rest, which is where the displacement is
absorbed. Repaired by hand against the page; the sounding notes are unchanged apart from that one
eighth of silence. The score lives in `songs/` and is not committed here, so only its
`cleaned_sha256` moves — the repair itself is recorded in that song's `fixes.json`, because a
re-clean rebuilds from a source that still has the fault.

## Verification

Each case re-run against the same homr (`94b20bd`):

| case | before | after |
| --- | --- | --- |
| `laulun-aika-3-s5` | 2.0% | 98.8% |
| `laulun-aika-3-s6` | 0% of 62 | 100% |
| `laulun-aika-3-s7` | 0% of 89 | 100% |
| `kaksi-laulua-krapulasta-2-s16` | one structure fault | 100% |
| `kayttaytymisohjeita-s8` | 0% of 28 | every note matched, no faults |

`src/clean_score/tests/test_band_grouping.py` pins the ordering itself without needing a song:
a reading of this system beats the score and the song, it covers only the bars it names, and — the
correction — the score's own map beats a reading of the whole song.

The harness side of this (the freeze, `QUALITY.md` and the re-run sweep) is a companion pull
request in `eerovil/homr`, which the merge path here cannot release; it has to be merged by hand.

[AgentDeck session](https://bazzite.taile8d16e.ts.net/chats/903ee7f2dd9b474a9278291fd5ac066a)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
