### PR TITLE
Use homr's supported printed-system proposal API

### DIFF
--- a/src/song_app/system_finder.py
+++ b/src/song_app/system_finder.py
@@ -14,9 +14,10 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import subprocess
 from contextlib import nullcontext
-from typing import Callable, Dict, List, Optional
+from typing import Callable, List, Optional
 
 from . import heavy_slot, omr, pdf_systems, system_finder_legacy as legacy
 from .omr import Engine, HomrError, HomrMissing
@@ -56,11 +57,15 @@ def _engine_command(engine: Engine) -> List[str]:
 
 
 def _unsupported(stderr: str) -> bool:
-    """Whether this is the expected old-homr answer that permits compatibility fallback."""
-    lowered = stderr.lower()
-    return "--find-system-bounds" in lowered and (
-        "unrecognized arguments" in lowered or "no such option" in lowered
-    )
+    """Only an explicit rejection of the proposal flag permits legacy fallback."""
+    # argparse also prints supported options in its usage text. Finding the flag
+    # there must not turn an unrelated CLI error into a successful legacy result.
+    return re.search(
+        r"(?:unrecognized arguments|no such option):[^\r\n]*"
+        r"(?<![\w-])--find-system-bounds(?![\w-])",
+        stderr,
+        re.IGNORECASE,
+    ) is not None
 
 
 def _page_from_homr(
@@ -110,6 +115,8 @@ def _page_from_homr(
     try:
         payload = json.loads(result.stdout)
         rows = payload["systems"]
+        if not isinstance(rows, list):
+            raise ValueError("systems must be a list")
         bounds = [
             SystemBounds(
                 index=int(row["index"]),
@@ -121,11 +128,13 @@ def _page_from_homr(
             )
             for row in rows
         ]
-    except (KeyError, TypeError, ValueError, json.JSONDecodeError) as exc:
+    except (KeyError, TypeError, ValueError, OverflowError) as exc:
         raise HomrError(f"Could not read homr's system proposal for page {page}: {exc}") from exc
 
     if any(bound.page != page for bound in bounds):
         raise HomrError(f"homr returned a system for the wrong page while proposing page {page}")
+    if any(bound.index < 1 or not 0.0 <= bound.top < bound.bottom <= 1.0 for bound in bounds):
+        raise HomrError(f"homr returned invalid system bounds while proposing page {page}")
     return bounds
 
 

--- a/src/song_app/system_finder.py
+++ b/src/song_app/system_finder.py
@@ -1,285 +1,132 @@
-"""Propose where each printed system sits on a page.
+"""Ask homr to propose printed-system bounds, with the pre-#213 path as fallback.
 
-The scan reads exactly the bands ``.systems.json`` names, and until now every
-one of them was drawn by hand — by a person dragging in the Systems editor, or
-by an AI reading a page with a percentage ruler over it. That is the right
-place for the *judgement* to live and this module does not take it away: what
-comes back here is a **proposal**, returned to the editor unsaved, for a person
-to correct and save. Nothing writes bounds.
+The supported implementation now belongs to the homr fork.  This adapter keeps the
+song app's one-heavy-slot-per-page scheduling and turns homr's machine-readable JSON
+into the existing :class:`SystemBounds` values.  It never saves a proposal.
 
-**Why this can work when issue #80 could not.** That attempt read the pixels
-itself: it looked for staff lines with morphology and grouped staves into
-systems by the bracket down the left margin. Staff-line detection died at half a
-degree of skew and at 20% ink dropout, and only some editions print the bracket
-— across nine real songs the grouping agreed with the score twice. This asks
-**homr** instead, which finds staves for a living: the same segmentation network
-and the same ``detect_staff`` that read the music, stopped before any of it is
-parsed. A page costs seconds rather than the ~30s of a full read, and when it
-fails it fails the way the scan will fail on the same page, which is the honest
-answer.
-
-**Grouping is decided by the barlines, not by the gaps.** Which staves make up
-one system is the part homr does not answer: its ``MultiStaff`` is a grand staff
-or a brace, which choral engraving mostly does not print. The obvious rule —
-staves close together are one system — is measured here and does not work: on
-page 1 of the fixture the gaps *inside* a system run 0.060–0.077 of the page and
-the gaps *between* systems run 0.067–0.086, so the two ranges overlap and no
-threshold separates them. What does separate them is what the music says: two
-staves of the same system carry the same bars, so their barlines stand at the
-same x positions, and two staves of different systems hold different bars and
-theirs do not. On all seven pages measured, that agreement is 0.6–1.0 within a
-system and 0.0–0.5 across a break.
-
-The gaps still have one job, as a **veto**: a break has to show at least as much
-white as an ordinary within-system gap does. That is what catches the case where
-a poor scan loses a staff's barlines and the agreement collapses on a pair that
-is plainly one system (B1b's last system, and one pair on page 3 of the fixture).
-
-Coordinates are fractions of page height throughout — the units
-``.systems.json`` uses — so nothing here depends on the resolution it read at.
+Until the merged fork has been installed and re-measured on the host, an older homr
+that does not know ``--find-system-bounds`` falls back to the previous app-side helper.
+That fallback is deliberately isolated in :mod:`system_finder_legacy`; new grouping
+work belongs in homr, not here.
 """
 
 from __future__ import annotations
 
 import json
 import os
-import statistics
 import subprocess
-import tempfile
-from typing import Callable, Dict, List, Optional, Sequence, Tuple
+from contextlib import nullcontext
+from typing import Callable, Dict, List, Optional
 
-from . import heavy_slot, omr, pdf_systems
+from . import heavy_slot, omr, pdf_systems, system_finder_legacy as legacy
 from .omr import Engine, HomrError, HomrMissing
 from .pdf_systems import SystemBounds
 
 Logger = Callable[[str], None]
-
-#: The helper that runs inside homr's venv and reports the staves.
-HELPER = os.path.join(
-    os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))),
-    "scripts", "homr_staves.py",
-)
-
-#: What to rasterise a page at before handing it to homr. homr resizes to 1920
-#: wide itself, so more than this buys nothing and costs the render.
 FIND_DPI = int(os.getenv("SYSTEM_FIND_DPI", "200"))
-
-#: Segmentation is seconds; this is a wedged-process guard, not a budget.
 DEFAULT_TIMEOUT = 300
 
-#: Two barlines are "at the same place" within this fraction of page width.
-TOL_X = 0.008
-
-#: A barline this close to a staff's own left or right end is the system's
-#: opening or closing line, which every system has wherever its bars fall.
-EDGE_X = 0.02
-
-#: How much of the smaller barline set has to line up for one system.
-AGREE = 0.6
-
-#: Slack on the gap comparisons, so two gaps that are the same gap do not turn
-#: on the last bits of a subtraction. Deliberately tiny: on the pages measured,
-#: a real break is 20% wider than an ordinary gap and the closest false one is
-#: 6% narrower, so there is nothing here to tune.
-SLACK = 1.001
+# Compatibility exports for callers/tests written before #213.  Production proposal
+# work below does not use these; they stay only while the old installed homr may need
+# the fallback implementation.
+TOL_X = legacy.TOL_X
+EDGE_X = legacy.EDGE_X
+AGREE = legacy.AGREE
+SLACK = legacy.SLACK
+group_staves = legacy.group_staves
+bands_for_page = legacy.bands_for_page
+_interior_barlines = legacy._interior_barlines
+_agreement = legacy._agreement
+_gap_threshold = legacy._gap_threshold
+staves_on_page = legacy.staves_on_page
 
 
-def _noop(_msg: str) -> None:
+def _noop(_message: str) -> None:
     pass
 
 
-# --- the pixels ----------------------------------------------------------
+def _engine_command(engine: Engine) -> List[str]:
+    """Return the public homr CLI command for either an install or checkout engine."""
+    if len(engine.command) == 1:
+        return [engine.command[0]]
+    # Checkout engines run the same package through ``python -c`` for ordinary OMR.
+    # Proposal mode is a public homr CLI feature, so invoke that module directly while
+    # preserving the engine's PYTHONPATH.
+    return [engine.command[0], "-m", "homr.main"]
 
 
-def staves_on_page(
-    image_path: str,
-    engine: Optional[Engine] = None,
-    log: Logger = _noop,
+def _unsupported(stderr: str) -> bool:
+    """Whether this is the expected old-homr answer that permits compatibility fallback."""
+    lowered = stderr.lower()
+    return "--find-system-bounds" in lowered and (
+        "unrecognized arguments" in lowered or "no such option" in lowered
+    )
+
+
+def _page_from_homr(
+    pdf_path: str,
+    page: int,
+    *,
+    engine: Engine,
+    dpi: int,
+    log: Logger,
     timeout: int = DEFAULT_TIMEOUT,
-) -> Dict:
-    """Ask homr where the staves and barlines are on one page image.
-
-    Returns the helper's JSON: ``staves`` and ``bar_lines``, each a box in
-    fractions of the image. Raises :class:`omr.HomrError` when homr could not
-    read the page, the same exception the scan raises for the same reason.
-    """
-    command, env = _helper_command(engine)
+) -> Optional[List[SystemBounds]]:
+    """Ask supported homr for one page; return ``None`` only for an older CLI."""
+    command = _engine_command(engine) + [
+        pdf_path,
+        "--gpu",
+        "no",
+        "--find-system-bounds",
+        "--system-page",
+        str(page),
+        "--system-dpi",
+        str(dpi),
+    ]
     try:
-        out = subprocess.run(
-            command + [image_path],
-            capture_output=True, text=True, timeout=timeout,
-            env={**os.environ, **env},
+        result = subprocess.run(
+            command,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            env={**os.environ, **engine.env},
         )
     except OSError as exc:
         raise HomrMissing(f"Could not run {command[0]}: {exc}") from exc
     except subprocess.TimeoutExpired as exc:
-        raise HomrError(f"Looking for staves did not finish within {timeout}s.") from exc
-    for line in (out.stderr or "").splitlines():
+        raise HomrError(f"Looking for systems did not finish within {timeout}s.") from exc
+
+    for line in (result.stderr or "").splitlines():
         if line.strip():
             log(line.rstrip())
-    if out.returncode != 0 or not (out.stdout or "").strip():
+    if result.returncode != 0:
+        if _unsupported(result.stderr or ""):
+            return None
         raise HomrError(
-            f"homr found no staves on {os.path.basename(image_path)}.\n"
-            + "\n".join((out.stderr or "").splitlines()[-20:])
+            f"homr could not propose systems for page {page}.\n"
+            + "\n".join((result.stderr or "").splitlines()[-20:])
         )
+
     try:
-        return json.loads(out.stdout)
-    except ValueError as exc:
-        raise HomrError(
-            f"Could not read what homr said about {os.path.basename(image_path)}: {exc}"
-        ) from exc
+        payload = json.loads(result.stdout)
+        rows = payload["systems"]
+        bounds = [
+            SystemBounds(
+                index=int(row["index"]),
+                page=int(row["page"]),
+                top=float(row["top"]),
+                bottom=float(row["bottom"]),
+                measure_start=int(row.get("measure_start", 0)),
+                measure_end=int(row.get("measure_end", 0)),
+            )
+            for row in rows
+        ]
+    except (KeyError, TypeError, ValueError, json.JSONDecodeError) as exc:
+        raise HomrError(f"Could not read homr's system proposal for page {page}: {exc}") from exc
 
-
-def _helper_command(engine: Optional[Engine]) -> Tuple[List[str], Dict[str, str]]:
-    """``(argv, env)`` that runs :data:`HELPER` under ``engine``'s homr.
-
-    The engine's own ``command`` runs homr's CLI; this needs its *interpreter*,
-    which for the installed venv sits beside the binary and for a checkout
-    engine is that same interpreter with the working copy in front of it on
-    ``PYTHONPATH``. Both come off the engine rather than being guessed, so
-    proposing bands and reading music use the same homr.
-    """
-    engine = engine or omr.default_engine()
-    if not engine:
-        raise HomrMissing(
-            f"homr is not installed ({omr.homr_binary()}). Run scripts/install-homr.sh, "
-            "or set HOMR_BIN if it lives somewhere else."
-        )
-    python = engine.command[0] if len(engine.command) > 1 else _python_beside(engine.command[0])
-    if not python:
-        raise HomrMissing(
-            f"Could not find the interpreter beside {engine.command[0]}; "
-            "looking for staves needs homr's own venv, not just its binary."
-        )
-    return [python, HELPER], dict(engine.env)
-
-
-def _python_beside(binary: str) -> Optional[str]:
-    if os.path.sep not in binary:
-        return None
-    python = os.path.join(os.path.dirname(binary), "python")
-    return python if os.access(python, os.X_OK) else None
-
-
-# --- the grouping --------------------------------------------------------
-
-
-def _interior_barlines(staff: Dict, bar_lines: Sequence[Dict]) -> List[float]:
-    """The x of every barline standing on this staff, minus its own two ends.
-
-    The opening and closing lines are dropped because every system has them at
-    the same place whatever bars it holds, so leaving them in makes any two
-    staves agree a little and the evidence weaker for it.
-    """
-    found = []
-    for bar in bar_lines:
-        if bar["bottom"] < staff["top"] - 0.005 or bar["top"] > staff["bottom"] + 0.005:
-            continue
-        x = (bar["left"] + bar["right"]) / 2
-        if x < staff["left"] + EDGE_X or x > staff["right"] - EDGE_X:
-            continue
-        found.append(x)
-    return sorted(found)
-
-
-def _agreement(a: Sequence[float], b: Sequence[float]) -> Optional[float]:
-    """How much of the smaller barline set the other one stands under.
-
-    ``None`` when one of the staves has no interior barline to compare — a
-    system of a single bar says nothing here, and is left to the gaps.
-    """
-    if not a or not b:
-        return None
-    hits_a = sum(1 for x in a if any(abs(x - y) <= TOL_X for y in b))
-    hits_b = sum(1 for y in b if any(abs(x - y) <= TOL_X for x in a))
-    return max(hits_a / len(a), hits_b / len(b))
-
-
-def group_staves(staves: Sequence[Dict], bar_lines: Sequence[Dict]) -> List[List[Dict]]:
-    """Split a page's staves into systems.
-
-    Adjacent staves are one system when their barlines line up; where neither
-    staff has an interior barline the gap decides, and a break is vetoed when
-    the page shows no more white there than it does inside a system.
-    """
-    staves = sorted(staves, key=lambda s: s["top"])
-    if len(staves) < 2:
-        return [list(staves)] if staves else []
-
-    bars = [_interior_barlines(s, bar_lines) for s in staves]
-    gaps = [staves[i + 1]["top"] - staves[i]["bottom"] for i in range(len(staves) - 1)]
-    scores = [_agreement(bars[i], bars[i + 1]) for i in range(len(staves) - 1)]
-
-    same = [None if s is None else s >= AGREE for s in scores]
-
-    inside = [g for g, s in zip(gaps, same) if s]
-    if inside:
-        ordinary = statistics.median(inside)
-        # A break needs the white to go with it. A poor scan can lose a staff's
-        # barlines outright, and then the agreement collapses on a pair the page
-        # plainly prints as one system -- sitting *closer* together than the
-        # page's own within-system spacing. Measured: B1b's last system at 0.91
-        # of an ordinary gap and one pair on page 3 of the fixture at 0.97,
-        # against real breaks at 1.05 to 1.37. Strictly closer, so a page that
-        # happens to space its systems like its staves keeps every break the
-        # barlines found.
-        same = [True if s is False and g < ordinary / SLACK else s
-                for s, g in zip(same, gaps)]
-        same = [s if s is not None else g <= ordinary * SLACK
-                for s, g in zip(same, gaps)]
-    else:
-        # Nothing to learn from the barlines anywhere on this page (every system
-        # is one bar wide, or none was detected). Fall back to the widest step in
-        # the sorted gaps, which is the best the geometry alone can do.
-        same = [g < _gap_threshold(gaps) for g in gaps]
-
-    systems: List[List[Dict]] = [[staves[0]]]
-    for keep, staff in zip(same, staves[1:]):
-        if keep:
-            systems[-1].append(staff)
-        else:
-            systems.append([staff])
-    return systems
-
-
-def _gap_threshold(gaps: Sequence[float]) -> float:
-    """Where the sorted gaps step up most, as a break/no-break line."""
-    ordered = sorted(gaps)
-    if len(ordered) < 2:
-        return ordered[0] + 1.0            # one gap: no evidence of a break
-    steps = [(ordered[i + 1] / max(ordered[i], 1e-6), i) for i in range(len(ordered) - 1)]
-    _, cut = max(steps)
-    return (ordered[cut] + ordered[cut + 1]) / 2
-
-
-def bands_for_page(page: int, staves: Sequence[Dict],
-                   bar_lines: Sequence[Dict]) -> List[SystemBounds]:
-    """One band per system on a page, contiguous, indexed from 1.
-
-    A boundary between two systems is put halfway between them, so the lyrics
-    under one system's last staff and anything printed above the next stay with
-    their own band. The first and last edges have no neighbour to halve, so they
-    are given the same room again and clamped to the page: too generous a band
-    costs a little white paper, and too tight a one cuts the words off.
-    """
-    systems = group_staves(staves, bar_lines)
-    if not systems:
-        return []
-    tops = [s[0]["top"] for s in systems]
-    bottoms = [s[-1]["bottom"] for s in systems]
-    between = [tops[i + 1] - bottoms[i] for i in range(len(systems) - 1)]
-    room = statistics.median(between) if between else 0.05
-
-    bands = []
-    for i in range(len(systems)):
-        top = max(0.0, tops[i] - room) if i == 0 else (bottoms[i - 1] + tops[i]) / 2
-        bottom = (min(1.0, bottoms[i] + room) if i == len(systems) - 1
-                  else (bottoms[i] + tops[i + 1]) / 2)
-        bands.append(SystemBounds(index=i + 1, page=page, top=top, bottom=bottom))
-    return bands
-
-
-# --- the whole PDF -------------------------------------------------------
+    if any(bound.page != page for bound in bounds):
+        raise HomrError(f"homr returned a system for the wrong page while proposing page {page}")
+    return bounds
 
 
 def find_bands(
@@ -290,43 +137,53 @@ def find_bands(
     dpi: int = FIND_DPI,
     queue: bool = True,
 ) -> List[SystemBounds]:
-    """Propose a band for every printed system in a PDF, page by page.
+    """Request homr's proposal page by page, unsaved, falling back only for old homr."""
+    engine = engine or omr.default_engine()
+    if not engine:
+        raise HomrMissing(
+            f"homr is not installed ({omr.homr_binary()}). Run scripts/install-homr.sh, "
+            "or set HOMR_BIN if it lives somewhere else."
+        )
 
-    Indices run across the whole score, the way saved bounds do. Nothing is
-    written: the caller shows this and a person saves it.
-
-    **One heavy slot per page**, the rule :mod:`omr` settled: a page is seconds
-    of every core, releasing between pages lets a render or a suite in, and a
-    page that is interrupted costs that page rather than the PDF. A page homr
-    cannot read raises — unlike the scan there is nothing partial worth
-    keeping, because a missing band is music that would never be read at all.
-    """
-    scratch = tempfile.TemporaryDirectory(prefix="sysfind-")
-    workdir = out_dir or scratch.name
-    try:
-        bands: List[SystemBounds] = []
-        pages = pdf_systems.page_count(pdf_path)
-        for page in range(1, pages + 1):
-            image = pdf_systems.render_page(pdf_path, page, dpi, workdir)
-            with _queued(f"song app find systems p{page}", log, queue) as slot:
-                watched = slot.guard(log)
-                watched(f"Looking for systems on page {page} of {pages}")
-                found = staves_on_page(image, engine=engine, log=watched)
-                slot.check()
-            page_bands = bands_for_page(page, found["staves"], found["bar_lines"])
-            log(f"Page {page}: {len(found['staves'])} staves in "
-                f"{len(page_bands)} system(s)")
-            for band in page_bands:
-                bands.append(SystemBounds(index=len(bands) + 1, page=page,
-                                          top=band.top, bottom=band.bottom))
-        return bands
-    finally:
-        scratch.cleanup()
-
-
-def _queued(label: str, log: Logger, queue: bool):
-    """A heavy slot for this page, or an un-held one for a caller holding it."""
-    if not queue:
-        from contextlib import nullcontext
-        return nullcontext(heavy_slot.Slot())
-    return heavy_slot.heavy_slot(label, log=log)
+    pages = pdf_systems.page_count(pdf_path)
+    proposed: List[SystemBounds] = []
+    for page in range(1, pages + 1):
+        lease = (
+            heavy_slot.heavy_slot(f"song app find systems p{page}", log=log)
+            if queue
+            else nullcontext(heavy_slot.Slot())
+        )
+        with lease as slot:
+            watched = slot.guard(log)
+            watched(f"Looking for systems on page {page} of {pages}")
+            found = _page_from_homr(
+                pdf_path,
+                page,
+                engine=engine,
+                dpi=dpi,
+                log=watched,
+            )
+            slot.check()
+        if found is None:
+            log("Installed homr has no supported system-bound proposal; using compatibility fallback")
+            return legacy.find_bands(
+                pdf_path,
+                out_dir=out_dir,
+                engine=engine,
+                log=log,
+                dpi=dpi,
+                queue=queue,
+            )
+        log(f"Page {page}: {len(found)} system(s)")
+        for bound in found:
+            proposed.append(
+                SystemBounds(
+                    index=len(proposed) + 1,
+                    page=page,
+                    top=bound.top,
+                    bottom=bound.bottom,
+                    measure_start=bound.measure_start,
+                    measure_end=bound.measure_end,
+                )
+            )
+    return proposed

--- a/src/song_app/system_finder_legacy.py
+++ b/src/song_app/system_finder_legacy.py
@@ -1,0 +1,332 @@
+"""Propose where each printed system sits on a page.
+
+The scan reads exactly the bands ``.systems.json`` names, and until now every
+one of them was drawn by hand — by a person dragging in the Systems editor, or
+by an AI reading a page with a percentage ruler over it. That is the right
+place for the *judgement* to live and this module does not take it away: what
+comes back here is a **proposal**, returned to the editor unsaved, for a person
+to correct and save. Nothing writes bounds.
+
+**Why this can work when issue #80 could not.** That attempt read the pixels
+itself: it looked for staff lines with morphology and grouped staves into
+systems by the bracket down the left margin. Staff-line detection died at half a
+degree of skew and at 20% ink dropout, and only some editions print the bracket
+— across nine real songs the grouping agreed with the score twice. This asks
+**homr** instead, which finds staves for a living: the same segmentation network
+and the same ``detect_staff`` that read the music, stopped before any of it is
+parsed. A page costs seconds rather than the ~30s of a full read, and when it
+fails it fails the way the scan will fail on the same page, which is the honest
+answer.
+
+**Grouping is decided by the barlines, not by the gaps.** Which staves make up
+one system is the part homr does not answer: its ``MultiStaff`` is a grand staff
+or a brace, which choral engraving mostly does not print. The obvious rule —
+staves close together are one system — is measured here and does not work: on
+page 1 of the fixture the gaps *inside* a system run 0.060–0.077 of the page and
+the gaps *between* systems run 0.067–0.086, so the two ranges overlap and no
+threshold separates them. What does separate them is what the music says: two
+staves of the same system carry the same bars, so their barlines stand at the
+same x positions, and two staves of different systems hold different bars and
+theirs do not. On all seven pages measured, that agreement is 0.6–1.0 within a
+system and 0.0–0.5 across a break.
+
+The gaps still have one job, as a **veto**: a break has to show at least as much
+white as an ordinary within-system gap does. That is what catches the case where
+a poor scan loses a staff's barlines and the agreement collapses on a pair that
+is plainly one system (B1b's last system, and one pair on page 3 of the fixture).
+
+Coordinates are fractions of page height throughout — the units
+``.systems.json`` uses — so nothing here depends on the resolution it read at.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import statistics
+import subprocess
+import tempfile
+from typing import Callable, Dict, List, Optional, Sequence, Tuple
+
+from . import heavy_slot, omr, pdf_systems
+from .omr import Engine, HomrError, HomrMissing
+from .pdf_systems import SystemBounds
+
+Logger = Callable[[str], None]
+
+#: The helper that runs inside homr's venv and reports the staves.
+HELPER = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))),
+    "scripts", "homr_staves.py",
+)
+
+#: What to rasterise a page at before handing it to homr. homr resizes to 1920
+#: wide itself, so more than this buys nothing and costs the render.
+FIND_DPI = int(os.getenv("SYSTEM_FIND_DPI", "200"))
+
+#: Segmentation is seconds; this is a wedged-process guard, not a budget.
+DEFAULT_TIMEOUT = 300
+
+#: Two barlines are "at the same place" within this fraction of page width.
+TOL_X = 0.008
+
+#: A barline this close to a staff's own left or right end is the system's
+#: opening or closing line, which every system has wherever its bars fall.
+EDGE_X = 0.02
+
+#: How much of the smaller barline set has to line up for one system.
+AGREE = 0.6
+
+#: Slack on the gap comparisons, so two gaps that are the same gap do not turn
+#: on the last bits of a subtraction. Deliberately tiny: on the pages measured,
+#: a real break is 20% wider than an ordinary gap and the closest false one is
+#: 6% narrower, so there is nothing here to tune.
+SLACK = 1.001
+
+
+def _noop(_msg: str) -> None:
+    pass
+
+
+# --- the pixels ----------------------------------------------------------
+
+
+def staves_on_page(
+    image_path: str,
+    engine: Optional[Engine] = None,
+    log: Logger = _noop,
+    timeout: int = DEFAULT_TIMEOUT,
+) -> Dict:
+    """Ask homr where the staves and barlines are on one page image.
+
+    Returns the helper's JSON: ``staves`` and ``bar_lines``, each a box in
+    fractions of the image. Raises :class:`omr.HomrError` when homr could not
+    read the page, the same exception the scan raises for the same reason.
+    """
+    command, env = _helper_command(engine)
+    try:
+        out = subprocess.run(
+            command + [image_path],
+            capture_output=True, text=True, timeout=timeout,
+            env={**os.environ, **env},
+        )
+    except OSError as exc:
+        raise HomrMissing(f"Could not run {command[0]}: {exc}") from exc
+    except subprocess.TimeoutExpired as exc:
+        raise HomrError(f"Looking for staves did not finish within {timeout}s.") from exc
+    for line in (out.stderr or "").splitlines():
+        if line.strip():
+            log(line.rstrip())
+    if out.returncode != 0 or not (out.stdout or "").strip():
+        raise HomrError(
+            f"homr found no staves on {os.path.basename(image_path)}.\n"
+            + "\n".join((out.stderr or "").splitlines()[-20:])
+        )
+    try:
+        return json.loads(out.stdout)
+    except ValueError as exc:
+        raise HomrError(
+            f"Could not read what homr said about {os.path.basename(image_path)}: {exc}"
+        ) from exc
+
+
+def _helper_command(engine: Optional[Engine]) -> Tuple[List[str], Dict[str, str]]:
+    """``(argv, env)`` that runs :data:`HELPER` under ``engine``'s homr.
+
+    The engine's own ``command`` runs homr's CLI; this needs its *interpreter*,
+    which for the installed venv sits beside the binary and for a checkout
+    engine is that same interpreter with the working copy in front of it on
+    ``PYTHONPATH``. Both come off the engine rather than being guessed, so
+    proposing bands and reading music use the same homr.
+    """
+    engine = engine or omr.default_engine()
+    if not engine:
+        raise HomrMissing(
+            f"homr is not installed ({omr.homr_binary()}). Run scripts/install-homr.sh, "
+            "or set HOMR_BIN if it lives somewhere else."
+        )
+    python = engine.command[0] if len(engine.command) > 1 else _python_beside(engine.command[0])
+    if not python:
+        raise HomrMissing(
+            f"Could not find the interpreter beside {engine.command[0]}; "
+            "looking for staves needs homr's own venv, not just its binary."
+        )
+    return [python, HELPER], dict(engine.env)
+
+
+def _python_beside(binary: str) -> Optional[str]:
+    if os.path.sep not in binary:
+        return None
+    python = os.path.join(os.path.dirname(binary), "python")
+    return python if os.access(python, os.X_OK) else None
+
+
+# --- the grouping --------------------------------------------------------
+
+
+def _interior_barlines(staff: Dict, bar_lines: Sequence[Dict]) -> List[float]:
+    """The x of every barline standing on this staff, minus its own two ends.
+
+    The opening and closing lines are dropped because every system has them at
+    the same place whatever bars it holds, so leaving them in makes any two
+    staves agree a little and the evidence weaker for it.
+    """
+    found = []
+    for bar in bar_lines:
+        if bar["bottom"] < staff["top"] - 0.005 or bar["top"] > staff["bottom"] + 0.005:
+            continue
+        x = (bar["left"] + bar["right"]) / 2
+        if x < staff["left"] + EDGE_X or x > staff["right"] - EDGE_X:
+            continue
+        found.append(x)
+    return sorted(found)
+
+
+def _agreement(a: Sequence[float], b: Sequence[float]) -> Optional[float]:
+    """How much of the smaller barline set the other one stands under.
+
+    ``None`` when one of the staves has no interior barline to compare — a
+    system of a single bar says nothing here, and is left to the gaps.
+    """
+    if not a or not b:
+        return None
+    hits_a = sum(1 for x in a if any(abs(x - y) <= TOL_X for y in b))
+    hits_b = sum(1 for y in b if any(abs(x - y) <= TOL_X for x in a))
+    return max(hits_a / len(a), hits_b / len(b))
+
+
+def group_staves(staves: Sequence[Dict], bar_lines: Sequence[Dict]) -> List[List[Dict]]:
+    """Split a page's staves into systems.
+
+    Adjacent staves are one system when their barlines line up; where neither
+    staff has an interior barline the gap decides, and a break is vetoed when
+    the page shows no more white there than it does inside a system.
+    """
+    staves = sorted(staves, key=lambda s: s["top"])
+    if len(staves) < 2:
+        return [list(staves)] if staves else []
+
+    bars = [_interior_barlines(s, bar_lines) for s in staves]
+    gaps = [staves[i + 1]["top"] - staves[i]["bottom"] for i in range(len(staves) - 1)]
+    scores = [_agreement(bars[i], bars[i + 1]) for i in range(len(staves) - 1)]
+
+    same = [None if s is None else s >= AGREE for s in scores]
+
+    inside = [g for g, s in zip(gaps, same) if s]
+    if inside:
+        ordinary = statistics.median(inside)
+        # A break needs the white to go with it. A poor scan can lose a staff's
+        # barlines outright, and then the agreement collapses on a pair the page
+        # plainly prints as one system -- sitting *closer* together than the
+        # page's own within-system spacing. Measured: B1b's last system at 0.91
+        # of an ordinary gap and one pair on page 3 of the fixture at 0.97,
+        # against real breaks at 1.05 to 1.37. Strictly closer, so a page that
+        # happens to space its systems like its staves keeps every break the
+        # barlines found.
+        same = [True if s is False and g < ordinary / SLACK else s
+                for s, g in zip(same, gaps)]
+        same = [s if s is not None else g <= ordinary * SLACK
+                for s, g in zip(same, gaps)]
+    else:
+        # Nothing to learn from the barlines anywhere on this page (every system
+        # is one bar wide, or none was detected). Fall back to the widest step in
+        # the sorted gaps, which is the best the geometry alone can do.
+        same = [g < _gap_threshold(gaps) for g in gaps]
+
+    systems: List[List[Dict]] = [[staves[0]]]
+    for keep, staff in zip(same, staves[1:]):
+        if keep:
+            systems[-1].append(staff)
+        else:
+            systems.append([staff])
+    return systems
+
+
+def _gap_threshold(gaps: Sequence[float]) -> float:
+    """Where the sorted gaps step up most, as a break/no-break line."""
+    ordered = sorted(gaps)
+    if len(ordered) < 2:
+        return ordered[0] + 1.0            # one gap: no evidence of a break
+    steps = [(ordered[i + 1] / max(ordered[i], 1e-6), i) for i in range(len(ordered) - 1)]
+    _, cut = max(steps)
+    return (ordered[cut] + ordered[cut + 1]) / 2
+
+
+def bands_for_page(page: int, staves: Sequence[Dict],
+                   bar_lines: Sequence[Dict]) -> List[SystemBounds]:
+    """One band per system on a page, contiguous, indexed from 1.
+
+    A boundary between two systems is put halfway between them, so the lyrics
+    under one system's last staff and anything printed above the next stay with
+    their own band. The first and last edges have no neighbour to halve, so they
+    are given the same room again and clamped to the page: too generous a band
+    costs a little white paper, and too tight a one cuts the words off.
+    """
+    systems = group_staves(staves, bar_lines)
+    if not systems:
+        return []
+    tops = [s[0]["top"] for s in systems]
+    bottoms = [s[-1]["bottom"] for s in systems]
+    between = [tops[i + 1] - bottoms[i] for i in range(len(systems) - 1)]
+    room = statistics.median(between) if between else 0.05
+
+    bands = []
+    for i in range(len(systems)):
+        top = max(0.0, tops[i] - room) if i == 0 else (bottoms[i - 1] + tops[i]) / 2
+        bottom = (min(1.0, bottoms[i] + room) if i == len(systems) - 1
+                  else (bottoms[i] + tops[i + 1]) / 2)
+        bands.append(SystemBounds(index=i + 1, page=page, top=top, bottom=bottom))
+    return bands
+
+
+# --- the whole PDF -------------------------------------------------------
+
+
+def find_bands(
+    pdf_path: str,
+    out_dir: Optional[str] = None,
+    engine: Optional[Engine] = None,
+    log: Logger = _noop,
+    dpi: int = FIND_DPI,
+    queue: bool = True,
+) -> List[SystemBounds]:
+    """Propose a band for every printed system in a PDF, page by page.
+
+    Indices run across the whole score, the way saved bounds do. Nothing is
+    written: the caller shows this and a person saves it.
+
+    **One heavy slot per page**, the rule :mod:`omr` settled: a page is seconds
+    of every core, releasing between pages lets a render or a suite in, and a
+    page that is interrupted costs that page rather than the PDF. A page homr
+    cannot read raises — unlike the scan there is nothing partial worth
+    keeping, because a missing band is music that would never be read at all.
+    """
+    scratch = tempfile.TemporaryDirectory(prefix="sysfind-")
+    workdir = out_dir or scratch.name
+    try:
+        bands: List[SystemBounds] = []
+        pages = pdf_systems.page_count(pdf_path)
+        for page in range(1, pages + 1):
+            image = pdf_systems.render_page(pdf_path, page, dpi, workdir)
+            with _queued(f"song app find systems p{page}", log, queue) as slot:
+                watched = slot.guard(log)
+                watched(f"Looking for systems on page {page} of {pages}")
+                found = staves_on_page(image, engine=engine, log=watched)
+                slot.check()
+            page_bands = bands_for_page(page, found["staves"], found["bar_lines"])
+            log(f"Page {page}: {len(found['staves'])} staves in "
+                f"{len(page_bands)} system(s)")
+            for band in page_bands:
+                bands.append(SystemBounds(index=len(bands) + 1, page=page,
+                                          top=band.top, bottom=band.bottom))
+        return bands
+    finally:
+        scratch.cleanup()
+
+
+def _queued(label: str, log: Logger, queue: bool):
+    """A heavy slot for this page, or an un-held one for a caller holding it."""
+    if not queue:
+        from contextlib import nullcontext
+        return nullcontext(heavy_slot.Slot())
+    return heavy_slot.heavy_slot(label, log=log)

--- a/src/song_app/tests/test_system_finder.py
+++ b/src/song_app/tests/test_system_finder.py
@@ -23,6 +23,7 @@ import shutil
 import pytest
 
 from src.song_app import omr, pdf_systems, system_finder
+from src.song_app import system_finder_legacy as legacy
 from src.song_app.tests import benchmark
 
 # --- the rule -------------------------------------------------------------
@@ -151,7 +152,9 @@ def test_a_page_with_no_staves_proposes_nothing():
     assert system_finder.bands_for_page(1, [], []) == []
 
 
-# --- reaching homr --------------------------------------------------------
+# --- reaching legacy homr -------------------------------------------------
+# Keep testing the compatibility helper where it lives after #213. The public
+# adapter's supported CLI contract is covered in test_system_finder_homr_api.py.
 
 
 def test_the_helper_runs_under_the_engine_that_would_read_the_page(monkeypatch, tmp_path):
@@ -170,21 +173,21 @@ def test_the_helper_runs_under_the_engine_that_would_read_the_page(monkeypatch, 
     installed = omr.Engine(key="default", label="main", command=[str(venv_bin / "homr")],
                            default=True)
     monkeypatch.setattr(omr, "default_engine", lambda: installed)
-    command, env = system_finder._helper_command(None)
-    assert command == [str(python), system_finder.HELPER]
+    command, env = legacy._helper_command(None)
+    assert command == [str(python), legacy.HELPER]
     assert env == {}
 
     checkout = omr.Engine(key="wt", label="branch", command=[str(python), "-c", "..."],
                           env={"PYTHONPATH": "/somewhere/homr"})
-    command, env = system_finder._helper_command(checkout)
-    assert command == [str(python), system_finder.HELPER]
+    command, env = legacy._helper_command(checkout)
+    assert command == [str(python), legacy.HELPER]
     assert env == {"PYTHONPATH": "/somewhere/homr"}
 
 
 def test_no_homr_is_refused_by_name(monkeypatch):
     monkeypatch.setattr(omr, "default_engine", lambda: None)
     with pytest.raises(omr.HomrMissing) as raised:
-        system_finder._helper_command(None)
+        legacy._helper_command(None)
     assert "install-homr.sh" in str(raised.value)
 
 
@@ -197,11 +200,11 @@ def test_a_page_homr_could_not_read_says_so(monkeypatch, tmp_path):
         stdout = ""
         stderr = "No noteheads found"
 
-    monkeypatch.setattr(system_finder, "_helper_command",
+    monkeypatch.setattr(legacy, "_helper_command",
                         lambda engine: (["/bin/true"], {}))
-    monkeypatch.setattr(system_finder.subprocess, "run", lambda *a, **k: Failed())
+    monkeypatch.setattr(legacy.subprocess, "run", lambda *a, **k: Failed())
     with pytest.raises(omr.HomrError) as raised:
-        system_finder.staves_on_page(str(image))
+        legacy.staves_on_page(str(image))
     assert "No noteheads found" in str(raised.value)
 
 

--- a/src/song_app/tests/test_system_finder_homr_api.py
+++ b/src/song_app/tests/test_system_finder_homr_api.py
@@ -1,0 +1,165 @@
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+
+from src.song_app import omr, system_finder
+from src.song_app.pdf_systems import SystemBounds
+
+
+def _engine(command=None):
+    return omr.Engine(
+        key="test",
+        label="test homr",
+        command=command or ["/opt/homr/bin/homr"],
+        env={},
+    )
+
+
+def test_supported_homr_cli_is_the_primary_proposal_path(monkeypatch):
+    calls = []
+    monkeypatch.setattr(system_finder.pdf_systems, "page_count", lambda _pdf: 2)
+
+    def propose(pdf_path, page, *, engine, dpi, log, timeout=300):
+        calls.append((pdf_path, page, engine.key, dpi))
+        return [SystemBounds(index=1, page=page, top=0.1, bottom=0.9)]
+
+    monkeypatch.setattr(system_finder, "_page_from_homr", propose)
+    monkeypatch.setattr(
+        system_finder.legacy,
+        "find_bands",
+        lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("legacy fallback used")),
+    )
+
+    found = system_finder.find_bands(
+        "/tmp/score.pdf", engine=_engine(), queue=False, dpi=200
+    )
+
+    assert calls == [
+        ("/tmp/score.pdf", 1, "test", 200),
+        ("/tmp/score.pdf", 2, "test", 200),
+    ]
+    assert [(item.index, item.page) for item in found] == [(1, 1), (2, 2)]
+
+
+def test_checkout_engine_uses_public_homr_module_cli(monkeypatch):
+    called = {}
+
+    def run(command, **kwargs):
+        called["command"] = command
+        called["env"] = kwargs["env"]
+        return SimpleNamespace(
+            returncode=0,
+            stdout=json.dumps(
+                {
+                    "systems": [
+                        {
+                            "index": 1,
+                            "page": 3,
+                            "top": 0.2,
+                            "bottom": 0.7,
+                            "measure_start": 0,
+                            "measure_end": 0,
+                        }
+                    ]
+                }
+            ),
+            stderr="",
+        )
+
+    monkeypatch.setattr(system_finder.subprocess, "run", run)
+    engine = _engine(["/venv/bin/python", "-c", "from homr.main import main; main()"])
+    object.__setattr__(engine, "env", {"PYTHONPATH": "/work/homr"})
+
+    found = system_finder._page_from_homr(
+        "/tmp/score.pdf", 3, engine=engine, dpi=200, log=lambda _line: None
+    )
+
+    assert called["command"] == [
+        "/venv/bin/python",
+        "-m",
+        "homr.main",
+        "/tmp/score.pdf",
+        "--gpu",
+        "no",
+        "--find-system-bounds",
+        "--system-page",
+        "3",
+        "--system-dpi",
+        "200",
+    ]
+    assert called["env"]["PYTHONPATH"] == "/work/homr"
+    assert found == [SystemBounds(index=1, page=3, top=0.2, bottom=0.7)]
+
+
+def test_old_homr_cli_selects_compatibility_fallback(monkeypatch):
+    monkeypatch.setattr(
+        system_finder.subprocess,
+        "run",
+        lambda *args, **kwargs: SimpleNamespace(
+            returncode=2,
+            stdout="",
+            stderr="homer: error: unrecognized arguments: --find-system-bounds --system-page 1",
+        ),
+    )
+
+    assert (
+        system_finder._page_from_homr(
+            "/tmp/score.pdf",
+            1,
+            engine=_engine(),
+            dpi=200,
+            log=lambda _line: None,
+        )
+        is None
+    )
+
+
+def test_fallback_restarts_with_the_legacy_whole_pdf_path(monkeypatch):
+    monkeypatch.setattr(system_finder.pdf_systems, "page_count", lambda _pdf: 4)
+    calls = []
+
+    def unsupported(*args, **kwargs):
+        calls.append("supported")
+        return None
+
+    expected = [SystemBounds(index=1, page=1, top=0.1, bottom=0.9)]
+
+    def legacy(*args, **kwargs):
+        calls.append("legacy")
+        return expected
+
+    monkeypatch.setattr(system_finder, "_page_from_homr", unsupported)
+    monkeypatch.setattr(system_finder.legacy, "find_bands", legacy)
+
+    found = system_finder.find_bands(
+        "/tmp/score.pdf", engine=_engine(), queue=False, dpi=200
+    )
+
+    assert found == expected
+    assert calls == ["supported", "legacy"]
+
+
+def test_supported_homr_failure_does_not_hide_behind_legacy(monkeypatch):
+    monkeypatch.setattr(
+        system_finder.subprocess,
+        "run",
+        lambda *args, **kwargs: SimpleNamespace(
+            returncode=1,
+            stdout="",
+            stderr="segmentation failed",
+        ),
+    )
+
+    try:
+        system_finder._page_from_homr(
+            "/tmp/score.pdf",
+            1,
+            engine=_engine(),
+            dpi=200,
+            log=lambda _line: None,
+        )
+    except omr.HomrError as error:
+        assert "segmentation failed" in str(error)
+    else:
+        raise AssertionError("supported homr failure was hidden")

--- a/src/song_app/tests/test_system_finder_proposal_contract.py
+++ b/src/song_app/tests/test_system_finder_proposal_contract.py
@@ -1,0 +1,135 @@
+"""The app/homr proposal boundary must not hide failures or approve bounds."""
+
+import json
+from contextlib import contextmanager
+from types import SimpleNamespace
+
+import pytest
+
+from src.song_app import omr, system_finder
+from src.song_app.pdf_systems import SystemBounds
+
+
+def engine():
+    return omr.Engine(key="test", label="test homr", command=["/test/homr"])
+
+
+def response(monkeypatch, *, stdout="", stderr="", returncode=0):
+    monkeypatch.setattr(
+        system_finder.subprocess,
+        "run",
+        lambda *args, **kwargs: SimpleNamespace(
+            returncode=returncode, stdout=stdout, stderr=stderr
+        ),
+    )
+
+
+@pytest.mark.parametrize("diagnostic", [
+    "homr: error: unrecognized arguments: --system-page 1",
+    "Error: No such option: --system-page",
+    "homr: error: unrecognized arguments: --find-system-bounds-extra",
+])
+def test_supported_option_in_usage_does_not_hide_an_unrelated_error(monkeypatch, diagnostic):
+    response(
+        monkeypatch,
+        returncode=2,
+        stderr="usage: homr [--find-system-bounds] input\n" + diagnostic,
+    )
+    monkeypatch.setattr(system_finder.pdf_systems, "page_count", lambda _pdf: 1)
+
+    def no_fallback(*args, **kwargs):
+        pytest.fail("a supported CLI failure must not trigger the compatibility helper")
+
+    monkeypatch.setattr(system_finder.legacy, "find_bands", no_fallback)
+    with pytest.raises(omr.HomrError, match="could not propose systems"):
+        system_finder.find_bands("score.pdf", engine=engine(), queue=False)
+
+
+@pytest.mark.parametrize("diagnostic", [
+    "homr: error: unrecognized arguments: --find-system-bounds --system-page 1",
+    "Error: No such option: --find-system-bounds",
+])
+def test_explicitly_unsupported_proposal_flag_still_permits_fallback(monkeypatch, diagnostic):
+    response(monkeypatch, stderr=diagnostic, returncode=2)
+    assert system_finder._page_from_homr(
+        "score.pdf", 1, engine=engine(), dpi=200, log=lambda _line: None
+    ) is None
+
+
+@pytest.mark.parametrize("payload", [
+    None,
+    [],
+    {},
+    {"systems": {}},
+    {"systems": ""},
+    {"systems": [None]},
+    {"systems": [{"index": 1, "page": 1}]},
+])
+def test_malformed_json_shape_is_a_proposal_error(monkeypatch, payload):
+    response(monkeypatch, stdout=json.dumps(payload))
+    with pytest.raises(omr.HomrError, match="Could not read homr's system proposal"):
+        system_finder._page_from_homr(
+            "score.pdf", 1, engine=engine(), dpi=200, log=lambda _line: None
+        )
+
+
+@pytest.mark.parametrize("change", [
+    {"top": float("nan")},
+    {"bottom": float("inf")},
+    {"top": -0.1},
+    {"bottom": 1.1},
+    {"top": 0.9},
+    {"index": 0},
+    {"index": float("inf")},
+    {"page": 2},
+])
+def test_unusable_bounds_are_not_returned_to_the_editor(monkeypatch, change):
+    row = {"index": 1, "page": 1, "top": 0.1, "bottom": 0.9, **change}
+    response(monkeypatch, stdout=json.dumps({"systems": [row]}))
+    with pytest.raises(omr.HomrError):
+        system_finder._page_from_homr(
+            "score.pdf", 1, engine=engine(), dpi=200, log=lambda _line: None
+        )
+
+
+def test_each_page_has_its_own_lease_and_proposals_do_not_save(monkeypatch, tmp_path):
+    events = []
+    active = []
+    monkeypatch.setattr(system_finder.pdf_systems, "page_count", lambda _pdf: 2)
+    saved = tmp_path / ".systems.json"
+    saved.write_text("human-approved bounds", encoding="utf-8")
+
+    @contextmanager
+    def lease(label, log):
+        assert not active
+        active.append(label)
+        events.append("enter")
+        try:
+            yield SimpleNamespace(
+                guard=lambda logger: logger,
+                check=lambda: events.append("check"),
+            )
+        finally:
+            active.pop()
+            events.append("exit")
+
+    def propose(_pdf, page, **kwargs):
+        assert len(active) == 1
+        events.append(f"page {page}")
+        return [SystemBounds(index=1, page=page, top=0.1, bottom=0.9)]
+
+    monkeypatch.setattr(system_finder.heavy_slot, "heavy_slot", lease)
+    monkeypatch.setattr(system_finder, "_page_from_homr", propose)
+    found = system_finder.find_bands(
+        "score.pdf", out_dir=str(tmp_path), engine=engine(), queue=True
+    )
+    assert events == ["enter", "page 1", "check", "exit", "enter", "page 2", "check", "exit"]
+    assert [(band.index, band.page) for band in found] == [(1, 1), (2, 2)]
+    assert saved.read_text(encoding="utf-8") == "human-approved bounds"
+    assert list(tmp_path.iterdir()) == [saved]
+
+
+def test_public_proposal_reports_a_missing_engine_before_reading_pages(monkeypatch):
+    monkeypatch.setattr(omr, "default_engine", lambda: None)
+    with pytest.raises(omr.HomrMissing, match="install-homr.sh"):
+        system_finder.find_bands("score.pdf", queue=False)


### PR DESCRIPTION
Implements the choir-app side of #213.

The app now asks the homr fork's public `--find-system-bounds --system-page` mode for proposals while preserving the existing one-heavy-slot-per-page scheduling and score-wide reindexing. The pre-#213 app-side detector/grouping and `scripts/homr_staves.py` remain isolated as a compatibility fallback only when the installed homr explicitly reports that the new CLI option is unsupported; real proposal failures are surfaced rather than hidden by fallback.

No proposal is saved automatically. No host install/deployment is part of this PR. The fallback stays until the homr PR is merged, manually installed, and re-measured as required by #213.