### PR TITLE
Answer the grid before saying assembly lost the notes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1361,13 +1361,51 @@ state model are in `DESIGN.md`.
   of staves, assembly costs **nothing**: 89.7% per-system, 89.8% assembled. Over the 4
   where the staff count varies between systems it costs **65 points** — 93.5% to 28.3% —
   and 592 of those 791 faults are `size`, against 20 voice.
-  That is `_fill_column` below: a short system's staves are filled **from the top**, so a
-  page's lower voice lands on the upper row and every note of that column reads as the
-  wrong number of notes in the wrong place. It is deliberate as far as it goes — naming an
-  absent voice needs a person, and the `--per-system` grid asks one, which this harness
-  does not run — but the file `assemble` writes does put those notes on the wrong rows, and
-  anything reading it before the grid answers sees the numbers above. #173 said the same
-  thing and it is now the *whole* of the remaining loss rather than the larger half of it.
+  **That 65 points is what an unanswered file scores, and #195 measured how much of it is
+  the file rather than the answer.** The harness scores `scanned.musicxml`, which is a
+  positional intermediate — `_fill_column` fills a short system's staves from the top and
+  says so, and naming the rows is the `--per-system` grid's job, which the harness does not
+  run. So this pull request proposes reporting the same four pages with the grid **answered**
+  the way an operator would, from the reviewed score's own per-band grouping: cleaned in
+  per-system mode and imploded back to the page's printed shape, the pipeline the reference
+  itself came out of. Same parses, same scorer, same references.
+  `scripts/answered_vs_reference.py` is that measurement, committed for the same reason
+  `scripts/flatten_vs_reference.py` was: it re-scores parses somebody else already made, so
+  it needs no homr and the claim below can be checked rather than taken.
+
+  | 4 varying pages | per-system | assembled | assembled, grid answered |
+  | --- | --- | --- | --- |
+  | | 93.5% | 28.3% | **77.2%** |
+  | `size` faults | | 592 | **127** |
+
+  Answering the grid returns **48.9 of the 65 points**, and the control says the pipeline is
+  not what did it: over the 10 uniform pages the same round trip costs **1.0 point**
+  (89.8% → 88.8%), so it neither flatters nor punishes. Corpus-wide, the fourteen pages read
+  **84.4%** answered against 68.2% unanswered.
+
+  **And the 16.3 points left are not row placement at all.** They are on two pages, and both
+  are one thing: a crop that read **one bar more than the page prints** — Kaksi laulua
+  krapulasta 2 p2 s9 and p3 s12 each read 5 bars of a 4-bar system, the only two bar-count
+  disagreements in the corpus — after which the assembled score's bar numbers and the page's
+  part company and every later bar is compared against its neighbour. Scored up to that
+  point those pages are **95.5%** and **97.9%**, against per-system 96.0% and 98.3%: with the
+  grid answered, assembly costs **nothing**. The other two varying pages, which have no extra
+  bar, come back at 84.4% and 92.3% against per-system 86.3% and 94.4%. Under the #141 rule
+  the extra bar is homr's — the parse disagrees with the page — but nothing in the app
+  notices it, though `pdf_systems.label` already knows each band's printed bar range and
+  `read_systems` could compare the two.
+  **So `_fill_column` is not losing music, and it should not start guessing.** The tempting
+  fix is to work out which voice went silent from the clef, the part's range across the join,
+  or the row it held in the neighbouring systems. It would not help, because a short system
+  is usually not a silent voice: of the 9 narrow systems on these four pages, **2** are a
+  voice resting (Kaksi laulua p2 s8 and p3 s11, both tenors) and **7** are divisi printed on
+  two staves in one system and combined onto one in the others — Käyttäytymisohjeita prints
+  T1 and T2 apart in exactly one system of each page and together in the rest. There the
+  narrow system's first staff carries *two* of the reference's rows, so no assignment of it
+  to a single row is right, and no evidence in the pixels changes that. The judgement is
+  which parts a staff carries, not which row it sits on, and the grid already asks for it.
+  What the numbers above do settle is that **every assembled figure this map has quoted is a
+  number about an unanswered file**, including #192's own 68.2%.
   **Which voice is absent from a short system is not decided here**, because it is not
   recoverable from pixels — you need the words, the range, or the piece. Columns are
   filled from the top and the empty rows are measure rests; naming them is

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1372,6 +1372,21 @@ state model are in `DESIGN.md`.
   `scripts/answered_vs_reference.py` is that measurement, committed for the same reason
   `scripts/flatten_vs_reference.py` was: it re-scores parses somebody else already made, so
   it needs no homr and the claim below can be checked rather than taken.
+  **And the answer it was made with is frozen** (`fixtures/answered-pages.json`,
+  `scripts/answered_pages.py`), which is the difference between a committed script and
+  committed evidence. The grid answer used to be read live — the bands out of
+  `.systems.json`, the grouping out of the reviewed cleaned score — and both are host state
+  that has moved under earlier measurements on this map already, so the same script on the
+  same cached parses could later answer a different question and print a number with nothing
+  saying the question had changed. The manifest records each band's index, its printed bar
+  range and the staves the grid was answered with, and the scoring path reads that and never
+  a song. A page nobody froze is refused rather than read off the host, and a song that has
+  moved under a frozen page **stops the run** naming the band and both readings; `--record`
+  is the one way to write it and says what it changed.
+  `src/clean_score/tests/test_answered_pages.py` pins the refusals — a grouping edited
+  underneath a frozen run, a band dragged, a band inserted, a page never frozen — and that
+  the grid handed to the rebuild comes off the manifest. It needs no songs, no homr and no
+  MuseScore.
 
   | 4 varying pages | per-system | assembled | assembled, grid answered |
   | --- | --- | --- | --- |

--- a/fixtures/answered-pages.json
+++ b/fixtures/answered-pages.json
@@ -1,0 +1,698 @@
+{
+ "why": "The grid answers each measurement in scripts/answered_vs_reference.py was made with. Frozen so a later run of the same script on the same cached parses cannot quietly answer a different question.",
+ "pages": [
+  {
+   "song": "heraa-suomi-final",
+   "page": 1,
+   "bounds_sha256": "3ea930e00408d3de",
+   "cleaned_sha256": "7c698aaacc1fcedb",
+   "bands": [
+    {
+     "index": 1,
+     "measure_start": 1,
+     "measure_end": 3,
+     "staves": [
+      "T1+T2",
+      "B1+B2"
+     ]
+    },
+    {
+     "index": 2,
+     "measure_start": 4,
+     "measure_end": 5,
+     "staves": [
+      "T1+T2",
+      "B1+B2"
+     ]
+    },
+    {
+     "index": 3,
+     "measure_start": 6,
+     "measure_end": 8,
+     "staves": [
+      "T1+T2",
+      "B1+B2"
+     ]
+    },
+    {
+     "index": 4,
+     "measure_start": 9,
+     "measure_end": 10,
+     "staves": [
+      "T1+T2",
+      "B1+B2"
+     ]
+    }
+   ]
+  },
+  {
+   "song": "heraa-suomi-final",
+   "page": 2,
+   "bounds_sha256": "3ea930e00408d3de",
+   "cleaned_sha256": "7c698aaacc1fcedb",
+   "bands": [
+    {
+     "index": 5,
+     "measure_start": 11,
+     "measure_end": 13,
+     "staves": [
+      "T1+T2",
+      "B1+B2"
+     ]
+    },
+    {
+     "index": 6,
+     "measure_start": 14,
+     "measure_end": 15,
+     "staves": [
+      "T1+T2",
+      "B1+B2"
+     ]
+    },
+    {
+     "index": 7,
+     "measure_start": 16,
+     "measure_end": 17,
+     "staves": [
+      "T1+T2",
+      "B1+B2"
+     ]
+    }
+   ]
+  },
+  {
+   "song": "heraa-suomi-final",
+   "page": 3,
+   "bounds_sha256": "3ea930e00408d3de",
+   "cleaned_sha256": "7c698aaacc1fcedb",
+   "bands": [
+    {
+     "index": 8,
+     "measure_start": 18,
+     "measure_end": 20,
+     "staves": [
+      "T1+T2",
+      "B1+B2"
+     ]
+    },
+    {
+     "index": 9,
+     "measure_start": 21,
+     "measure_end": 23,
+     "staves": [
+      "T1+T2",
+      "B1+B2"
+     ]
+    },
+    {
+     "index": 10,
+     "measure_start": 24,
+     "measure_end": 27,
+     "staves": [
+      "T1+T2",
+      "B1+B2"
+     ]
+    },
+    {
+     "index": 11,
+     "measure_start": 28,
+     "measure_end": 29,
+     "staves": [
+      "T1+T2",
+      "B1+B2"
+     ]
+    }
+   ]
+  },
+  {
+   "song": "heraa-suomi-final",
+   "page": 4,
+   "bounds_sha256": "3ea930e00408d3de",
+   "cleaned_sha256": "7c698aaacc1fcedb",
+   "bands": [
+    {
+     "index": 12,
+     "measure_start": 30,
+     "measure_end": 31,
+     "staves": [
+      "T1+T2",
+      "B1+B2"
+     ]
+    },
+    {
+     "index": 13,
+     "measure_start": 32,
+     "measure_end": 34,
+     "staves": [
+      "T1+T2",
+      "B1+B2"
+     ]
+    },
+    {
+     "index": 14,
+     "measure_start": 35,
+     "measure_end": 37,
+     "staves": [
+      "T1+T2",
+      "B1+B2"
+     ]
+    },
+    {
+     "index": 15,
+     "measure_start": 38,
+     "measure_end": 40,
+     "staves": [
+      "T1+T2",
+      "B1+B2"
+     ]
+    }
+   ]
+  },
+  {
+   "song": "heraa-suomi-final",
+   "page": 5,
+   "bounds_sha256": "3ea930e00408d3de",
+   "cleaned_sha256": "7c698aaacc1fcedb",
+   "bands": [
+    {
+     "index": 16,
+     "measure_start": 41,
+     "measure_end": 43,
+     "staves": [
+      "T1+T2",
+      "B1+B2"
+     ]
+    },
+    {
+     "index": 17,
+     "measure_start": 44,
+     "measure_end": 46,
+     "staves": [
+      "T1+T2",
+      "B1+B2"
+     ]
+    },
+    {
+     "index": 18,
+     "measure_start": 47,
+     "measure_end": 49,
+     "staves": [
+      "T1+T2",
+      "B1+B2"
+     ]
+    },
+    {
+     "index": 19,
+     "measure_start": 50,
+     "measure_end": 52,
+     "staves": [
+      "T1+T2",
+      "B1+B2"
+     ]
+    }
+   ]
+  },
+  {
+   "song": "heraa-suomi-final",
+   "page": 6,
+   "bounds_sha256": "3ea930e00408d3de",
+   "cleaned_sha256": "7c698aaacc1fcedb",
+   "bands": [
+    {
+     "index": 20,
+     "measure_start": 53,
+     "measure_end": 55,
+     "staves": [
+      "T1+T2",
+      "B1+B2"
+     ]
+    },
+    {
+     "index": 21,
+     "measure_start": 56,
+     "measure_end": 58,
+     "staves": [
+      "T1+T2",
+      "B1+B2"
+     ]
+    },
+    {
+     "index": 22,
+     "measure_start": 59,
+     "measure_end": 60,
+     "staves": [
+      "T1+T2",
+      "B1+B2"
+     ]
+    },
+    {
+     "index": 23,
+     "measure_start": 61,
+     "measure_end": 63,
+     "staves": [
+      "T1+T2",
+      "B1+B2"
+     ]
+    },
+    {
+     "index": 24,
+     "measure_start": 64,
+     "measure_end": 66,
+     "staves": [
+      "T1+T2",
+      "B1+B2"
+     ]
+    }
+   ]
+  },
+  {
+   "song": "kaksi-laulua-krapulasta-2",
+   "page": 1,
+   "bounds_sha256": "6ac94615b7d569c8",
+   "cleaned_sha256": "2e07068ae150141c",
+   "bands": [
+    {
+     "index": 1,
+     "measure_start": 1,
+     "measure_end": 6,
+     "staves": [
+      "T1+T2",
+      "B1+B2"
+     ]
+    },
+    {
+     "index": 2,
+     "measure_start": 7,
+     "measure_end": 11,
+     "staves": [
+      "T1+T2",
+      "B1+B2"
+     ]
+    },
+    {
+     "index": 3,
+     "measure_start": 12,
+     "measure_end": 15,
+     "staves": [
+      "T1+T2",
+      "B1+B2"
+     ]
+    },
+    {
+     "index": 4,
+     "measure_start": 16,
+     "measure_end": 18,
+     "staves": [
+      "T1+T2",
+      "B1+B2"
+     ]
+    },
+    {
+     "index": 5,
+     "measure_start": 19,
+     "measure_end": 21,
+     "staves": [
+      "T1+T2",
+      "B1+B2"
+     ]
+    }
+   ]
+  },
+  {
+   "song": "kaksi-laulua-krapulasta-2",
+   "page": 2,
+   "bounds_sha256": "6ac94615b7d569c8",
+   "cleaned_sha256": "2e07068ae150141c",
+   "bands": [
+    {
+     "index": 6,
+     "measure_start": 22,
+     "measure_end": 24,
+     "staves": [
+      "T1+T2",
+      "B1+B2"
+     ]
+    },
+    {
+     "index": 7,
+     "measure_start": 25,
+     "measure_end": 28,
+     "staves": [
+      "T1+T2",
+      "B1",
+      "B2"
+     ]
+    },
+    {
+     "index": 8,
+     "measure_start": 29,
+     "measure_end": 32,
+     "staves": [
+      "B1",
+      "B2"
+     ]
+    },
+    {
+     "index": 9,
+     "measure_start": 33,
+     "measure_end": 36,
+     "staves": [
+      "T1+T2",
+      "B1",
+      "B2"
+     ]
+    },
+    {
+     "index": 10,
+     "measure_start": 37,
+     "measure_end": 39,
+     "staves": [
+      "T1+T2",
+      "B1",
+      "B2"
+     ]
+    }
+   ]
+  },
+  {
+   "song": "kaksi-laulua-krapulasta-2",
+   "page": 3,
+   "bounds_sha256": "6ac94615b7d569c8",
+   "cleaned_sha256": "2e07068ae150141c",
+   "bands": [
+    {
+     "index": 11,
+     "measure_start": 40,
+     "measure_end": 41,
+     "staves": [
+      "B1",
+      "B2"
+     ]
+    },
+    {
+     "index": 12,
+     "measure_start": 42,
+     "measure_end": 45,
+     "staves": [
+      "T1+T2",
+      "B1",
+      "B2"
+     ]
+    },
+    {
+     "index": 13,
+     "measure_start": 46,
+     "measure_end": 50,
+     "staves": [
+      "T1+T2",
+      "B1",
+      "B2"
+     ]
+    },
+    {
+     "index": 14,
+     "measure_start": 51,
+     "measure_end": 54,
+     "staves": [
+      "T1+T2",
+      "B1",
+      "B2"
+     ]
+    },
+    {
+     "index": 15,
+     "measure_start": 55,
+     "measure_end": 57,
+     "staves": [
+      "T1+T2",
+      "B1",
+      "B2"
+     ]
+    }
+   ]
+  },
+  {
+   "song": "kaksi-laulua-krapulasta-2",
+   "page": 4,
+   "bounds_sha256": "6ac94615b7d569c8",
+   "cleaned_sha256": "2e07068ae150141c",
+   "bands": [
+    {
+     "index": 16,
+     "measure_start": 58,
+     "measure_end": 60,
+     "staves": [
+      "T1+T2",
+      "B1",
+      "B2"
+     ]
+    },
+    {
+     "index": 17,
+     "measure_start": 61,
+     "measure_end": 65,
+     "staves": [
+      "T1+T2",
+      "B1",
+      "B2"
+     ]
+    },
+    {
+     "index": 18,
+     "measure_start": 66,
+     "measure_end": 69,
+     "staves": [
+      "T1+T2",
+      "B1",
+      "B2"
+     ]
+    },
+    {
+     "index": 19,
+     "measure_start": 70,
+     "measure_end": 76,
+     "staves": [
+      "T1+T2",
+      "B1",
+      "B2"
+     ]
+    },
+    {
+     "index": 20,
+     "measure_start": 77,
+     "measure_end": 86,
+     "staves": [
+      "T1+T2",
+      "B1",
+      "B2"
+     ]
+    }
+   ]
+  },
+  {
+   "song": "kayttaytymisohjeita",
+   "page": 1,
+   "bounds_sha256": "c15e3eb5c355f683",
+   "cleaned_sha256": "9d3460c8766040f4",
+   "bands": [
+    {
+     "index": 1,
+     "measure_start": 1,
+     "measure_end": 4,
+     "staves": [
+      "T1+T2",
+      "B1+B2"
+     ]
+    },
+    {
+     "index": 2,
+     "measure_start": 5,
+     "measure_end": 8,
+     "staves": [
+      "T1+T2",
+      "B1+B2"
+     ]
+    },
+    {
+     "index": 3,
+     "measure_start": 9,
+     "measure_end": 11,
+     "staves": [
+      "T1+T2",
+      "B1+B2"
+     ]
+    },
+    {
+     "index": 4,
+     "measure_start": 12,
+     "measure_end": 14,
+     "staves": [
+      "T1+T2",
+      "B1+B2"
+     ]
+    }
+   ]
+  },
+  {
+   "song": "kayttaytymisohjeita",
+   "page": 2,
+   "bounds_sha256": "c15e3eb5c355f683",
+   "cleaned_sha256": "9d3460c8766040f4",
+   "bands": [
+    {
+     "index": 5,
+     "measure_start": 15,
+     "measure_end": 18,
+     "staves": [
+      "T1",
+      "T2",
+      "B1+B2"
+     ]
+    },
+    {
+     "index": 6,
+     "measure_start": 19,
+     "measure_end": 22,
+     "staves": [
+      "T1+T2",
+      "B1+B2"
+     ]
+    },
+    {
+     "index": 7,
+     "measure_start": 23,
+     "measure_end": 26,
+     "staves": [
+      "T1+T2",
+      "B1+B2"
+     ]
+    },
+    {
+     "index": 8,
+     "measure_start": 27,
+     "measure_end": 31,
+     "staves": [
+      "T1+T2",
+      "B1+B2"
+     ]
+    },
+    {
+     "index": 9,
+     "measure_start": 32,
+     "measure_end": 36,
+     "staves": [
+      "T1+T2",
+      "B1+B2"
+     ]
+    }
+   ]
+  },
+  {
+   "song": "kayttaytymisohjeita",
+   "page": 3,
+   "bounds_sha256": "c15e3eb5c355f683",
+   "cleaned_sha256": "9d3460c8766040f4",
+   "bands": [
+    {
+     "index": 10,
+     "measure_start": 37,
+     "measure_end": 41,
+     "staves": [
+      "T1+T2",
+      "B1+B2"
+     ]
+    },
+    {
+     "index": 11,
+     "measure_start": 42,
+     "measure_end": 46,
+     "staves": [
+      "T1+T2",
+      "B1+B2"
+     ]
+    },
+    {
+     "index": 12,
+     "measure_start": 47,
+     "measure_end": 50,
+     "staves": [
+      "T1+T2",
+      "B1+B2"
+     ]
+    },
+    {
+     "index": 13,
+     "measure_start": 51,
+     "measure_end": 54,
+     "staves": [
+      "T1",
+      "T2",
+      "B1+B2"
+     ]
+    },
+    {
+     "index": 14,
+     "measure_start": 55,
+     "measure_end": 58,
+     "staves": [
+      "T1+T2",
+      "B1+B2"
+     ]
+    }
+   ]
+  },
+  {
+   "song": "kayttaytymisohjeita",
+   "page": 4,
+   "bounds_sha256": "c15e3eb5c355f683",
+   "cleaned_sha256": "9d3460c8766040f4",
+   "bands": [
+    {
+     "index": 15,
+     "measure_start": 59,
+     "measure_end": 62,
+     "staves": [
+      "T1+T2",
+      "B1+B2"
+     ]
+    },
+    {
+     "index": 16,
+     "measure_start": 63,
+     "measure_end": 66,
+     "staves": [
+      "T1+T2",
+      "B1+B2"
+     ]
+    },
+    {
+     "index": 17,
+     "measure_start": 67,
+     "measure_end": 71,
+     "staves": [
+      "T1+T2",
+      "B1+B2"
+     ]
+    },
+    {
+     "index": 18,
+     "measure_start": 72,
+     "measure_end": 74,
+     "staves": [
+      "T1+T2",
+      "B1+B2"
+     ]
+    },
+    {
+     "index": 19,
+     "measure_start": 75,
+     "measure_end": 78,
+     "staves": [
+      "T1+T2",
+      "B1+B2"
+     ]
+    }
+   ]
+  }
+ ]
+}

--- a/scripts/answered_pages.py
+++ b/scripts/answered_pages.py
@@ -1,0 +1,228 @@
+"""The operator answer a measurement was made with, frozen so it cannot move.
+
+`scripts/answered_vs_reference.py` scores an assembled page with the per-system
+grid answered, and the answer it uses is the thing the whole number turns on.
+That answer used to be read live: the bands out of `songs/<slug>/.systems.json`
+and the grouping out of the reviewed cleaned score, both of which are host state
+and both of which have already moved under earlier measurements on this map.  A
+committed script reading them would keep running and keep printing a number,
+with nothing in the evidence saying the question had changed.
+
+So this pull request proposes that the answer be **written down**.  A manifest
+entry names, per page, each band's index, the measure range it covers and the
+grouping the grid was answered with, plus a digest of the two files that were
+read to get them.  The scoring path then reads the manifest and never the songs,
+which is what makes a frozen run reproducible on a host that has no `songs/` at
+all.
+
+**Drift is refused, not absorbed.**  When the song files *are* present they are
+compared against the entry, and any difference stops the run naming the band and
+both readings.  Silently taking the live value would be the failure this file
+exists to prevent; silently keeping the frozen one and saying nothing would be
+the same failure wearing better manners.  Re-recording is a deliberate act
+(`--record`), and it says what it changed.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, List, Optional, Sequence, Tuple
+
+#: Committed beside the reviewed-song manifest, and for the same reason: it is
+#: what a claim in `CLAUDE.md` rests on, so it travels with the checkout.
+MANIFEST = Path("fixtures/answered-pages.json")
+
+
+class Drifted(RuntimeError):
+    """The song files no longer say what the frozen run was made against."""
+
+
+class NotFrozen(RuntimeError):
+    """Nothing has been written down for this page."""
+
+
+@dataclass(frozen=True)
+class FrozenBand:
+    """One printed system, as the frozen run saw it."""
+
+    index: int
+    measure_start: int
+    measure_end: int
+    #: The printed staves of this system, each as the cleaned parts it carries --
+    #: `[["T1", "T2"], ["B1"], ["B2"]]`. This is the grid answer.
+    grouping: List[List[str]]
+
+    def to_dict(self) -> dict:
+        # One string per printed staff -- `["T1+T2", "B1", "B2"]` -- because the
+        # manifest is read by people as well as by the script, and a nested list
+        # of one name per line buries the answer in punctuation. Part names are
+        # a voice letter and a number, so `+` cannot occur inside one.
+        return {
+            "index": self.index,
+            "measure_start": self.measure_start,
+            "measure_end": self.measure_end,
+            "staves": ["+".join(staff) for staff in self.grouping],
+        }
+
+    @staticmethod
+    def from_dict(raw: dict) -> "FrozenBand":
+        return FrozenBand(
+            index=int(raw["index"]),
+            measure_start=int(raw["measure_start"]),
+            measure_end=int(raw["measure_end"]),
+            grouping=[staff.split("+") for staff in raw["staves"]],
+        )
+
+
+@dataclass(frozen=True)
+class FrozenPage:
+    """Everything a run needs to answer one page's grid without reading a song."""
+
+    song: str
+    page: int
+    bands: List[FrozenBand]
+    #: What the bounds and the cleaned score hashed to when this was recorded.
+    #: Carried so a drift report can say *which* file moved, not merely that one
+    #: did -- a bounds edit and a score edit want different responses.
+    bounds_sha256: str = ""
+    cleaned_sha256: str = ""
+
+    @property
+    def key(self) -> Tuple[str, int]:
+        return (self.song, self.page)
+
+    @property
+    def name(self) -> str:
+        return f"{self.song}-p{self.page}"
+
+    @property
+    def groupings(self) -> List[List[List[str]]]:
+        return [band.grouping for band in self.bands]
+
+    def to_dict(self) -> dict:
+        return {
+            "song": self.song,
+            "page": self.page,
+            "bounds_sha256": self.bounds_sha256,
+            "cleaned_sha256": self.cleaned_sha256,
+            "bands": [band.to_dict() for band in self.bands],
+        }
+
+    @staticmethod
+    def from_dict(raw: dict) -> "FrozenPage":
+        return FrozenPage(
+            song=raw["song"],
+            page=int(raw["page"]),
+            bands=[FrozenBand.from_dict(b) for b in raw["bands"]],
+            bounds_sha256=raw.get("bounds_sha256", ""),
+            cleaned_sha256=raw.get("cleaned_sha256", ""),
+        )
+
+
+def digest(path: Path) -> str:
+    """The short hash the manifest records, or `""` for a file that is not here."""
+    if not path.is_file():
+        return ""
+    return hashlib.sha256(path.read_bytes()).hexdigest()[:16]
+
+
+def load(path: Path = MANIFEST) -> Dict[Tuple[str, int], FrozenPage]:
+    """Every page anybody has frozen, keyed by song and page."""
+    if not Path(path).is_file():
+        return {}
+    raw = json.loads(Path(path).read_text())
+    pages = [FrozenPage.from_dict(entry) for entry in raw.get("pages", [])]
+    return {page.key: page for page in pages}
+
+
+def frozen_page(
+    song: str, page: int, path: Path = MANIFEST
+) -> FrozenPage:
+    """The entry for one page, or a refusal naming it.
+
+    A page nobody has written down is an error and never a reason to go and read
+    the song: the answer is the measurement's input, and inventing it from
+    whatever the host holds today is exactly the substitution this refuses.
+    """
+    found = load(path).get((song, page))
+    if found is None:
+        raise NotFrozen(
+            f"{song}-p{page} is not in {path}: no grid answer has been frozen for "
+            f"it, and the live song is not a substitute. Record it first "
+            f"(`scripts/answered_vs_reference.py --record {song}-p{page}`)."
+        )
+    return found
+
+
+def save(pages: Sequence[FrozenPage], path: Path = MANIFEST, why: str = "") -> None:
+    """Write the manifest out, pages in a stable order."""
+    ordered = sorted(pages, key=lambda p: (p.song, p.page))
+    body = {
+        "why": why or (
+            "The grid answers each measurement in scripts/answered_vs_reference.py "
+            "was made with. Frozen so a later run of the same script on the same "
+            "cached parses cannot quietly answer a different question."
+        ),
+        "pages": [page.to_dict() for page in ordered],
+    }
+    Path(path).write_text(json.dumps(body, indent=1, ensure_ascii=False) + "\n")
+
+
+def compare(frozen: FrozenPage, live: FrozenPage) -> List[str]:
+    """What the song says now that the frozen run did not, band by band.
+
+    Returns sentences rather than raising, so a caller can report every
+    difference at once. Digests are deliberately **not** compared: a cleaned
+    score can be edited in ways that leave this page's grouping alone, and
+    stopping a run over that would train somebody to re-record without reading.
+    What is compared is what the measurement actually consumed.
+    """
+    said = []
+    if [b.index for b in frozen.bands] != [b.index for b in live.bands]:
+        said.append(
+            f"{frozen.name}: frozen against systems "
+            f"{[b.index for b in frozen.bands]}, the song now has "
+            f"{[b.index for b in live.bands]}"
+        )
+        return said
+    for was, now in zip(frozen.bands, live.bands):
+        where = f"{frozen.name} s{was.index}"
+        if (was.measure_start, was.measure_end) != (now.measure_start, now.measure_end):
+            said.append(
+                f"{where}: frozen over bars {was.measure_start}-{was.measure_end}, "
+                f"the song now says {now.measure_start}-{now.measure_end}"
+            )
+        if was.grouping != now.grouping:
+            said.append(
+                f"{where}: frozen answering {_say(was.grouping)}, the song now "
+                f"says {_say(now.grouping)}"
+            )
+    return said
+
+
+def check(frozen: FrozenPage, live: Optional[FrozenPage]) -> None:
+    """Refuse a run whose song has moved under it.
+
+    `live` is `None` when the song is not on this host, which is not drift and
+    not an error: the frozen entry is the whole input, so the run is exactly as
+    reproducible without the song as with it.
+    """
+    if live is None:
+        return
+    said = compare(frozen, live)
+    if said:
+        raise Drifted(
+            "\n".join(
+                ["The song no longer says what this measurement was frozen against:"]
+                + [f"  {line}" for line in said]
+                + ["Re-record it deliberately (--record) if the song is right now; "
+                   "do not score against a mixture of the two."]
+            )
+        )
+
+
+def _say(grouping: Sequence[Sequence[str]]) -> str:
+    return ", ".join("+".join(staff) for staff in grouping) or "nothing"

--- a/scripts/answered_vs_reference.py
+++ b/scripts/answered_vs_reference.py
@@ -1,0 +1,231 @@
+#!/usr/bin/env python3
+"""Score an assembled page again, this time with the per-system grid answered.
+
+`omr_systems.assemble` writes `scanned.musicxml`, which is a **positional**
+document: a short system's staves go in the top columns and the rest rest, and
+which part each column holds is deliberately not decided (see that module).  So
+scoring that file against a reference whose rows are parts measures the missing
+operator answer as if it were lost music -- which is what issue #195 was opened
+to separate.
+
+This runs the rest of the way the app runs: the assembled page is converted,
+cleaned in per-system mode with the grid answered from the reviewed score's own
+per-band grouping, and imploded back to the page's printed shape.  That is the
+pipeline the reference itself came out of, so the two sides are comparable.
+
+    .venv/bin/python scripts/answered_vs_reference.py                 # every page
+    .venv/bin/python scripts/answered_vs_reference.py kaksi-laulua-krapulasta-2-p3
+
+**Run the uniform pages too.**  A page whose systems all print the same number of
+staves has nothing for the grid to fix, so it measures what the round trip costs
+on its own; without that control an improvement on the varying pages says
+nothing.  Measured for #195 it is 1.0 point over 10 pages.
+
+Nothing here reads a page: it re-scores parses somebody else already made.  The
+cached band parses, page references and assembled pages come from #192's store
+(`--store`), and the scorer is the fork's own `compare_output` from a homr
+worktree (`--scorer`) -- the same two pieces #192 used, so the numbers stay
+comparable with the ones it published.
+"""
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import time
+from pathlib import Path
+
+from dotenv import load_dotenv
+from lxml import etree
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT))
+
+DEFAULT_STORE = Path.home() / ".local/share/musescore-choir-plugins/issue-192"
+DEFAULT_SCORER = Path.home() / "homr/.worktrees/issue-195-scorer"
+
+
+def log(message: str) -> None:
+    print(f"{time.strftime('%H:%M:%S')} {message}", flush=True)
+
+
+def groupings(slug: str, bands, band_grouping, implode_grouping, reference_files):
+    """What each band's system prints, in the words the reference is built from.
+
+    A song with nothing recorded per system falls back to the grouping `implode`
+    infers from the part names -- which is what the reference fell back to as
+    well, so the two sides still agree about what a row is.
+    """
+    cleaned = reference_files(slug).cleaned
+    found = [
+        band_grouping(slug, etree.parse(str(cleaned)).getroot(), band.measure_start)
+        for band in bands
+    ]
+    if any(g is None for g in found):
+        inferred = [
+            printed.names
+            for printed in implode_grouping(
+                etree.parse(str(cleaned)).getroot(), None
+            ).printed
+        ]
+        found = [g if g is not None else inferred for g in found]
+    return found
+
+
+def match_octave_notation(source: Path, made: Path) -> None:
+    """Undo an octave the clean added in notation only.
+
+    Cleaning marks a men's-choir treble staff `G8vb` (`clef-octave-change=-1`).
+    The scorer reads a note as a staff position, so a clef saying "sounds an
+    octave lower" with the pitches left where they were puts every note of that
+    staff seven positions out against a reference written the other way round.
+    That is a difference of notation between two files rather than of music, and
+    it has nothing to do with which row a staff landed on, so it is normalised
+    away here instead of being measured.
+    """
+    was = {}
+    for part in etree.parse(str(source)).getroot().findall("part"):
+        clef = part.find("measure/attributes/clef")
+        was[part.get("id")] = int(
+            (clef.findtext("clef-octave-change") or 0) if clef is not None else 0
+        )
+    tree = etree.parse(str(made))
+    moved = False
+    for part in tree.getroot().findall("part"):
+        clef = part.find("measure/attributes/clef")
+        now = int(
+            (clef.findtext("clef-octave-change") or 0) if clef is not None else 0
+        )
+        shift = now - was.get(part.get("id"), 0)
+        if not shift:
+            continue
+        moved = True
+        for octave in part.iter("octave"):
+            octave.text = str(int(octave.text) + shift)
+    if moved:
+        tree.write(str(made), xml_declaration=True, encoding="UTF-8")
+
+
+def answer(slug, page, bands, assembled, work, parts, cli):
+    """Clean the assembled page with the grid answered, imploded to the page shape."""
+    per_band = groupings(slug, bands, parts["band_grouping"],
+                         parts["implode_grouping"], parts["reference_files"])
+    widest = max(per_band, key=len)
+
+    work.mkdir(parents=True, exist_ok=True)
+    source = work / f"{slug}-p{page}.musicxml"
+    source.write_bytes(assembled.read_bytes())
+    mscx = parts["pipeline"].convert_to_mscx(str(source), str(work))
+
+    per_system = parts["per_system"]
+    layouts = per_system.layout_for_file(mscx)
+    if len(layouts) != len(bands):
+        raise RuntimeError(
+            f"{len(layouts)} systems in the file against {len(bands)} bands"
+        )
+    answers = {}
+    for layout, grouping in zip(layouts, per_band):
+        answers[layout.index] = {
+            row.staff_id: (",".join(grouping[n]) if n < len(grouping)
+                           else per_system.CLEARED)
+            for n, row in enumerate(layout.staves)
+        }
+
+    cleaned = work / f"{slug}-p{page}_cleaned.mscx"
+    with per_system.use_answer_file(str(work / "answers.json")):
+        per_system.save_answers(mscx, answers)
+        parts["clean_main"](mscx, str(cleaned), interactive=False, per_system=True)
+    if not cleaned.exists():
+        raise RuntimeError("cleaning produced nothing")
+
+    root = etree.parse(str(cleaned)).getroot()
+    parts["implode"](root, widest, parts["drop_rests_for"](slug))
+    imploded = work / f"{slug}-p{page}_imploded.mscx"
+    etree.ElementTree(root).write(str(imploded), encoding="UTF-8",
+                                 xml_declaration=True)
+    exported = work / f"{slug}-p{page}_answered.musicxml"
+    made = subprocess.run([cli, str(imploded), "-o", str(exported)],
+                          capture_output=True, text=True, timeout=600)
+    if made.returncode != 0 or not exported.exists():
+        raise RuntimeError(f"MuseScore refused the export: {made.stderr[-200:]}")
+    match_octave_notation(assembled, exported)
+    return exported, ",".join("+".join(g) for g in widest)
+
+
+def row(result) -> dict:
+    return dict(score=round(result.score, 1), scored=result.scored,
+                agree=result.agree, voice=result.voice, pitch=result.pitch,
+                size=result.size, timing=result.timing, meter=result.meter)
+
+
+def main() -> None:
+    load_dotenv()
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("pages", nargs="*", help="e.g. kaksi-laulua-krapulasta-2-p3")
+    parser.add_argument("--store", type=Path, default=DEFAULT_STORE,
+                        help="where the cached parses and references live")
+    parser.add_argument("--scorer", type=Path, default=DEFAULT_SCORER,
+                        help="a homr checkout to take `fixturecheck.compare` from")
+    args = parser.parse_args()
+
+    sys.path.insert(0, str(args.scorer))
+    from fixturecheck.compare import compare_output
+
+    os.chdir(ROOT)
+    from scripts.implode_report import drop_rests_for
+    from scripts.make_stem_fixture import band_grouping
+    from scripts.reference_manifest import reference_files
+    from src.clean_score.implode import grouping as implode_grouping
+    from src.clean_score.implode import implode
+    from src.clean_score.main import main as clean_main
+    from src.clean_score.utils import per_system
+    from src.song_app import pdf_systems, pipeline
+
+    parts = dict(band_grouping=band_grouping, implode_grouping=implode_grouping,
+                 reference_files=reference_files, drop_rests_for=drop_rests_for,
+                 implode=implode, clean_main=clean_main, per_system=per_system,
+                 pipeline=pipeline)
+    cli = os.environ.get("MUSESCORE_CLI_PATH", "musescore3")
+
+    pooled = {}
+    with tempfile.TemporaryDirectory(prefix="answered-") as scratch:
+        for line in (args.store / "results.jsonl").read_text().splitlines():
+            done = json.loads(line)
+            slug, page = done["song"], done["page"]
+            name = f"{slug}-p{page}"
+            if args.pages and name not in args.pages:
+                continue
+            reference = args.store / "refs" / f"{name}.musicxml"
+            assembled = args.store / "parses" / f"assembled-{name}.musicxml"
+            if not reference.exists() or not assembled.exists():
+                log(f"{name}: nothing cached for it; skipped")
+                continue
+            bands = sorted(
+                (b for b in pdf_systems.load_bounds(f"songs/{slug}") if b.page == page),
+                key=lambda b: b.index,
+            )
+            before = row(compare_output(reference, assembled))
+            try:
+                made, rows = answer(slug, page, bands, assembled,
+                                    Path(scratch) / name, parts, cli)
+            except Exception as failure:                        # noqa: BLE001
+                log(f"{name}: could not answer it — {failure}")
+                continue
+            after = row(compare_output(reference, made))
+            log(f"{name}: assembled {before['score']}% (size {before['size']}) "
+                f"-> answered {after['score']}% (size {after['size']}); rows {rows}")
+            for side, got in (("assembled", before), ("answered", after)):
+                held = pooled.setdefault(side, dict(agree=0, scored=0))
+                held["agree"] += got["agree"]
+                held["scored"] += got["scored"]
+
+    for side, held in pooled.items():
+        if held["scored"]:
+            log(f"{side}: {100.0 * held['agree'] / held['scored']:.1f}% "
+                f"over {held['scored']} notes")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/answered_vs_reference.py
+++ b/scripts/answered_vs_reference.py
@@ -9,17 +9,27 @@ operator answer as if it were lost music -- which is what issue #195 was opened
 to separate.
 
 This runs the rest of the way the app runs: the assembled page is converted,
-cleaned in per-system mode with the grid answered from the reviewed score's own
-per-band grouping, and imploded back to the page's printed shape.  That is the
-pipeline the reference itself came out of, so the two sides are comparable.
+cleaned in per-system mode with the grid answered, and imploded back to the
+page's printed shape.  That is the pipeline the reference itself came out of, so
+the two sides are comparable.
 
-    .venv/bin/python scripts/answered_vs_reference.py                 # every page
+    .venv/bin/python scripts/answered_vs_reference.py                 # every frozen page
     .venv/bin/python scripts/answered_vs_reference.py kaksi-laulua-krapulasta-2-p3
 
 **Run the uniform pages too.**  A page whose systems all print the same number of
 staves has nothing for the grid to fix, so it measures what the round trip costs
 on its own; without that control an improvement on the varying pages says
 nothing.  Measured for #195 it is 1.0 point over 10 pages.
+
+**The grid answer is frozen, not read live.**  It comes from
+`fixtures/answered-pages.json` (`scripts/answered_pages.py`), which records each
+band's index, its printed measure range and the grouping the grid was answered
+with.  A page that has not been frozen is an error and never a fall back to the
+song; a song that has moved under a frozen page stops the run naming the band.
+That matters because the bands and the reviewed cleaned score are host state and
+have moved under earlier measurements on this map already -- see #195.
+
+    .venv/bin/python scripts/answered_vs_reference.py --record        # write the manifest
 
 Nothing here reads a page: it re-scores parses somebody else already made.  The
 cached band parses, page references and assembled pages come from #192's store
@@ -43,6 +53,8 @@ from lxml import etree
 ROOT = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(ROOT))
 
+from scripts import answered_pages  # noqa: E402
+
 DEFAULT_STORE = Path.home() / ".local/share/musescore-choir-plugins/issue-192"
 DEFAULT_SCORER = Path.home() / "homr/.worktrees/issue-195-scorer"
 
@@ -51,27 +63,46 @@ def log(message: str) -> None:
     print(f"{time.strftime('%H:%M:%S')} {message}", flush=True)
 
 
-def groupings(slug: str, bands, band_grouping, implode_grouping, reference_files):
-    """What each band's system prints, in the words the reference is built from.
+def read_live(slug, page, parts):
+    """What the song on this host says about a page, or `None` if it has none.
 
-    A song with nothing recorded per system falls back to the grouping `implode`
-    infers from the part names -- which is what the reference fell back to as
-    well, so the two sides still agree about what a row is.
+    Only ever used to *check* a frozen entry, or to record one in the first
+    place. Nothing scored is taken from here.
     """
-    cleaned = reference_files(slug).cleaned
-    found = [
-        band_grouping(slug, etree.parse(str(cleaned)).getroot(), band.measure_start)
-        for band in bands
-    ]
-    if any(g is None for g in found):
-        inferred = [
-            printed.names
-            for printed in implode_grouping(
-                etree.parse(str(cleaned)).getroot(), None
-            ).printed
-        ]
-        found = [g if g is not None else inferred for g in found]
-    return found
+    try:
+        bands = sorted(
+            (b for b in parts["pdf_systems"].load_bounds(f"songs/{slug}")
+             if b.page == page),
+            key=lambda b: b.index,
+        )
+        cleaned = parts["reference_files"](slug).cleaned
+    except Exception:                                       # noqa: BLE001
+        return None
+    if not bands:
+        return None
+    found = []
+    for band in bands:
+        grouping = parts["band_grouping"](
+            slug, etree.parse(str(cleaned)).getroot(), band.measure_start
+        )
+        if grouping is None:
+            grouping = [
+                printed.names
+                for printed in parts["implode_grouping"](
+                    etree.parse(str(cleaned)).getroot(), None
+                ).printed
+            ]
+        found.append(answered_pages.FrozenBand(
+            index=band.index,
+            measure_start=band.measure_start or 0,
+            measure_end=band.measure_end or 0,
+            grouping=[list(staff) for staff in grouping],
+        ))
+    return answered_pages.FrozenPage(
+        song=slug, page=page, bands=found,
+        bounds_sha256=answered_pages.digest(Path(f"songs/{slug}/.systems.json")),
+        cleaned_sha256=answered_pages.digest(Path(cleaned)),
+    )
 
 
 def match_octave_notation(source: Path, made: Path) -> None:
@@ -108,32 +139,42 @@ def match_octave_notation(source: Path, made: Path) -> None:
         tree.write(str(made), xml_declaration=True, encoding="UTF-8")
 
 
-def answer(slug, page, bands, assembled, work, parts, cli):
-    """Clean the assembled page with the grid answered, imploded to the page shape."""
-    per_band = groupings(slug, bands, parts["band_grouping"],
-                         parts["implode_grouping"], parts["reference_files"])
-    widest = max(per_band, key=len)
+def grid_answers(frozen, layouts, cleared):
+    """The per-system grid, filled in from the frozen answer and nothing else.
 
-    work.mkdir(parents=True, exist_ok=True)
-    source = work / f"{slug}-p{page}.musicxml"
-    source.write_bytes(assembled.read_bytes())
-    mscx = parts["pipeline"].convert_to_mscx(str(source), str(work))
-
-    per_system = parts["per_system"]
-    layouts = per_system.layout_for_file(mscx)
-    if len(layouts) != len(bands):
+    This is where the measurement's one judgement enters, so it is a function of
+    the frozen page and the file's own layout -- there is no argument it could
+    take the live song through.
+    """
+    per_band = frozen.groupings
+    if len(layouts) != len(per_band):
         raise RuntimeError(
-            f"{len(layouts)} systems in the file against {len(bands)} bands"
+            f"{len(layouts)} systems in the file against {len(per_band)} frozen bands"
         )
     answers = {}
     for layout, grouping in zip(layouts, per_band):
         answers[layout.index] = {
-            row.staff_id: (",".join(grouping[n]) if n < len(grouping)
-                           else per_system.CLEARED)
+            row.staff_id: (",".join(grouping[n]) if n < len(grouping) else cleared)
             for n, row in enumerate(layout.staves)
         }
+    return answers
 
-    cleaned = work / f"{slug}-p{page}_cleaned.mscx"
+
+def answer(frozen, assembled, work, parts, cli):
+    """Clean the assembled page with the frozen grid answer, imploded to the page."""
+    widest = max(frozen.groupings, key=len)
+
+    work.mkdir(parents=True, exist_ok=True)
+    source = work / f"{frozen.name}.musicxml"
+    source.write_bytes(assembled.read_bytes())
+    mscx = parts["pipeline"].convert_to_mscx(str(source), str(work))
+
+    per_system = parts["per_system"]
+    answers = grid_answers(
+        frozen, per_system.layout_for_file(mscx), per_system.CLEARED
+    )
+
+    cleaned = work / f"{frozen.name}_cleaned.mscx"
     with per_system.use_answer_file(str(work / "answers.json")):
         per_system.save_answers(mscx, answers)
         parts["clean_main"](mscx, str(cleaned), interactive=False, per_system=True)
@@ -141,11 +182,11 @@ def answer(slug, page, bands, assembled, work, parts, cli):
         raise RuntimeError("cleaning produced nothing")
 
     root = etree.parse(str(cleaned)).getroot()
-    parts["implode"](root, widest, parts["drop_rests_for"](slug))
-    imploded = work / f"{slug}-p{page}_imploded.mscx"
+    parts["implode"](root, widest, parts["drop_rests_for"](frozen.song))
+    imploded = work / f"{frozen.name}_imploded.mscx"
     etree.ElementTree(root).write(str(imploded), encoding="UTF-8",
                                  xml_declaration=True)
-    exported = work / f"{slug}-p{page}_answered.musicxml"
+    exported = work / f"{frozen.name}_answered.musicxml"
     made = subprocess.run([cli, str(imploded), "-o", str(exported)],
                           capture_output=True, text=True, timeout=600)
     if made.returncode != 0 or not exported.exists():
@@ -160,6 +201,42 @@ def row(result) -> dict:
                 size=result.size, timing=result.timing, meter=result.meter)
 
 
+def wanted(store: Path, chosen) -> list:
+    """The pages to work on, in the store's own order."""
+    found = []
+    for line in (store / "results.jsonl").read_text().splitlines():
+        done = json.loads(line)
+        name = f"{done['song']}-p{done['page']}"
+        if chosen and name not in chosen:
+            continue
+        if any(name == f"{s}-p{p}" for s, p in found):
+            continue
+        found.append((done["song"], done["page"]))
+    return found
+
+
+def record(store, chosen, manifest, parts) -> None:
+    """Write down the grid answers the songs on this host give today."""
+    held = answered_pages.load(manifest)
+    for slug, page in wanted(store, chosen):
+        live = read_live(slug, page, parts)
+        if live is None:
+            log(f"{slug}-p{page}: no song on this host to record from; left alone")
+            continue
+        was = held.get((slug, page))
+        if was is None:
+            log(f"{slug}-p{page}: recorded, {len(live.bands)} bands")
+        else:
+            moved = answered_pages.compare(was, live)
+            log(f"{slug}-p{page}: re-recorded" if moved else
+                f"{slug}-p{page}: unchanged")
+            for line in moved:
+                log(f"    was -> now: {line}")
+        held[(slug, page)] = live
+    answered_pages.save(list(held.values()), manifest)
+    log(f"wrote {manifest}")
+
+
 def main() -> None:
     load_dotenv()
     parser = argparse.ArgumentParser(description=__doc__)
@@ -168,12 +245,17 @@ def main() -> None:
                         help="where the cached parses and references live")
     parser.add_argument("--scorer", type=Path, default=DEFAULT_SCORER,
                         help="a homr checkout to take `fixturecheck.compare` from")
+    parser.add_argument("--manifest", type=Path, default=None,
+                        help="the frozen grid answers "
+                             f"(default {answered_pages.MANIFEST})")
+    parser.add_argument("--record", action="store_true",
+                        help="write the manifest from the songs on this host, "
+                             "instead of scoring")
     args = parser.parse_args()
 
-    sys.path.insert(0, str(args.scorer))
-    from fixturecheck.compare import compare_output
-
     os.chdir(ROOT)
+    manifest = args.manifest or answered_pages.MANIFEST
+
     from scripts.implode_report import drop_rests_for
     from scripts.make_stem_fixture import band_grouping
     from scripts.reference_manifest import reference_files
@@ -186,30 +268,39 @@ def main() -> None:
     parts = dict(band_grouping=band_grouping, implode_grouping=implode_grouping,
                  reference_files=reference_files, drop_rests_for=drop_rests_for,
                  implode=implode, clean_main=clean_main, per_system=per_system,
-                 pipeline=pipeline)
-    cli = os.environ.get("MUSESCORE_CLI_PATH", "musescore3")
+                 pipeline=pipeline, pdf_systems=pdf_systems)
 
+    if args.record:
+        record(args.store, args.pages, manifest, parts)
+        return
+
+    sys.path.insert(0, str(args.scorer))
+    from fixturecheck.compare import compare_output
+
+    cli = os.environ.get("MUSESCORE_CLI_PATH", "musescore3")
     pooled = {}
     with tempfile.TemporaryDirectory(prefix="answered-") as scratch:
-        for line in (args.store / "results.jsonl").read_text().splitlines():
-            done = json.loads(line)
-            slug, page = done["song"], done["page"]
+        for slug, page in wanted(args.store, args.pages):
             name = f"{slug}-p{page}"
-            if args.pages and name not in args.pages:
-                continue
             reference = args.store / "refs" / f"{name}.musicxml"
             assembled = args.store / "parses" / f"assembled-{name}.musicxml"
             if not reference.exists() or not assembled.exists():
                 log(f"{name}: nothing cached for it; skipped")
                 continue
-            bands = sorted(
-                (b for b in pdf_systems.load_bounds(f"songs/{slug}") if b.page == page),
-                key=lambda b: b.index,
-            )
+            # Frozen first, and the song only as a check on it. A page nobody
+            # wrote down, or one the song has moved under, stops the run rather
+            # than being scored against whatever this host holds today.
+            try:
+                frozen = answered_pages.frozen_page(slug, page, manifest)
+                answered_pages.check(frozen, read_live(slug, page, parts))
+            except (answered_pages.NotFrozen, answered_pages.Drifted) as refused:
+                # Loudly and with a non-zero exit, because the alternative is a
+                # run that keeps printing a number for a question that moved.
+                raise SystemExit(str(refused))
             before = row(compare_output(reference, assembled))
             try:
-                made, rows = answer(slug, page, bands, assembled,
-                                    Path(scratch) / name, parts, cli)
+                made, rows = answer(frozen, assembled, Path(scratch) / name,
+                                    parts, cli)
             except Exception as failure:                        # noqa: BLE001
                 log(f"{name}: could not answer it — {failure}")
                 continue

--- a/src/clean_score/tests/test_answered_pages.py
+++ b/src/clean_score/tests/test_answered_pages.py
@@ -1,0 +1,182 @@
+"""A frozen measurement's grid answer cannot be moved by the songs on this host.
+
+`scripts/answered_vs_reference.py` scores an assembled page with the per-system
+grid answered, and that answer is the input the whole finding turns on.  It used
+to be read live -- the bands out of `.systems.json` and the grouping out of the
+reviewed cleaned score -- both of which are host state that has already moved
+under earlier measurements on this map.  So what is pinned here is that the
+frozen entry is the *only* thing the run can be answered from: a page nobody
+wrote down is refused rather than invented, a song that has moved stops the run
+rather than being absorbed, and the grid the rebuild is handed comes off the
+manifest whatever the song says now.
+"""
+
+import json
+from types import SimpleNamespace
+
+import pytest
+
+from scripts import answered_pages, answered_vs_reference
+
+
+def band(index, start, end, staves):
+    return answered_pages.FrozenBand(
+        index=index, measure_start=start, measure_end=end,
+        grouping=[s.split("+") for s in staves],
+    )
+
+
+def page(bands=None, song="fixture", number=2):
+    return answered_pages.FrozenPage(
+        song=song, page=number,
+        bands=bands or [
+            band(1, 1, 4, ["T1+T2", "B1+B2"]),
+            band(2, 5, 8, ["T1", "T2", "B1+B2"]),
+        ],
+        bounds_sha256="aaaa", cleaned_sha256="bbbb",
+    )
+
+
+def written(tmp_path, *pages):
+    path = tmp_path / "answered-pages.json"
+    answered_pages.save(list(pages), path)
+    return path
+
+
+def layouts(*staff_counts):
+    """Stand-ins for `per_system.layout_for_file`, note-bearing staves only."""
+    return [
+        SimpleNamespace(
+            index=n,
+            staves=[SimpleNamespace(staff_id=k + 1) for k in range(count)],
+        )
+        for n, count in enumerate(staff_counts)
+    ]
+
+
+def test_the_manifest_round_trips_the_answer_it_was_given(tmp_path) -> None:
+    path = written(tmp_path, page())
+
+    back = answered_pages.frozen_page("fixture", 2, path)
+
+    assert back.groupings == [[["T1", "T2"], ["B1", "B2"]],
+                              [["T1"], ["T2"], ["B1", "B2"]]]
+    assert [b.measure_start for b in back.bands] == [1, 5]
+    assert json.loads(path.read_text())["pages"][0]["bands"][1]["staves"] == [
+        "T1", "T2", "B1+B2"
+    ]
+
+
+def test_a_page_nobody_froze_is_refused_rather_than_read_off_the_song(
+    tmp_path,
+) -> None:
+    path = written(tmp_path, page())
+
+    with pytest.raises(answered_pages.NotFrozen) as refused:
+        answered_pages.frozen_page("fixture", 3, path)
+
+    assert "fixture-p3" in str(refused.value)
+    assert "--record" in str(refused.value)
+
+
+def test_a_live_grouping_edited_underneath_a_frozen_run_stops_it(tmp_path) -> None:
+    """The regression this file exists for: the song moved, the run refuses."""
+    path = written(tmp_path, page())
+    frozen = answered_pages.frozen_page("fixture", 2, path)
+    now = page(bands=[
+        band(1, 1, 4, ["T1+T2", "B1+B2"]),
+        band(2, 5, 8, ["T1+T2", "B1", "B2"]),      # the operator answer changed
+    ])
+
+    with pytest.raises(answered_pages.Drifted) as refused:
+        answered_pages.check(frozen, now)
+
+    said = str(refused.value)
+    assert "fixture-p2 s2" in said
+    assert "T1, T2, B1+B2" in said                  # what the run was frozen with
+    assert "T1+T2, B1, B2" in said                  # what the song says now
+    # And the frozen answer is untouched by the song having moved.
+    assert answered_pages.frozen_page("fixture", 2, path).groupings[1] == [
+        ["T1"], ["T2"], ["B1", "B2"]
+    ]
+
+
+def test_a_band_whose_bars_moved_stops_the_run_too(tmp_path) -> None:
+    path = written(tmp_path, page())
+    frozen = answered_pages.frozen_page("fixture", 2, path)
+    now = page(bands=[
+        band(1, 1, 4, ["T1+T2", "B1+B2"]),
+        band(2, 5, 9, ["T1", "T2", "B1+B2"]),      # the band was dragged
+    ])
+
+    with pytest.raises(answered_pages.Drifted) as refused:
+        answered_pages.check(frozen, now)
+
+    assert "bars 5-8" in str(refused.value)
+    assert "5-9" in str(refused.value)
+
+
+def test_a_band_inserted_into_the_page_is_named_as_such(tmp_path) -> None:
+    """Bands are positional, so a new one silently re-points every later answer."""
+    path = written(tmp_path, page())
+    frozen = answered_pages.frozen_page("fixture", 2, path)
+    now = page(bands=[
+        band(1, 1, 2, ["T1+T2", "B1+B2"]),
+        band(3, 3, 4, ["T1+T2", "B1+B2"]),
+        band(2, 5, 8, ["T1", "T2", "B1+B2"]),
+    ])
+
+    with pytest.raises(answered_pages.Drifted) as refused:
+        answered_pages.check(frozen, now)
+
+    assert "[1, 2]" in str(refused.value)
+    assert "[1, 3, 2]" in str(refused.value)
+
+
+def test_a_host_with_no_song_at_all_is_not_drift(tmp_path) -> None:
+    """The frozen entry is the whole input, so a fresh clone scores the same run."""
+    frozen = answered_pages.frozen_page("fixture", 2, written(tmp_path, page()))
+
+    answered_pages.check(frozen, None)
+
+
+def test_an_edit_that_left_this_page_alone_does_not_stop_the_run(tmp_path) -> None:
+    """Only what the measurement consumed is compared, not the file's hash.
+
+    A cleaned score can be edited in a bar this page does not cover. Stopping for
+    that would teach somebody to re-record without reading, which is the habit
+    the refusal exists to prevent.
+    """
+    frozen = answered_pages.frozen_page("fixture", 2, written(tmp_path, page()))
+    now = page()
+    object.__setattr__(now, "cleaned_sha256", "something else entirely")
+
+    answered_pages.check(frozen, now)
+
+
+def test_the_grid_is_filled_in_from_the_frozen_answer(tmp_path) -> None:
+    """What the rebuild is handed, per system and per staff."""
+    frozen = answered_pages.frozen_page("fixture", 2, written(tmp_path, page()))
+
+    answers = answered_vs_reference.grid_answers(frozen, layouts(2, 3), "-")
+
+    assert answers == {0: {1: "T1,T2", 2: "B1,B2"},
+                       1: {1: "T1", 2: "T2", 3: "B1,B2"}}
+
+
+def test_a_staff_the_frozen_answer_does_not_name_is_cleared_not_guessed(
+    tmp_path,
+) -> None:
+    frozen = answered_pages.frozen_page("fixture", 2, written(tmp_path, page()))
+
+    answers = answered_vs_reference.grid_answers(frozen, layouts(3, 3), "-")
+
+    assert answers[0] == {1: "T1,T2", 2: "B1,B2", 3: "-"}
+
+
+def test_a_file_with_more_systems_than_the_frozen_page_is_refused(tmp_path) -> None:
+    """Answers are positional, so a mismatch would answer the wrong system."""
+    frozen = answered_pages.frozen_page("fixture", 2, written(tmp_path, page()))
+
+    with pytest.raises(RuntimeError, match="3 systems in the file against 2"):
+        answered_vs_reference.grid_answers(frozen, layouts(2, 3, 2), "-")

--- a/src/song_app/omr_systems.py
+++ b/src/song_app/omr_systems.py
@@ -33,6 +33,18 @@ columns are filled from the top and the empty rows are measure rests; naming
 them is ``clean_score``'s ``--per-system`` grid's job, and that grid already asks
 a person, which is the only reliable answer.
 
+Issue #195 measured what that refusal costs and what it does not. Scored before
+the grid is answered, the four corpus pages whose systems print different staff
+counts read 28.3% against a per-system 93.5%, and 592 of the 791 faults are
+`size` -- but that is the intermediate being read as if it were the product.
+Answered from the reviewed score's own per-band grouping the same four pages read
+**77.2%**, and every point still missing is on the two pages where a crop read
+one bar more than the page prints; up to that bar assembly costs nothing. A
+better guess here would also not help: of the 9 narrow systems on those pages
+only 2 are a voice resting, and 7 are divisi printed apart in one system and
+together in the rest, where the narrow system's first staff carries two of the
+page's rows and no single row is the right answer.
+
 **Bounds are a precondition.** This module is given the printed systems; it does
 not look for them. Detecting them from the image was measured and abandoned in
 issue #80 (staff-line detection died at half a degree of skew, and grouping by
@@ -486,6 +498,16 @@ def assemble(scans: Sequence[SystemScan], out_path: str) -> str:
     columns 1 and 2 and leaves the rest resting. That is not a claim about which
     voice is missing -- it is a refusal to make one. The per-system grid asks a
     person, per system and per staff, and top-alignment is the shape it expects.
+
+    **So this file is a positional intermediate and reading it as the product
+    gives a wrong number** (#195). On the four corpus pages whose systems print
+    different staff counts it scores 28.3% against a per-system 93.5%; answered
+    the way an operator answers it, the same pages score 77.2%, and what is left
+    is two pages where a crop read one bar more than the page prints rather than
+    anything about rows. Guessing the row instead would not close it: 7 of those
+    pages' 9 narrow systems are divisi printed apart in one system and together in
+    the rest, so the narrow system's first staff carries two of the page's rows
+    and there is no single row to put it on.
 
     Three seams are closed here, all of them consequences of each crop being its
     own document. ``divisions`` is unified across the score and every duration


### PR DESCRIPTION
Closes #195

`omr_systems.assemble` costs 65 points on a page whose printed systems do not all carry the
same number of staves — 93.5% per-system against 28.3% assembled, with 592 of the 791 faults
`size`. #195 asked how much of that is the operator answer the harness never gave and how much
is the file `assemble` writes.

**Almost all of it is the missing answer.** Scored with the per-system grid answered the way an
operator answers it — from the reviewed score's own per-band grouping, cleaned in per-system
mode and imploded back to the page's printed shape, which is the pipeline the reference itself
came out of — the same four pages read **77.2%** on the same parses, the same scorer and the
same references. The control says the round trip is not what did it: over the ten uniform pages,
which have nothing for the grid to fix, it costs **1.0 point** (89.8% → 88.8%).

**The 16.3 points left are not row placement.** They are on two pages, and both are one thing: a
crop that read one bar more than the page prints (Kaksi laulua krapulasta 2 p2 s9 and p3 s12,
the only two bar-count disagreements in the corpus), after which the assembled score's bar
numbers and the page's part company. Up to that bar those pages read **95.5%** and **97.9%**
against a per-system 96.0% and 98.3% — with the grid answered, assembly costs nothing.

**And `_fill_column` should not start guessing.** Of the 9 narrow systems on these pages only 2
are a voice resting; 7 are divisi printed on two staves in one system and combined onto one in
the rest, where the narrow system's first staff carries *two* of the page's rows and no single
row is right. The judgement is which parts a staff carries, not which row it sits on.

## What is in the change

- `CLAUDE.md` and the `omr_systems` module / `assemble` docstrings: the 65 points is now stated
  as what an *unanswered* file scores, with the answered numbers beside it and the caveat that
  every assembled figure this map has quoted — including #192's 68.2% — is a number about an
  unanswered file. The corpus reads 84.4% answered.
- `scripts/answered_vs_reference.py`: the measurement, committed for the same reason
  `scripts/flatten_vs_reference.py` was. It re-scores parses somebody else already made, so it
  needs no homr, and it runs the uniform pages as its own control.

## The grid answer is frozen, not read live

Follow-up on review of `34edcad`. The script read its operator answer off host state — the bands
out of `songs/<slug>/.systems.json` and the grouping out of the reviewed cleaned score — both of
which have already moved under earlier measurements on this map. So `fixtures/answered-pages.json`
(`scripts/answered_pages.py`) now records each band's index, its printed bar range and the staves
the grid was answered with, and the scoring path reads that and never a song: a frozen run
reproduces on a host with no `songs/` at all. A page nobody froze is refused rather than read off
the host, and a song that has moved under a frozen page stops the run naming the band and both
readings; `--record` is the one way to write the manifest and says what it changed.
`src/clean_score/tests/test_answered_pages.py` pins both halves.

## Verification

- `src/clean_score/tests/test_answered_pages.py` (new, 10), plus `test_reference_manifest.py`, `test_band_grouping.py` and `src/song_app/tests/test_omr_systems.py` — 69 passed.
- All fourteen pages re-scored off the frozen manifest give the numbers already published, pooled
  68.2% assembled and 84.4% answered.
- A grouping edited under a frozen page stops the run with exit 1 and names the band; an unfrozen
  page stops it naming the page.
- CI on this branch.

No repository change is proposed for the extra bar; it is named in the terminal report as the
next thing to look at.

[AgentDeck session](https://bazzite.taile8d16e.ts.net/chats/180b850c110c40c3a9eceff905a07cc2)

